### PR TITLE
ecf_calc python 3 compatibility updates and indentation fixes

### DIFF
--- a/ciao-4.9/contrib/bin/ecf_calc
+++ b/ciao-4.9/contrib/bin/ecf_calc
@@ -20,7 +20,7 @@ Usage:
 
 __version__ = "CIAO 4.9"
 toolname = "ecf_calc"
-__revision__ = "3 April 2017"
+__revision__ = "03 April 2017"
 
 import numpy, tempfile, sys, os, paramio, cxcdm
 import pycrates as pcr
@@ -66,12 +66,12 @@ class HistoryCrate():
         Use CXCDM to get history records
         """
         self.history = []
-        tab = cxcdm.dmBlockOpen(filename)
+        tab = cxcdm.dmBlockOpen( filename )
         for ii in range(1, cxcdm.dmBlockGetNoKeys(tab)+1):
             cxcdm.dmBlockMoveToKey(tab,ii)
             while True:
                 hist = cxcdm.dmBlockReadComment(tab)
-                if None == hist:
+                if hist is None:
                     break
                 elif 2 != len(hist):
                     break
@@ -82,13 +82,13 @@ class HistoryCrate():
         cxcdm.dmBlockClose(tab)
             
 
-    def put_history(self, infile ):
+    def put_history(self, infile):
         """
         """
         tab = cxcdm.dmBlockOpen(infile, update=True)
-        cxcdm.dmBlockMoveToKey( tab, cxcdm.dmBlockGetNoKeys(tab))
+        cxcdm.dmBlockMoveToKey(tab, cxcdm.dmBlockGetNoKeys(tab))
         for t,v in self.history:
-            cxcdm.dmBlockWriteComment( tab, t, v )
+            cxcdm.dmBlockWriteComment(tab, t, v)
             
         cxcdm.dmBlockClose(tab)
 
@@ -96,17 +96,17 @@ class HistoryCrate():
 class HistoryIMAGECrate(pcr.IMAGECrate, HistoryCrate):
     def __init__(self, filename, mode="r"):        
         pcr.IMAGECrate.__init__(self,filename, mode=mode)
-        self.get_history( filename)
+        self.get_history(filename)
 
-    def write( self, outfile, *args, **kwargs ):
+    def write(self, outfile, *args, **kwargs):
         """
         Overide crates write to include history
         """
-        pcr.IMAGECrate.write( self, outfile, *args, **kwargs )
-        self.put_history( outfile )
+        pcr.IMAGECrate.write(self, outfile, *args, **kwargs)
+        self.put_history(outfile)
 
 
-class HistoryTABLECrate( pcr.TABLECrate, HistoryCrate):
+class HistoryTABLECrate(pcr.TABLECrate, HistoryCrate):
     def __init__(self, filename, mode="r"):        
         pcr.TABLECrate.__init__(self,filename, mode=mode)
         self.get_history( filename)
@@ -116,7 +116,7 @@ class HistoryTABLECrate( pcr.TABLECrate, HistoryCrate):
         Overide crates write to include history
         """
         pcr.TABLECrate.write(self, outfile, *args, **kwargs)
-        self.put_history(outfile)
+        self.put_history( outfile )
 
 
 ################################################
@@ -396,27 +396,27 @@ def plot_ecf(rad_file):
 
 @handle_ciao_errors(toolname, __revision__)   # decorate top-level routine    
 def doit():
-    params = get_par(sys.argv)
+     params = get_par(sys.argv)
 
-    infile = params["infile"]
-    outfile = params["outfile"]
-    radius = params["radius"]
-    x = params["xpos"]
-    y = params["ypos"]
-    bin = params["binsize"]
-    fraction = params["fraction"]
-    plot = params["plot"]
-    clobber = params["clobber"]
-    
-    filter = reg(radius,x,y,bin,infile)
-    get_ecf(infile,filter,outfile,x,y,radius,bin,fraction,clobber)
+     infile = params["infile"]
+     outfile = params["outfile"]
+     radius = params["radius"]
+     x = params["xpos"]
+     y = params["ypos"]
+     bin = params["binsize"]
+     fraction = params["fraction"]
+     plot = params["plot"]
+     clobber = params["clobber"]
 
-    add_tool_history(outfile,toolname,params)
+     filter = reg(radius,x,y,bin,infile)
+     get_ecf(infile,filter,outfile,x,y,radius,bin,fraction,clobber)
 
-    if plot:
-        plot_ecf(outfile)
-        pause()
+     add_tool_history(outfile,toolname,params)
+
+     if plot:
+         plot_ecf(outfile)
+         pause()
      
 
 if __name__ == "__main__":
-     doit()
+    doit()

--- a/ciao-4.9/contrib/bin/ecf_calc
+++ b/ciao-4.9/contrib/bin/ecf_calc
@@ -18,9 +18,9 @@ Usage:
 
 """
 
-__version__ = "CIAO 4.8"
+__version__ = "CIAO 4.9"
 toolname = "ecf_calc"
-__revision__ = "09 November 2015"
+__revision__ = "3 April 2017"
 
 import numpy, tempfile, sys, os, paramio, cxcdm
 import pycrates as pcr
@@ -66,12 +66,12 @@ class HistoryCrate():
         Use CXCDM to get history records
         """
         self.history = []
