### PR TITLE
Blanksky randomseed

### DIFF
--- a/ciao-4.9/contrib/bin/blanksky
+++ b/ciao-4.9/contrib/bin/blanksky
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-__version__ = "CIAO 4.8.1"
+__version__ = "CIAO 4.9"
 toolname = "blanksky"
-__revision__  = "05 October 2016"
+__revision__  = "14 February 2017"
 
 import os, sys, paramio, tempfile, shutil, stat
 import pycrates as pcr
@@ -265,6 +265,7 @@ def get_par(argv):
     # pars["band"] = params["band"] = paramio.pgetstr(pfile,"band")
     pars["bkgparams"] = params["bkgparams"] = paramio.pgetstr(pfile,"bkgparams")
     pars["weight_method"] = params["weight"] = paramio.pgetstr(pfile,"weight_method")        
+    pars["random"] = params["randomseed"] = paramio.pgeti(pfile,"random")
     pars["tmpdir"] = params["tmpdir"] = paramio.pgetstr(pfile,"tmpdir")
     pars["verbose"] = params["verbose"] = paramio.pgeti(pfile,"verbose")
     pars["clobber"] = params["clobber"] = paramio.pgetstr(pfile, "clobber")
@@ -546,24 +547,28 @@ def blanksky(infile,filters,asols,tmpdir,keywords,verbose,clobber):
 
             bkg_repro = bkg_calib # delete if apply_gain is implemented, uncomment above block
 
-            # add the PNT header keywords from the evt file
+            # add the PNT and AVG header keywords from the evt file
             # modify bkg file header
-            for key in ["RA_PNT","DEC_PNT","ROLL_PNT"]:
+            for key in ["RA_PNT","DEC_PNT","ROLL_PNT","DY_AVG","DZ_AVG","DTH_AVG"]:
                 dmkeypar.punlearn()
                 dmhedit.punlearn()
 
-                dmkeypar.infile = infile
-                dmkeypar.keyword = key
+                try:
+                    dmkeypar.infile = infile
+                    dmkeypar.keyword = key
+                    dmkeypar()
 
