### PR TITLE
mktgresp support typeI files, tgsplit include REGION extension

### DIFF
--- a/ciao-4.9/contrib/bin/mktgresp
+++ b/ciao-4.9/contrib/bin/mktgresp
@@ -20,7 +20,7 @@
 from __future__ import print_function
 
 toolname = "mktgresp"
-__revision__ = "19 Sep 2016"
+__revision__ = "06 March 2017"
 
 
 import os
@@ -142,11 +142,18 @@ def get_order_and_arm( phafile, orderlist ):
     
     myf = pyc.read_file(phafile)
 
-    parts = myf.get_column("tg_part").values.copy()
-    orders = myf.get_column("tg_m").values.copy()
-    ids = myf.get_column("tg_srcid").values.copy()
-    xx = myf.get_column("x").values.copy()
-    yy = myf.get_column("y").values.copy()
+    try:
+        parts = myf.get_column("tg_part").values.copy()
+        orders = myf.get_column("tg_m").values.copy()
+        ids = myf.get_column("tg_srcid").values.copy()
+        xx = myf.get_column("x").values.copy()
+        yy = myf.get_column("y").values.copy()
+    except:
+        parts = [myf.get_key_value("tg_part")]
+        orders = [myf.get_key_value("tg_m")]
+        ids = [myf.get_key_value("tg_srcid")]
+        xx = [myf.get_key_value("x")]
+        yy = [myf.get_key_value("y")]
 
     zz = parse_orderlist( orderlist, parts, ids, xx, yy )
 

--- a/ciao-4.9/contrib/bin/tgsplit
+++ b/ciao-4.9/contrib/bin/tgsplit
@@ -20,8 +20,9 @@
 from __future__ import print_function
 
 toolname = "tgsplit"
-__revision__ = "13 Sep 2016"
+__revision__ = "06 March 2017"
 
+from ciao_contrib.runtool import make_tool
 from pycrates import read_file, write_file
 import numpy as np
 import stk
@@ -47,7 +48,7 @@ def get_unique_id( infile ):
     # err, tg_srcid isn't correct in response files so can't use it.
     keys = [ 'obs_id', 'obi_num', 'cycle', 'tg_m', 'tg_part']
 
-    tab = read_file( infile )
+    tab = read_file( infile, "r" )
 
     retval = [ tab.get_key_value(k) for k in keys ]
 
@@ -96,7 +97,7 @@ def update_ontime( pha ):
     valid_vals = [x for x in ontimes if x ] # filter( lambda x: x, ontimes)  # filter out the None's
 
     if len(valid_vals) == 0:
-        tab.write()
+        tab.get_dataset().write()
         return
 
     avg_ontime = np.average(valid_vals)
@@ -105,14 +106,14 @@ def update_ontime( pha ):
     tab.get_key("livetime").value = avg_ontime * dtcor
     tab.get_key("exposure").value = avg_ontime * dtcor    
 
-    tab.write()
+    tab.get_dataset().write()
     
     return
 
 def copy_infile( infile, tgm, tgp, root, clobber ):
     """
     """
-    from ciao_contrib.runtool import dmcopy
+    dmcopy = make_tool("dmcopy")
     sgn = 'p' if tgm > 0 else 'm'
     arm = tgpart[tgp].lower()    
     dmcopy.infile=infile
@@ -131,7 +132,7 @@ def split_pha2( tgm, tgp, infile, root, clobber ):
     """
     Run dmtype2split on the pha file to create the src spectrum.
     """
-    from ciao_contrib.runtool import dmtype2split
+    dmtype2split=make_tool("dmtype2split")
 
     sgn = 'p' if tgm > 0 else 'm'
     arm = tgpart[tgp].lower()    
@@ -141,8 +142,13 @@ def split_pha2( tgm, tgp, infile, root, clobber ):
     v = dmtype2split()    
     if v : verb2(v)
 
+    retval = dmtype2split.outfile.replace("[SPECTRUM]","")
+    dmappend = make_tool("dmappend")
+    v = dmappend( infile+"[REGION][subspace -time]", retval )
+    if v: verb0(v)
+
     verb1("Created source spectrum: {}".format(dmtype2split.outfile))
-    return dmtype2split.outfile.replace("[SPECTRUM]","")
+    return retval
     
 
 def split_bkg_tge( infile, clobber ):
@@ -155,7 +161,7 @@ def split_bkg_tge( infile, clobber ):
     
     update_ontime(infile)
     
-    tab = read_file(infile)
+    tab = read_file(infile, "r")
 
     # sum counts, sum backscale values
     bgcts = tab.get_column("background_up").values + tab.get_column("background_down").values
@@ -180,12 +186,14 @@ def split_bkg_tge( infile, clobber ):
     verb1( "Created background spectrum: {}".format(outfile))
 
     # Hack to delete the background columns from the source file.