-        tab = cxcdm.dmBlockOpen( filename )
-        for ii in xrange( 1, cxcdm.dmBlockGetNoKeys(tab)+1 ):
+        tab = cxcdm.dmBlockOpen(filename)
+        for ii in range(1, cxcdm.dmBlockGetNoKeys(tab)+1):
             cxcdm.dmBlockMoveToKey(tab,ii)
             while True:
                 hist = cxcdm.dmBlockReadComment(tab)
-                if hist is None:
+                if None == hist:
                     break
                 elif 2 != len(hist):
                     break
@@ -85,7 +85,7 @@ class HistoryCrate():
     def put_history(self, infile ):
         """
         """
-        tab = cxcdm.dmBlockOpen( infile, update=True)
+        tab = cxcdm.dmBlockOpen(infile, update=True)
         cxcdm.dmBlockMoveToKey( tab, cxcdm.dmBlockGetNoKeys(tab))
         for t,v in self.history:
             cxcdm.dmBlockWriteComment( tab, t, v )
@@ -93,8 +93,8 @@ class HistoryCrate():
         cxcdm.dmBlockClose(tab)
 
 
-class HistoryIMAGECrate( pcr.IMAGECrate, HistoryCrate):
-    def __init__( self, filename, mode="r" ):        
+class HistoryIMAGECrate(pcr.IMAGECrate, HistoryCrate):
+    def __init__(self, filename, mode="r"):        
         pcr.IMAGECrate.__init__(self,filename, mode=mode)
         self.get_history( filename)
 
@@ -107,16 +107,16 @@ class HistoryIMAGECrate( pcr.IMAGECrate, HistoryCrate):
 
 
 class HistoryTABLECrate( pcr.TABLECrate, HistoryCrate):
-    def __init__( self, filename, mode="r" ):        
+    def __init__(self, filename, mode="r"):        
         pcr.TABLECrate.__init__(self,filename, mode=mode)
         self.get_history( filename)
 
-    def write( self, outfile, *args, **kwargs ):
+    def write(self, outfile, *args, **kwargs):
         """
         Overide crates write to include history
         """
-        pcr.TABLECrate.write( self, outfile, *args, **kwargs )
-        self.put_history( outfile )
+        pcr.TABLECrate.write(self, outfile, *args, **kwargs)
+        self.put_history(outfile)
 
 
 ################################################
@@ -144,11 +144,11 @@ def get_par(argv):
 
     pars["infile"] = paramio.pgetstr(pfile,"infile")
     if pars["infile"] == "":
-         raise ValueError("The infile parameter is empty.")
+        raise ValueError("The infile parameter is empty.")
 
     pars["outfile"] = paramio.pgetstr(pfile,"outfile")
     if pars["outfile"] == "":
-         raise ValueError("The outfile parameter is empty.")
+        raise ValueError("The outfile parameter is empty.")
 
     pars["radius"] = paramio.pgetd(pfile,"radius")
 
@@ -167,12 +167,12 @@ def get_par(argv):
     pars["clobber"] = paramio.pgetb(pfile, "clobber") ==1
 
     if pars["clobber"] == 0:
-         pars["clobber"] == False
+        pars["clobber"] == False
     else:
-         pars["clobber"] == True
+        pars["clobber"] == True
 
     if pars["clobber"] == False and os.path.isfile(pars["outfile"]) == True:
-         raise IOError("clobber=no and outfile already exists.")
+        raise IOError("clobber=no and outfile already exists.")
     
     paramio.paramclose(pfile)
     return pars
@@ -396,25 +396,25 @@ def plot_ecf(rad_file):
 
 @handle_ciao_errors(toolname, __revision__)   # decorate top-level routine    
 def doit():
-     params = get_par(sys.argv)
+    params = get_par(sys.argv)
 
-     infile = params["infile"]
-     outfile = params["outfile"]
-     radius = params["radius"]
-     x = params["xpos"]
-     y = params["ypos"]
-     bin = params["binsize"]
-     fraction = params["fraction"]
-     plot = params["plot"]
-     clobber = params["clobber"]
+    infile = params["infile"]
+    outfile = params["outfile"]
+    radius = params["radius"]
+    x = params["xpos"]
+    y = params["ypos"]
+    bin = params["binsize"]
+    fraction = params["fraction"]
+    plot = params["plot"]
+    clobber = params["clobber"]
+    
+    filter = reg(radius,x,y,bin,infile)
+    get_ecf(infile,filter,outfile,x,y,radius,bin,fraction,clobber)
 
-     filter = reg(radius,x,y,bin,infile)
-     get_ecf(infile,filter,outfile,x,y,radius,bin,fraction,clobber)
+    add_tool_history(outfile,toolname,params)
 
-     add_tool_history(outfile,toolname,params)
-
-     if plot == True:
-     	plot_ecf(outfile)
+    if plot:
+        plot_ecf(outfile)
         pause()
      
 


### PR DESCRIPTION
ecf_calc has been updated to work with Python 3.  xrange has been replaced with range, since it works for both Python 2 and 3 versions (using a list vs object in the particular instance doesn't change the results) and erroneous whitespaces/indentations were fixed.