### PR TITLE
Fix issue #10

### DIFF
--- a/ciao-4.9/contrib/bin/reproject_obs
+++ b/ciao-4.9/contrib/bin/reproject_obs
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2012, 2013, 2014, 2015, 2016
+# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -37,7 +37,7 @@ can be broken down into
 """
 
 toolname = 'reproject_obs'
-__revision__  = '27 October 2016'
+__revision__  = '31 March 2017'
 
 import os
 import sys
@@ -45,6 +45,7 @@ import shutil
 import tempfile
 
 import six
+import six.moves
 
 import paramio
 
@@ -368,7 +369,8 @@ def link_ancillary_files(taskrunner,
 
             else:
                 newnames = []
-                for (idx, afile) in zip(xrange(0, nfiles), afiles):
+                zs = zip(six.moves.xrange(0, nfiles), afiles)
+                for (idx, afile) in zs:
                     idval = chr(97 + idx)
                     newname = "{}{}{}.asol".format(outroot, label, idval)
                     newnames.append(os.path.basename(newname))

--- a/ciao-4.9/contrib/share/doc/xml/reproject_obs.xml
+++ b/ciao-4.9/contrib/share/doc/xml/reproject_obs.xml
@@ -752,6 +752,15 @@
       </LIST>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
+      <PARA>
+	The script now works when one (or more) of the ObsIds to be
+	reprojected has multiple aspect-solution files and the Python 3.5
+	version of CIAO 4.9 is being used. The previous behavior was to
+	error out with the message "ERROR name 'xrange' is not defined".
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
       <PARA>
         The code has been updated to avoid warning messages from
@@ -856,7 +865,7 @@
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>March 2017</LASTMODIFIED>
     
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
The xrange call was replaced with a call to six.moves.xrange. The fix
has been tested using Obsids 4200 and 1655 (although 4200 on its own
is sufficient) on both the Python 2.7 and 3.5 builds.