### PR TITLE
specextract; combing 3 spectra with bkgresp=no

### DIFF
--- a/ciao-4.9/contrib/bin/specextract
+++ b/ciao-4.9/contrib/bin/specextract
@@ -32,7 +32,7 @@ This script is an enhanced Python translation of the original CIAO tool specextr
 __version__ = "CIAO 4.9"
 
 toolname = "specextract"
-__revision__ = "30 January 2017"
+__revision__ = "14 March 2017"
 
 
 ##########################################################################
@@ -2011,7 +2011,7 @@ def specextract(args):
              raise IOError("Cannot use M.M. ACIS blanksky background files as infile, since responses cannot be produced.\n")
 
      # check defined response energy range for weighted warm observations
-     if weight == "yes":
+     if [weight == "yes", headerkeys["INSTRUME"] == "ACIS"] == [True,True]:
 
         # check focal plane temperature, if >-110C, then check FEF energy range
         # ObsID 114 (observed 2000-01-30 10:40:42) is first observation made at <-119C.

--- a/ciao-4.9/contrib/bin/specextract
+++ b/ciao-4.9/contrib/bin/specextract
@@ -32,7 +32,7 @@ This script is an enhanced Python translation of the original CIAO tool specextr
 __version__ = "CIAO 4.9"
 
 toolname = "specextract"
-__revision__ = "30 November 2016"
+__revision__ = "30 January 2017"
 
 
 ##########################################################################
@@ -3525,17 +3525,19 @@ def specextract(args):
 
          combine_spectra.bkg_spectra = ",".join(bphafiles)
 
-         if sum(cs_bkg_arfs)==src_count and sum(cs_bkg_rmfs)==src_count:
+         if dobkgresp == 1:
+             if sum(cs_bkg_arfs)==src_count and sum(cs_bkg_rmfs)==src_count:
 
-             combine_spectra.bkg_arfs    = ",".join(barffiles)
-             combine_spectra.bkg_rmfs    = ",".join(brmffiles)
+                 combine_spectra.bkg_arfs    = ",".join(barffiles)
+                 combine_spectra.bkg_rmfs    = ",".join(brmffiles)
 
-             combine_spectra()
-             v2("Combined source and background spectra and responses.")
+                 combine_spectra()
+                 v2("Combined source and background spectra and responses.")
 
          else:
              combine_spectra()
              v2("Combined source spectra and responses, and background spectra.")
+
      else:
 
          combine_spectra()

--- a/ciao-4.9/contrib/bin/specextract
+++ b/ciao-4.9/contrib/bin/specextract
@@ -2283,17 +2283,17 @@ def specextract(args):
 
  # cast as stacks
  if asp == "" and len(ancil["asol"]) != 0:
-         temp_asol_stk = make_stackfile(ancil["asol"],suffix="asol",delete=True)
+     temp_asol_stk = make_stackfile(ancil["asol"],suffix="asol",delete=True)
 
  if bpixfile == "" and len(ancil["bpix"]) != 0:
-         temp_bpix_stk =  make_stackfile(ancil["bpix"],suffix="bpix",delete=True)
+     temp_bpix_stk =  make_stackfile(ancil["bpix"],suffix="bpix",delete=True)
 
  if dtffile == "" and len(ancil["dtf"]) != 0:
-         if "" not in ancil["dtf"]:
-             temp_dtf_stk = make_stackfile(ancil["dtf"],suffix="dtf",delete=True)
+     if "" not in ancil["dtf"]:
+         temp_dtf_stk = make_stackfile(ancil["dtf"],suffix="dtf",delete=True)
          
  if mask == "" and len(ancil["msk"]) != 0:
-         temp_msk_stk = make_stackfile(ancil["msk"],suffix="msk",delete=True)
+     temp_msk_stk = make_stackfile(ancil["msk"],suffix="msk",delete=True)
 
  # assign stacks to variables
  if False not in [asp.lower() != "none", asp == ""]:

--- a/ciao-4.9/contrib/share/doc/xml/specextract.xml
+++ b/ciao-4.9/contrib/share/doc/xml/specextract.xml
@@ -1631,6 +1631,16 @@ unix% cat output.lis
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the April 2017 Release">
+      <PARA>
+	A bug was fixed that caused the script to fail when trying to
+	combine spectra when "bkgresp=no" and exactly *3* sets of
+	spectra were being co-added.  The data products created by
+	specextract were otherwise correct.  Focal plane temperature
+	testing of HRC observations is now skipped; the script would error out since the
+	FP_TEMP header keyword does not exist in HRC data. 
+      </PARA>
+    </ADESC>
 
     <BUGS>
       <PARA title="Caveat: Exposure Variations">
@@ -1677,7 +1687,7 @@ unix% cat output.lis
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>December 2016</LASTMODIFIED>
+    <LASTMODIFIED>April 2017</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This is a specextract fix a conditional affecting combining 3 spectra when bkgresp=no reported by a user. Running regression tests on this change indicates no affects on test results.