### PR TITLE
Update xspec convolution interface (fix #6)

### DIFF
--- a/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/tests/test_xsconvolve.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/tests/test_xsconvolve.py
@@ -1,0 +1,330 @@
+#
+#  Copyright (C) 2017
+#            Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from sherpa.data import Data1DInt
+from sherpa.models.basic import PowLaw1D
+from sherpa.astro.xspec import XSpowerlaw
+from sherpa.models.parameter import Parameter
+
+from sherpa_contrib.xspec.xsconvolve import XScflux
+from sherpa_contrib.xspec.xsmodels import XSConvolutionKernel, \
+    XSConvolutionModel
+
+
+def setup_data(elo=0.1, ehi=10.0, ebin=0.01):
+    """Return a data set.
+
+    Parameters
+    ----------
+    elo, ehi : number, optional
+        The start and end energy of the grid, in keV.
+    ebin : number, optional
+        The bin width, in keV.
+
+    Returns
+    -------
+    data : Data1DInt
+        The data object. The Y values are not expected to be used,
+        so are set to 1.
+
+    """
+
+    if elo >= ehi:
+        raise ValueError("elo >= ehi")
+    if elo <= 0:
+        raise ValueError("elo <= 0")
+    if ebin <= 0:
+        raise ValueError("ebin <= 0")
+
+    x = np.arange(elo, ehi + ebin, ebin)
+    if x.size < 2:
+        raise ValueError("elo, ehi, ebin not sensible")
+
+    y = np.ones(x.size - 1)
+    return Data1DInt('dummy', x[:-1], x[1:], y)
+
+
+def _check_pars(label, mdl, parvals):
+    """Check that we have the expected parameters.
+
+    Parameters
+    ----------
+    label : str
+        The label to use in the assertions
+    mdl
+        The model object. It must have a pars attribute.
+    parvals : sequence of tuples
+        Each entry gives the parameter name, value, frozen flag,
+        and units field.
+    """
+
+    nexp = len(parvals)
+    ngot = len(mdl.pars)
+    assert nexp == ngot, '{}: number of parameters'.format(label)
+
+    for i, vals in enumerate(parvals):
+
+        par = mdl.pars[i]
+        plbl = '{} param {}: '.format(label, i + 1)
+        assert isinstance(par, Parameter), plbl + 'is a parameter'
+        assert par.name == vals[0], plbl + 'name'
+        assert par.val == vals[1], plbl + 'value'
+        assert par.frozen == vals[2], plbl + 'frozen'
+        assert par.units == vals[3], plbl + 'units'
+
+
+def test_cflux_settings():
+    """Do the expected things happen when a model is calculated?"""
+
+    kern = XScflux('cflux')
+    assert isinstance(kern, XSConvolutionKernel), \
+        "cflux creates XSConvolutionKernel"
+
+    cfluxpars = [('Emin', 0.5, True, 'keV'),
+                 ('Emax', 10.0, True, 'keV'),
+                 ('lg10Flux', -12, False, 'cgs')]
+    _check_pars('cflux', kern, cfluxpars)
+
+    mdl = kern(PowLaw1D('pl'))
+    assert isinstance(mdl, XSConvolutionModel), \
+        "cflux(mdl) creates XSConvolutionModel"
+
+    plpars = [('gamma', 1.0, False, ''),
+              ('ref', 1.0, True, ''),
+              ('ampl', 1.0, False, '')]
+    _check_pars('model', mdl, cfluxpars + plpars)
+
+
+def _test_cflux_calc(mdl, slope, ampl):
+    """Test the CFLUX convolution model calculation.
+
+    This is a test of the convolution interface, as the results of
+    the convolution can be easily checked.
+
+    Parameters
+    ----------
+    mdl
+        The unconvolved model. It is assumed to be a power law (so
+        either a XSpowerlaw or PowLaw1D instance).
+    slope, ampl : number
+        The slope (gamma or PhoIndex) and amplitude
+        (ampl or norm) of the power law.
+
+    See Also
+    --------
+    test_cflux_calc_sherpa, test_cflux_calc_xspec
+
+    """
+
+    d = setup_data()
+
+    kern = XScflux('cflux')
+
+    mdl_unconvolved = mdl
+    mdl_convolved = kern(mdl)
+
+    # As it's just a power law can evaluate analytically
+    #
+    pterm = 1.0 - slope
+    emin = d.xlo[0]
+    emax = d.xhi[-1]
+    counts_expected = ampl * (emax**pterm - emin**pterm) / \
+        pterm
+
+    # Could evaluate the model directly, but check that it's working
+    # with the Sherpa setup. It is not clear that going through
+    # the eval_model method really buys us much testing since the
+    # main check we would really want to do is with the DataPHA
+    # class, but that requires a lot of set up; the idea is that
+    # the interface is abstract enough that going through
+    # Data1DInt's eval_model API is sufficient.
+    #
+    y_unconvolved = d.eval_model(mdl_unconvolved)
+    nbins_unconvolved = y_unconvolved.size
+    assert nbins_unconvolved == d.xlo.size, \
+        'unconvolved model has correct # bins'
+
+    counts_unconvolved = y_unconvolved.sum()
+
+    # This is mainly a sanity check of everything, as it is not
+    # directly related to the convolution model. The counts_expected
+    # term is > 0.01 with the chosen settings, so 1e-15
+    # is a hand-wavy term to say "essentially zero". It may need
+    # tweaking depending on platform/setup.
+    #
+    assert np.abs(counts_expected - counts_unconvolved) < 1e-15, \
+        'can integrate a power law'
+
+    # How to verify the convolution model? Well, one way is to
+    # give it a flux, get the model values, and then check that
+    # these values are very close to the expected values for
+    # that flux.
+    #
+    kern.emin = 0.5
+    kern.emax = 7.0
+
+    desired_flux = 3.2e-14
+    kern.lg10flux = np.log10(desired_flux)
+
+    y_convolved = d.eval_model(mdl_convolved)
+    nbins_convolved = y_convolved.size
+    assert nbins_convolved == d.xlo.size, \
+        'convolved model has correct # bins'
+
+    # The model evaluated by mdl_convolved should have a
+    # log_10(flux), over the kern.Emin to kern.Emax energy range,
+    # of kern.lg10Flux, when the flux is in erg/cm^2/s (assuming
+    # the model it is convolving has units of photon/cm^2/s).
+    #
+    # d.xlo and d.xhi are in keV, so need to convert them to
+    # erg.
+    #
+    # Use 1 keV = 1.60218e-9 erg for the conversion, which limits
+    # the accuracy (in part because I don't know how this compares
+    # to the value that XSPEC uses, which could depend on the
+    # version of XSPEC).
+    #
+    econv = 1.60218e-9
+    emid = econv * (d.xlo + d.xhi) / 2.0
+
+    y_signal = emid * y_convolved
+
+    # Do not bother with trying to correct for any partially-filled
+    # bins at the end of this range (there shouldn't be any).
+    #
+    idx = np.where((d.xlo >= kern.emin.val) &
+                   (d.xhi <= kern.emax.val))
+    flux = y_signal[idx].sum()
+
+    # Initial tests had desired_flux = 3.2e-14 and the difference
+    # ~ 1.6e-16. This has been used to determine the tolerance.
+    # Note that 2e-16/3.2e-14 ~ 0.006 ie ~ 0.6%
+    #
+    assert np.abs(flux - desired_flux) < 2e-16, \
+        'flux is not as expected'
+
+    # The cflux model should handle any change in the model amplitude
+    # (I believe; as there's no one definition of what the model
+    # amplitude means in XSPEC). So, increasing the amplitude - assumed
+    # to the last parameter of the input model - should result in
+    # the same flux values. The unconvolved model is checked to make
+    # sure it does scale (as a sanity check).
+    #
+    rescale = 1000.0
+    mdl.pars[-1].val *= rescale
+    y_unconvolved_rescaled = d.eval_model(mdl_unconvolved)
+    y_convolved_rescaled = d.eval_model(mdl_convolved)
+
+    assert_allclose(y_unconvolved, y_unconvolved_rescaled / rescale,
+                    atol=0, rtol=1e-7)
+    assert_allclose(y_convolved, y_convolved_rescaled,
+                    atol=0, rtol=1e-7)
+
+
+def test_cflux_calc_xspec():
+    """Test the CFLUX convolution model calculations (XSPEC model)
+
+    This is a test of the convolution interface, as the results of
+    the convolution can be easily checked. The model being convolved
+    is an XSPEC model.
+
+    See Also
+    --------
+    test_cflux_calc_sherpa
+
+    """
+
+    mdl = XSpowerlaw('xspec')
+    mdl.phoindex = 1.7
+    mdl.norm = 0.025
+    _test_cflux_calc(mdl, mdl.phoindex.val, mdl.norm.val)
+
+def test_cflux_calc_sherpa():
+    """Test the CFLUX convolution model calculations (sherpa model)
+
+    This is a test of the convolution interface, as the results of
+    the convolution can be easily checked. The model being convolved
+    is a Sherpa model.
+
+    See Also
+    --------
+    test_cflux_calc_xspec
+
+    """
+
+    mdl = PowLaw1D('sherpa')
+    mdl.gamma = 1.7
+    mdl.ampl = 0.025
+    _test_cflux_calc(mdl, mdl.gamma.val, mdl.ampl.val)
+
+
+def test_cflux_nbins():
+    """Check that the number of bins created by cflux is correct.
+
+    The test_cflux_calc_xxx routines do include a test of the number
+    of bins, but that is just for a Data1DInt dataset, so the model
+    only ever gets called with explicit lo and hi edges. This test
+    calls the model directly to check both 1 and 2 argument variants.
+
+    Notes
+    -----
+    There's no check of a non-contiguous grid.
+    """
+
+    spl = PowLaw1D('sherpa')
+    xpl = XSpowerlaw('xspec')
+
+    spl.gamma = 0.7
+    xpl.phoindex = 0.7
+
+    egrid = np.arange(0.1, 2, 0.01)
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+
+    nbins = elo.size
+
+    def check_bins(lbl, mdl):
+        y1 = mdl(egrid)
+        y2 = mdl(elo, ehi)
+
+        assert y1.size == nbins + 1, '{}: egrid'.format(lbl)
+        assert y2.size == nbins, '{}: elo/ehi'.format(lbl)
+
+    # verify assumptions
+    #
+    check_bins('Sherpa model', spl)
+    check_bins('XSPEC model', xpl)
+
+    # Now try the convolved versions
+    #
+    cflux = XScflux("conv")
+    check_bins('Convolved Sherpa', cflux(spl))
+    check_bins('Convolved XSPEC', cflux(xpl))
+
+
+if __name__ == "__main__":
+
+    test_cflux_settings()
+    test_cflux_calc_xspec()
+    test_cflux_calc_sherpa()
+    test_cflux_nbins()

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/tests/test_xsconvolve_ui.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/tests/test_xsconvolve_ui.py
@@ -1,0 +1,97 @@
+#
+#  Copyright (C) 2017
+#            Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Test the integration of the XSPEC convolution models with the ui layer.
+
+There's no testing of model evaluation, as that is done for the lower
+level. The assumption here is that if a XSConvolutionKernel is created
+then we can rely on the evaluation tests in test_xsconvolve.py.
+
+"""
+
+from sherpa.astro import ui
+from sherpa.utils.err import IdentifierErr
+
+from sherpa_contrib.xspec import xsconvolve
+from sherpa_contrib.xspec.xsmodels import XSConvolutionKernel
+
+# Hard-coded list of models that are expected to exist
+# and the number of thawed and frozen parameters.
+#
+_models = [
+    ('cflux', 1, 2),
+    ('gsmooth', 1, 1),
+    ('ireflect', 1, 6),
+    ('kdblur', 1, 3),
+    ('kdblur2', 1, 5),
+    ('kerrconv', 2, 5),
+    ('lsmooth', 1, 1),
+    ('partcov', 1, 0),
+    ('rdblur', 1, 3),
+    ('reflect', 1, 4),
+    ('simpl', 2, 1),
+    ('zashift', 0, 1),
+    ('zmshift', 0, 1)]
+
+
+def test_load_exists():
+    """Do the load_xsXXX variants exist?"""
+
+    for mname, _, _ in _models:
+        func = 'load_xs{}'.format(mname)
+        assert func in xsconvolve.__all__, func
+        
+
+def test_load_creates_kernel():
+    """Do the load_xsXXX functions create a convolution kernel with npars?"""
+
+    ui.clean()
+
+    # if this fails then something very strange is going on
+    try:
+        ui.get_model_component('delme')
+        assert False, 'Why does delme exist?'
+    except IdentifierErr:
+        pass
+    
+    for mname, nthaw, nfrozen in _models:
+        func = 'load_xs{}'.format(mname)
+        f = getattr(xsconvolve, func)
+        f('delme')
+
+        mdl = ui.get_model_component('delme')
+        assert isinstance(mdl, XSConvolutionKernel), \
+            "{} creates XSConvolutionKernel".format(mname)
+        
+        assert len(mdl.pars) == nthaw + nfrozen, \
+            '{}: number of pars matches'.format(mname)
+
+        nf = sum([1 for p in mdl.pars if p.frozen])
+        assert nf == nfrozen, \
+            '{}: number of frozen pars matches'.format(mname)
+
+    ui.clean()
+
+
+
+if __name__ == "__main__":
+
+    test_load_exists()
+    test_load_creates_kernel()

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/xsconvolve.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/xsconvolve.py
@@ -247,7 +247,7 @@ class XSpartcov(XSConvolutionKernel):
     def __init__(self, name='xspartcov'):
         self.CvrFract = Parameter(name, 'CvrFract', 0.5, min=0.05, max=0.95,
                                   hard_min=0.0, hard_max=1.0, frozen=False)
-        XSConvolutionKernel.__init__(self, name, (self.CvfFract,))
+        XSConvolutionKernel.__init__(self, name, (self.CvrFract,))
 
 
 class XSrdblur(XSConvolutionKernel):

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/xsconvolve.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/xsconvolve.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2013, 2014, 2015
+#  Copyright (C) 2012, 2013, 2014, 2015, 2017
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -21,9 +21,6 @@
 """
 Creates the load_xxx routines that load in the XSpec convolution
 models.
-
-This needs to be updated to take advantage of the changes to the
-XSpec module in Sherpa 4.8.
 
 Note that these models have seen little to no testing so please take
 care and report any issues to the CXC HelpDesk at

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/xsmodels.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/sherpa_contrib/xspec/xsmodels.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016
+#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -23,9 +23,6 @@ Support for X-Spec convolution models provided along with Sherpa
 but currently not exposed for use. This is the set of helper
 classes and routines; to use the models themselves import the
 sherpa_contrib.xspec.xsconvolve model.
-
-This needs to be updated to support the changes to the XSpec module
-in CIAO 4.8.
 
 This interface has seen limited testing, so please check the
 documentation and then the CXC HelpDesk -
@@ -115,28 +112,14 @@ class XSConvolutionKernel(xspec.XSModel):
 
         fluxes = np.asarray(rhs(rpars, *args, **kwargs))
 
-        # The Sherpa-provided interfaces to the X-Spec convolution
-        # models require that lo/hi values are given, so we need
-        # to check on args.
+        # As of CIAO 4.8, the Sherpa-provided interfaces to the
+        # X-Spec convolution models require either
+        #     pars, fluxes, edges
+        #     pars, fluxes, elo, ehi
+        # wihch simplifies this from earlier versions.
         #
-        if len(args) == 0:
-            raise TypeError("Evaluating {} model but sent no grid!".format(self.name))
-        elif len(args) == 1:
-            elo = args[0][:-1]
-            ehi = args[0][1:]
-            fluxes = fluxes[:-1]
-        elif len(args) == 2:
-            elo = args[0]
-            ehi = args[1]
-        else:
-            raise TypeError("Evaluating {} model but sent {} arguments, expected 1 or 2!".format(self.name, len(args)))
-
-        out = self._calc(lpars, elo, ehi, fluxes)
-
-        if len(args) == 1:
-            return np.append(out, 0)
-        else:
-            return out
+        # should **kwargs be sent as well?
+        return self._calc(lpars, fluxes, *args)
 
 
 class XSConvolutionModel(models.CompositeModel, models.ArithmeticModel):


### PR DESCRIPTION
This fixes the XSPEC convolution interface so that it works with Sherpa in CIAO 4.8 or greater. The Sherpa API to the model functions was changed, which simplified the interface but I never had time to update this module.

There are also two basic test scripts that were added to check the implementation. They found an existing bug that made the `XSpartcov` model unusable.