### PR TITLE
chandra_repro fix typo when badpixel=no

### DIFF
--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "19 Sep 2016"
+version = "06 March 2017"
 
 # import standard python modules as required
 #
@@ -2184,7 +2184,7 @@ def main_body( pars):
 
     #!### Issue warning if the badpixel step is turned off ###
     if not pars["badpixel"]:
-        v1('WARNING: badpixel=no, so archived bpix1.fits file will be used.\n')
+        v1('WARNING: badpixel=no, so archived bpix1.fits file will not be used.\n')
     
     #!### Gather and verify our inputs ###
     pars = get_inputs(pars)

--- a/ciao-4.9/contrib/share/doc/xml/chandra_repro.xml
+++ b/ciao-4.9/contrib/share/doc/xml/chandra_repro.xml
@@ -752,6 +752,14 @@ acisf084244478N003_2_bias0.fits.gz
 
 
 
+<ADESC title="Changes in scripts 4.9.2 (April 2017) release">
+  <PARA>
+    There are only internal changes to the script to tweak how HISTORY
+    records are written and to correct some verbose output.
+  </PARA>
+</ADESC>
+
+
 <ADESC title="Changes in scripts 4.8.4 (September 2016) release">
   <PARA>
     For ACIS CC mode data, pix_adj="default" now sets acis_process_events pix_adj=NONE 
@@ -1013,6 +1021,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>August 2016</LASTMODIFIED>
+    <LASTMODIFIED>March 2017</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Add a missing "not" to verbose output when run with badpixel=no.

