### PR TITLE
simulate_psf : Add range filter to marx output before reprojecting

### DIFF
--- a/ciao-4.9/contrib/bin/simulate_psf
+++ b/ciao-4.9/contrib/bin/simulate_psf
@@ -28,7 +28,7 @@ import sys
 import subprocess
 
 toolname = "simulate_psf"
-__revision__ = "13 Sep 2016"
+__revision__ = "06 March 2017"
 
 
 from cxcdm import *
@@ -798,10 +798,28 @@ def run_marx_reproject_events( pars ):
         
         If events have been reprojects then need to corrected
     """    
-    reproject_events = make_tool("reproject_events")
 
+    def get_xy_limits(infile):
+        """
+        The marx files may have events WAY! outside the tlmin/tlmax of the
+        column.  We need to filter those out here or it messes up
+        the limits and then when you display the ray file the data is
+        centered in a bad place (eg far from 4096,4096 [acis]).
+        """
+        from pycrates import read_file
+        tab = read_file(infile)
+        xl=tab.get_column("x").get_tlmin()
+        xh=tab.get_column("x").get_tlmax()
+        yl=tab.get_column("y").get_tlmin()
+        yh=tab.get_column("y").get_tlmax()
+        retval="[x={}:{},y={}:{}]".format(xl,xh,yl,yh)
+        return retval
+
+    limits = get_xy_limits( pars["_outroot_"]+ "_marx.fits"  )
+
+    reproject_events = make_tool("reproject_events")
     reproject_events.punlearn()
-    reproject_events.infile  = pars["_outroot_"]+ "_marx.fits" 
+    reproject_events.infile  = pars["_outroot_"]+ "_marx.fits"+limits
     reproject_events.outfile = pars["_outroot_"]+ "_projrays.fits" 
     reproject_events.random  = "-1"       # make sure no randomization
     reproject_events.match   = pars["infile"]

--- a/ciao-4.9/contrib/share/doc/xml/simulate_psf.xml
+++ b/ciao-4.9/contrib/share/doc/xml/simulate_psf.xml
@@ -935,7 +935,44 @@
         
     </ADESC>
 
-   <LASTMODIFIED>April 2016</LASTMODIFIED>
+
+    <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
+      <PARA>
+        There is an internal change which ensures that the output ray file
+        will retain the same event file sky boundary (ie TLMIN/TLMAX) 
+        as the input file.  Prior to this the ray file may not have
+        displayed nicely in ds9.  This only affects the way the data 
+        are displayed.
+      </PARA>
+    
+    </ADESC>
+
+
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see the
+        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
+          instructions page</HREF> for help on installing the package.
+      </PARA>
+    </ADESC>
+
+
+   <BUGS>
+      <PARA>
+        See the
+        <HREF link="http://cxc.harvard.edu/ciao/bugs/install_marx.html">bugs page
+        for this script</HREF> on the CIAO website for an up-to-date
+        listing of known bugs. 
+      </PARA>
+    </BUGS>
+
+
+
+
+   <LASTMODIFIED>March 2017</LASTMODIFIED>
 
 
   </ENTRY>


### PR DESCRIPTION
Ref #9 

add a DM filter to the marx output.  The x,y values can be far outside the normal tlmin/tlmax which, when run through dmmerge or reproject_events resets the limits to the limits of the data.  The upshot is that then opening in ds9 the data are centered in the middle of nowhere

My original thinking that I could just add a blind '[x:,y:]' didn't work.  It seemed to get applied to the y column but not the x.  So I had to go in and pull out the limits explicitly.

I added a new test for HRC (09.MAIN)  to make sure that the limits are getting pulled correctly for both ACIS and HRC.