-                dmkeypar()
+                except IOError:
+                    raise IOError("{0} missing the {1} header keyword.".format(infile,key)
 
-                dmhedit.infile = bkg_repro.name+"[EVENTS]"
-                dmhedit.filelist = ""
-                dmhedit.operation = "add"
-                dmhedit.key = key
-                dmhedit.value = dmkeypar.value
-                                
-                dmhedit()
+                finally:
+                    dmhedit.infile = bkg_repro.name+"[EVENTS]"
+                    dmhedit.filelist = ""
+                    dmhedit.operation = "add"
+                    dmhedit.key = key
+                    dmhedit.value = dmkeypar.value
+
+                    dmhedit()
                 
             bkg = tempfile.NamedTemporaryFile(suffix=".bkg",dir=tmpdir)
 
@@ -598,6 +603,7 @@ def doit():
 #    enband = params["enband"]
     bkgparams = params["bkgparams"]
     method = params["weight"].lower()
+    seed = params["randomseed"]
     tmpdir = params["tmpdir"]
     clobber = params["clobber"]
     verbose = params["verbose"]
@@ -663,7 +669,7 @@ def doit():
     reproject_events.outfile = outdir+outfile
     reproject_events.aspect = asol
     reproject_events.match = evtfile
-    reproject_events.random = "0"
+    reproject_events.random = seed
     reproject_events.verbose = verbose
     reproject_events.clobber = clobber
 

--- a/ciao-4.9/contrib/bin/blanksky
+++ b/ciao-4.9/contrib/bin/blanksky
@@ -559,7 +559,7 @@ def blanksky(infile,filters,asols,tmpdir,keywords,verbose,clobber):
                     dmkeypar()
 
                 except IOError:
-                    raise IOError("{0} missing the {1} header keyword.".format(infile,key)
+                    raise IOError("{0} missing the {1} header keyword.".format(infile,key))
 
                 finally:
                     dmhedit.infile = bkg_repro.name+"[EVENTS]"

--- a/ciao-4.9/contrib/bin/specextract
+++ b/ciao-4.9/contrib/bin/specextract
@@ -32,7 +32,7 @@ This script is an enhanced Python translation of the original CIAO tool specextr
 __version__ = "CIAO 4.9"
 
 toolname = "specextract"
-__revision__ = "30 November 2016"
+__revision__ = "30 January 2017"
 
 
 ##########################################################################
@@ -3525,17 +3525,19 @@ def specextract(args):
 
          combine_spectra.bkg_spectra = ",".join(bphafiles)
 
-         if sum(cs_bkg_arfs)==src_count and sum(cs_bkg_rmfs)==src_count:
+         if dobkgresp == 1:
+             if sum(cs_bkg_arfs)==src_count and sum(cs_bkg_rmfs)==src_count:
 
-             combine_spectra.bkg_arfs    = ",".join(barffiles)
-             combine_spectra.bkg_rmfs    = ",".join(brmffiles)
+                 combine_spectra.bkg_arfs    = ",".join(barffiles)
+                 combine_spectra.bkg_rmfs    = ",".join(brmffiles)
 
-             combine_spectra()
-             v2("Combined source and background spectra and responses.")
+                 combine_spectra()
+                 v2("Combined source and background spectra and responses.")
 
          else:
              combine_spectra()
              v2("Combined source spectra and responses, and background spectra.")
+
      else:
 
          combine_spectra()

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/runtool.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/runtool.py
@@ -2606,7 +2606,7 @@ parinfo['axbary'] = {
 parinfo['blanksky'] = {
     'istool': True,
     'req': [ParValue("evtfile","f","Source event file",None),ParValue("outfile","f","Output directory path + file name for output files",None)],
-    'opt': [ParValue("asolfile","f","Source aspect solution file(s)",None),ParSet("weight_method","s","Method to calculate background scale factor",'particle',["particle","time"]),ParValue("bkgparams","s","Optional argument for background scaling, default is [pi=300:500] for HRC and [energy=9000:12000] for ACIS",'default'),ParValue("tmpdir","s","Directory for temporary files",'${ASCDS_WORK_PATH}'),ParValue("clobber","b","OK to overwrite existing output file?",False),ParRange("verbose","i","Debug Level(0-5)",1,0,5)],
+    'opt': [ParValue("asolfile","f","Source aspect solution file(s)",None),ParSet("weight_method","s","Method to calculate background scale factor",'particle',["particle","time"]),ParValue("bkgparams","s","Optional argument for background scaling, default is [pi=300:500] for HRC and [energy=9000:12000] for ACIS",'default'),ParValue("tmpdir","s","Directory for temporary files",'${ASCDS_WORK_PATH}'),ParRange("random","i","random seed (0 = use time dependent seed)",0,0,None),ParValue("clobber","b","OK to overwrite existing output file?",False),ParRange("verbose","i","Debug Level(0-5)",1,0,5)],
     }
 
 

--- a/ciao-4.9/contrib/param/blanksky.par
+++ b/ciao-4.9/contrib/param/blanksky.par
@@ -5,6 +5,6 @@ weight_method,s,h,"particle",particle|time,,"Method to calculate background scal
 bkgparams,s,h,"default",,,"Optional argument for background scaling, default is [pi=300:500] for HRC and [energy=9000:12000] for ACIS"
 tmpdir,s,h,"${ASCDS_WORK_PATH}",,,"Directory for temporary files"
 random,i,h,0,0,,"Random seed, 0=clock time"
-clobber,b,h,yes,,,"OK to overwrite existing output file?"
+clobber,b,h,no,,,"OK to overwrite existing output file?"
 verbose,i,h,1,0,5,"Debug Level(0-5)"
 mode,s,h,"ql",,,

--- a/ciao-4.9/contrib/param/blanksky.par
+++ b/ciao-4.9/contrib/param/blanksky.par
@@ -4,6 +4,7 @@ asolfile,f,h,"",,,"Source aspect solution file(s)"
 weight_method,s,h,"particle",particle|time,,"Method to calculate background scale factor"
 bkgparams,s,h,"default",,,"Optional argument for background scaling, default is [pi=300:500] for HRC and [energy=9000:12000] for ACIS"
 tmpdir,s,h,"${ASCDS_WORK_PATH}",,,"Directory for temporary files"
-clobber,b,h,no,,,"OK to overwrite existing output file?"
+random,i,h,0,0,,"Random seed, 0=clock time"
+clobber,b,h,yes,,,"OK to overwrite existing output file?"
 verbose,i,h,1,0,5,"Debug Level(0-5)"
 mode,s,h,"ql",,,

--- a/ciao-4.9/contrib/share/doc/xml/blanksky.xml
+++ b/ciao-4.9/contrib/share/doc/xml/blanksky.xml
@@ -227,6 +227,20 @@
         </DESC>
       </PARAM>
 
+      <PARAM name="random" type="integer" def="0" min="0">
+        <SYNOPSIS>
+	  Random seed for randomization.
+        </SYNOPSIS>
+        <DESC>
+          <PARA>
+	    The random parameter is sent to reproject_events when
+	    processing the ACIS blanksky and HRC-I particle background
+	    files to match the observation. A value of 0 uses the
+	    system time to seed the random number generator. 
+          </PARA>
+        </DESC>
+      </PARAM>    
+
       <PARAM name="clobber" type="boolean" def="no" reqd="no">
         <DESC>
           <PARA>
@@ -290,6 +304,6 @@
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>February 2016</LASTMODIFIED>
+    <LASTMODIFIED>February 2017</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
The blanksky script, and associated files, have been updated to include a new "random" parameter to pass to reproject_events', in order to create re-producible results.

An additional change includes adding the DY_AVG, DZ_AVG, and DTH_AVG header keywords to the tailored blanksky background file that match the reference events file.