-    tab = read_file(infile)
+    tab = read_file(infile, "r")
     tab.delete_column( "background_up")
     tab.delete_column( "background_down")
     tab.delete_key("backscup")
     tab.delete_key("backscdn")    
-    write_file( tab, infile+".tmp", clobber=True)
+    #write_file( tab, infile+".tmp", clobber=True)
+    tab.get_dataset().write( infile+".tmp", clobber=True)
+    
     os.rename( infile+".tmp", infile )
     return outfile
     
@@ -200,7 +208,7 @@ def split_bkg_tge2( infile, clobber ):
     """
     update_ontime( infile )
 
-    tab = read_file(infile)
+    tab = read_file(infile,"r")
 
     # sum counts,  sum backscale values
     bgcts = tab.get_column("bg_counts").values
@@ -223,11 +231,12 @@ def split_bkg_tge2( infile, clobber ):
     verb1( "Created background spectrum: {}".format(outfile))
 
     # Hack to delete columns from the source spectrum.
-    tab = read_file(infile)
+    tab = read_file(infile,"r")
     tab.delete_column( "bg_counts")
     tab.delete_column( "bg_area")
     tab.delete_column( "bg_err")
-    write_file( tab, infile+".tmp", clobber=True)
+    #write_file( tab, infile+".tmp", clobber=True)
+    tab.get_dataset().write(infile+".tmp", clobber=True)
     os.rename( infile+".tmp", infile )
 
     return outfile
@@ -249,7 +258,7 @@ def get_respfile_from_arf( infile ):
 
     Assume to be in same dir as the ARF.
     """
-    tab = read_file(infile)
+    tab = read_file(infile,"r")
     grid = tab.get_key_value("respfile")
     isgrid = grid.split("(")
     if 2 != len(isgrid) or isgrid[0].lower() != 'grid':
@@ -281,7 +290,7 @@ def update_src_headers( src, bkg, arf, rmf ):
     update_if_not_blank( "respfile", withpath(rmf))
 
     
-    tab.write()
+    tab.get_dataset().write()
 
 
 
@@ -314,7 +323,7 @@ def split_pha2_and_background( infile, root, clobber ):
     """
 
     # Get the list of order & part to iterate over
-    tab = read_file( infile )
+    tab = read_file( infile, "r" )
     ftype = check_infile( tab, infile )
 
     if "TYPE:II" == ftype:

--- a/ciao-4.9/contrib/share/doc/xml/mktgresp.xml
+++ b/ciao-4.9/contrib/share/doc/xml/mktgresp.xml
@@ -403,6 +403,14 @@ parameter is angstroms.
     </PARAM>
     </PARAMLIST>
 
+  <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
+    <PARA>
+      The script can now work on TYPE:I (ie single spectra) PHA files.
+    </PARA>  
+  </ADESC>
+
+
+
    <ADESC title="Change in scripts 4.8.4 (September 2016) release">
      <PARA>
        Updates to allow for ACIS-I + grating configurations.
@@ -438,7 +446,7 @@ parameter is angstroms.
         for this tool</HREF>
         on the CIAO website for an up-to-date listing of known bugs.
       </PARA></BUGS>
-   <LASTMODIFIED>July 2016</LASTMODIFIED>
+   <LASTMODIFIED>March 2017</LASTMODIFIED>
 
 
 </ENTRY>

--- a/ciao-4.9/contrib/share/doc/xml/tgsplit.xml
+++ b/ciao-4.9/contrib/share/doc/xml/tgsplit.xml
@@ -372,8 +372,16 @@ Created background spectrum: tgcat_obs7435_heg_p1_bkg.pha
         simply the value for the aimpoint-chip.  This script will update
         the keywords appropriate for the set of chips each order falls on.     
      </PARA>
-   
    </ADESC>
+
+
+   <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
+     <PARA>
+         Updated to copy the [REGION] extension to the individual TYPE:I pha
+         files which are needed by mkgrmf.
+     </PARA>   
+   </ADESC>
+
 
     <ADESC title="Change in script 4.8.4 (September 2016) release">
       <PARA>
@@ -412,7 +420,7 @@ Created background spectrum: tgcat_obs7435_heg_p1_bkg.pha
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>July 2016</LASTMODIFIED>
+    <LASTMODIFIED>March 2017</LASTMODIFIED>
 
 
     </ENTRY>    


### PR DESCRIPTION
Ref: #7 

updated mktgresp to allow for type I files; however, mkgrmf requires the REGION extension which are not being copied by tgsplit.  So this also updates tgsplit to append the REGION extension.   This is harder than it seems since going through crates, the region block is dropped so I need to change several places to the dataset's write method