### PR TITLE
srcflux run fluximage with background=none

### DIFF
--- a/ciao-4.9/contrib/bin/srcflux
+++ b/ciao-4.9/contrib/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "19 Sep 2016"
+__revision__ = "06 Mar 2017"
 
 import os
 
@@ -1119,6 +1119,7 @@ def run_fluximage( infile, outroot, at_energy, src, bkg, myparams ):
     fluximage.verbose = myparams.verbose
     fluximage.cleanup = 'SAVE_ALL' not in os.environ
     fluximage.tmpdir = myparams.tmpdir
+    fluximage.background = "none"
     
     try:
         verb2(fluximage())

--- a/ciao-4.9/contrib/share/doc/xml/srcflux.xml
+++ b/ciao-4.9/contrib/share/doc/xml/srcflux.xml
@@ -1620,16 +1620,29 @@ bounds(region(my.reg))
 	The tool then computes a model independent flux using the
 	flux values computed using the eff2evt tool which uses the events'
 	energy and the local responses to estimate a flux value per event.
+    These are the "Flux" values printed to the screen and are the "NET_FLUX_APER"
+    values stored in the .flux output file.
+
       </PARA>
       <PARA>
       The fluximage tool is run to create an exposure corrected
       image for just a small region around the source and background.
       The photon flux is extracted from this image.
+      These values are not displayed to the terminal.  They are
+      stored in the "NET_PHOTFLUX_APER" columns in the .flux output file.
+
       </PARA>
       <PARA>
 	specextract is then run to generated the ARF and RMF needed to 
 	compute the model dependent fluxes using the modelflux tool.  
 	Both absorbed and unabsorbed fluxes can be computed.
+    The screen output "Mod.Flux" values are the absorbed model flux values which
+    are also stored in the "NET_MFLUX_APER" column in the .flux output file.
+    If a separate absorption model was supplied, then the "Unabs Mod.Flux"
+    screen output will be displayed with those flux values; those values
+    are also stored in the "NET_UMFLUX_APER" column in the .flux output file.
+    
+    
       </PARA>
       <PARA>
         The results are stored in an output file, one row per source, and one
@@ -1637,6 +1650,8 @@ bounds(region(my.reg))
         printed to the screen.            
       </PARA>
     </ADESC>
+
+
 
     <ADESC title="Caveats">
 
@@ -1707,6 +1722,17 @@ bounds(region(my.reg))
       
       </PARA>
 
+    </ADESC>
+
+
+    <ADESC title="Changes in the script 4.9.2 (April 2017) release">
+      <PARA>
+      There is a change to the script to correct an error for HRC-I 
+      photon fluxes (net_photflux_aper values) which was 
+      incorrectly including the background contribution twice.      
+      </PARA>
+    
+    
     </ADESC>
 
 
@@ -1813,6 +1839,6 @@ bounds(region(my.reg))
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>March 2015</LASTMODIFIED>
+    <LASTMODIFIED>March 2017</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Re:  #4 

fix to run fluximage with background=none so that background is not i… clude, and then double counted.  It only affets hrc-i.  2 new regression tests were added.  One for hrc-s number7 and one for hrc-i number8.

