### PR TITLE
update combine_spectra to recompute the stat_err column and set POISSERR=True

### DIFF
--- a/ciao-4.9/contrib/bin/combine_spectra
+++ b/ciao-4.9/contrib/bin/combine_spectra
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 
 toolname = "combine_spectra"
-__revision__ = "13 Sep 2016"
+__revision__ = "06 March 2017"
 
 import sys
 
@@ -635,7 +635,7 @@ def write_spectrum( outfile, phas, chans, out_cts, out_exp, out_bsc, outrmf, out
     
     """
 
-    cols2rm = "[cols -"+",-".join(['grouping', 'quality', 'grp_num', 'chans_per_grp', 'grp_data', 'grp_stat_err'])+"]"
+    cols2rm = "[cols -"+",-".join(['stat_err', 'grouping', 'quality', 'grp_num', 'chans_per_grp', 'grp_data', 'grp_stat_err'])+"]"
     
     from ciao_contrib.runtool import dmmerge
     inf = [phas[0]+"[subspace -time,-expno,-sky,-pos]"+cols2rm  ]
@@ -654,6 +654,13 @@ def write_spectrum( outfile, phas, chans, out_cts, out_exp, out_bsc, outrmf, out
         tab.get_key("EXPOSURE").value = out_exp
     if tab.key_exists("LIVETIME"):
         tab.get_key("LIVETIME").value = out_exp
+    if tab.key_exists("POISSERR"):
+        tab.get_key("POISSERR").value = True
+    else:
+        k = CrateKey()
+        k.name="POISSERR"
+        k.value=True
+        tab.add_key(k)
 
     if 'count_rate' in [x.lower() for x in tab.get_colnames()]:
         tab.get_column("count_rate").values = out_cts / out_exp

--- a/ciao-4.9/contrib/bin/combine_spectra
+++ b/ciao-4.9/contrib/bin/combine_spectra
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # 
-# Copyright (C) 2013,2014,2016 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013,2014,2016-2017 Smithsonian Astrophysical Observatory
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -160,7 +160,7 @@ class Spectrum():
             verb2("Grouping information in file {} will be ignored".format( infile ))
 
         if tab.column_exists("stat_err"):
-            verb2("Statistical errors in file {} will be ignored".format(infile))
+            verb2("Statistical errors in file {} will be recomputed using Gehrel's approximation.".format(infile))
 
         if tab.key_exists("grating") and tab.get_key_value("grating") in ['HETG','LETG']:
             self.is_grating = True
@@ -635,7 +635,7 @@ def write_spectrum( outfile, phas, chans, out_cts, out_exp, out_bsc, outrmf, out
     
     """
 
-    cols2rm = "[cols -"+",-".join(['stat_err', 'grouping', 'quality', 'grp_num', 'chans_per_grp', 'grp_data', 'grp_stat_err'])+"]"
+    cols2rm = "[cols -"+",-".join(['grouping', 'quality', 'grp_num', 'chans_per_grp', 'grp_data', 'grp_stat_err'])+"]"
     
     from ciao_contrib.runtool import dmmerge
     inf = [phas[0]+"[subspace -time,-expno,-sky,-pos]"+cols2rm  ]
@@ -650,17 +650,17 @@ def write_spectrum( outfile, phas, chans, out_cts, out_exp, out_bsc, outrmf, out
     tab = pc.read_file( dmmerge.outfile)
     tab.get_column("channel").values = chans
     tab.get_column("counts").values = out_cts
+
+    if tab.column_exists("stat_err"):
+        stat_err = 1.0+np.sqrt( out_cts +0.75)
+        etype = tab.get_column("stat_err").values.dtype
+        tab.get_column("stat_err").values = stat_err.astype(etype)
+        verb1("Using Gehrel's approximation for STAT_ERR values.")
+
     if tab.key_exists("EXPOSURE"):
         tab.get_key("EXPOSURE").value = out_exp
     if tab.key_exists("LIVETIME"):
         tab.get_key("LIVETIME").value = out_exp
-    if tab.key_exists("POISSERR"):
-        tab.get_key("POISSERR").value = True
-    else:
-        k = CrateKey()
-        k.name="POISSERR"
-        k.value=True
-        tab.add_key(k)
 
     if 'count_rate' in [x.lower() for x in tab.get_colnames()]:
         tab.get_column("count_rate").values = out_cts / out_exp

--- a/ciao-4.9/contrib/share/doc/xml/combine_grating_spectra.xml
+++ b/ciao-4.9/contrib/share/doc/xml/combine_grating_spectra.xml
@@ -717,10 +717,8 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 
     <ITEM>
         Statistical errors on the combined counts in the combined
-	source and background spectra are not computed by
-        the script, as it is left to the X-ray fitting
-        program chosen to fit the data to assign uncertainties to each
-        spectral bin. 
+	source and background spectra are only recomputed using the Gehrel's
+    approximation if the input file has a STAT_ERR column.
     </ITEM>
 
     <ITEM>
@@ -730,6 +728,16 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
        </LIST>
 </ADESC>
       
+
+<ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
+  <PARA>
+    If the input spectra contain a STAT_ERR column, the script will
+    now recompute the error using the Gehrel's approximation.
+  </PARA>
+</ADESC>
+
+
+
 
      <ADESC title="About Contributed Software">
       <PARA>
@@ -750,7 +758,7 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
     </BUGS>
 
    
-    <LASTMODIFIED>September 2014</LASTMODIFIED>
+    <LASTMODIFIED>March 2017</LASTMODIFIED>
 
 
   </ENTRY>

--- a/ciao-4.9/contrib/share/doc/xml/combine_spectra.xml
+++ b/ciao-4.9/contrib/share/doc/xml/combine_spectra.xml
@@ -350,10 +350,8 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 
     <ITEM>
         Statistical errors on the combined counts in the combined
-	source and background spectra are not computed by
-        the script, as it is left to the X-ray fitting
-        program chosen to fit the data to assign uncertainties to each
-        spectral bin. 
+	source and background spectra are only recomputed using the Gehrel's
+    approximation if the input file has a STAT_ERR column.
     </ITEM>
 
     <ITEM>
@@ -362,6 +360,16 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 
        </LIST>
 </ADESC>
+
+
+
+<ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
+  <PARA>
+    If the input spectra contain a STAT_ERR column, the script will
+    now recompute the error using the Gehrel's approximation.
+  </PARA>
+</ADESC>
+
 
 <ADESC title="Change in the 4.7.3 (June 2015) release">
   <PARA>
@@ -485,7 +493,7 @@ combined background counts in any channel is 0.
     </BUGS>
 
    
-    <LASTMODIFIED>June 2015</LASTMODIFIED>
+    <LASTMODIFIED>March 2017</LASTMODIFIED>
 
 
   </ENTRY>


### PR DESCRIPTION

I updated combine spectra (called by combine_grating_spectra) to drop the stat_err column and to se the POISSERR keyword=True.  Ref #17 

All the c_g_s tests are affects but none of the combine_spectra tests themselves are.

specextract with combine=yes is TBD.

