### PR TITLE
updated to use ftp://cda.cfa.harvard.edu as the default FTP 

### DIFF
--- a/ciao-4.9/contrib/Changes.CIAO_scripts
+++ b/ciao-4.9/contrib/Changes.CIAO_scripts
@@ -1,3 +1,16 @@
+
+## 4.9.3 - May 2017 ##
+
+  Updates scripts
+  
+    download_chandra_obsid & download_obsid_caldb & find_chandra_obsid
+    
+      Changes the default FTP server used by these scripts from
+      ftp://cdaftp.cfa.harvard.edu to ftp://cda.cfa.harvard.edu.
+      The FTP server on cdaftp.cfa.harvard.edu will be 
+      shutdown on or after 2017-06-13.
+
+
 ## 4.9.2 - April 2017 ##
 
   Updated scripts

--- a/ciao-4.9/contrib/bin/download_chandra_obsid
+++ b/ciao-4.9/contrib/bin/download_chandra_obsid
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016
+#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -55,17 +55,17 @@ argument or the CDA_MIRROR_SITE environment variable (the command-line
 argument takes precedence if both are set). The mirror name should
 point to the location of the byobsid directory - e.g.  for the Chandra
 Data Archive itself you would use
-ftp://cdaftp.cfa.harvard.edu/pub/. The leading ftp:// is required.
+ftp://cda.cfa.harvard.edu/pub/. The leading ftp:// is required.
 
 If you need to use a specific username and password then include it in
 the mirror setting - e.g.
-ftp://anonymous:anonymous@anonymous.com@cdaftp.cfa.harvard.edu/pub/. See
+ftp://anonymous:anonymous@anonymous.com@cda.cfa.harvard.edu/pub/. See
 http://tools.ietf.org/html/rfc3986 for more information.
 
 """
 
 toolname = "download_chandra_obsid"
-version = "12 September 2016"
+version = "15 May 2017"
 
 import sys
 import os
@@ -122,10 +122,10 @@ A mirror site of the Chandra Data Archive can be used by setting the
 variable; the command-line option takes precedence if both are
 set. The mirror name should point to the location of the byobsid
 directory and start with ftp:// - e.g. using the Chandra Data is
-equivalent to using a setting of ftp://cdaftp.cfa.harvard.edu/pub/. A
+equivalent to using a setting of ftp://cda.cfa.harvard.edu/pub/. A
 username and password can be included in this setting, following
 http://tools.ietf.org/html/rfc3986, e.g.
-ftp://anonymous:foo@bar.org@cdaftp.cfa.harvard.edu/pub/.
+ftp://anonymous:foo@bar.org@cda.cfa.harvard.edu/pub/.
 """
 
 

--- a/ciao-4.9/contrib/bin/download_obsid_caldb
+++ b/ciao-4.9/contrib/bin/download_obsid_caldb
@@ -21,12 +21,12 @@
 from __future__ import print_function
 
 toolname = "download_obsid_caldb"
-__revision__ = "28 March 2017"
+__revision__ = "15 May 2017"
 
 import os
 import sys
 
-CDA_SERVER = "ftp://cdaftp.cfa.harvard.edu/pub/arcftp/ChandraCalDB"
+CDA_SERVER = "ftp://cda.cfa.harvard.edu/pub/arcftp/ChandraCalDB"
 CDA_ENV = "CALDB_MIRROR_SITE" 
 
 

--- a/ciao-4.9/contrib/bin/find_chandra_obsid
+++ b/ciao-4.9/contrib/bin/find_chandra_obsid
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016
+#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -68,15 +68,15 @@ CDA_MIRROR_SITE environment variable (the command-line argument takes
 preference). The mirror argument should point to the location of the
 byobsid directory and start with ftp:// - e.g. using the Chandra Data
 is equivalent to using a setting of
-ftp://cdaftp.cfa.harvard.edu/pub/. A username and password can be
+ftp://cda.cfa.harvard.edu/pub/. A username and password can be
 included in this setting, following
 http://tools.ietf.org/html/rfc3986, e.g.
-ftp://anonymous:foo@bar.org@cdaftp.cfa.harvard.edu/pub/.
+ftp://anonymous:foo@bar.org@cda.cfa.harvard.edu/pub/.
 
 """
 
 toolname = "find_chandra_obsid"
-version = "18 October 2016"
+version = "15 May 2017"
 
 import sys
 import os

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/cda/data.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/cda/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016
+#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016, 2017
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -614,7 +614,7 @@ def init_ftp(mirror=None, username=None, userpass=None):
 
     If mirror is None then it is taken to be
 
-      ftp://cdaftp.cfa.harvard.edu/pub/
+      ftp://cda.cfa.harvard.edu/pub/
 
     Login details use the username and userpass values if set,
     otherwise values extracted from the mirror (if set), otherwise
@@ -622,7 +622,7 @@ def init_ftp(mirror=None, username=None, userpass=None):
     """
 
     if mirror is None:
-        base = 'ftp://cdaftp.cfa.harvard.edu/pub'
+        base = 'ftp://cda.cfa.harvard.edu/pub'
     else:
         base = mirror
 
@@ -665,7 +665,7 @@ def download_chandra_obsids(obsids,
     use that location instead. The value should refer to the directory
     that contains the "byobsid" directory and start with ftp://.  The
     default value is equivalent to setting mirror to
-    ftp://cdaftp.cfa.harvard.edu/pub/
+    ftp://cda.cfa.harvard.edu/pub/
 
     This routine does *not* check the CDA_MIRROR_SITE environment
     variable if mirror=None (this is assumed to have been resolved by
@@ -680,7 +680,7 @@ def download_chandra_obsids(obsids,
     The username and password for the FTP site uses the username and
     userpass arguments, if given, otherwise the values extracted from
     the mirror argument (if set and included - e.g.
-    ftp://anonymous@anonymous:cdaftp.cfa.harvard.edu/pub/), otherwise
+    ftp://anonymous@anonymous:cda.cfa.harvard.edu/pub/), otherwise
     the DEFAULT_USERNAME and DEFAULT_PASSWORD settings are used.
 
     The return value is an array of booleans that indicate whether the

--- a/ciao-4.9/contrib/share/doc/xml/download_chandra_obsid.xml
+++ b/ciao-4.9/contrib/share/doc/xml/download_chandra_obsid.xml
@@ -198,7 +198,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 
       <QEXAMPLE>
 	<SYNTAX>
-	  <LINE>&pr; download_chandra_obsid -m ftp://cdaftp.cfa.harvard.edu/pub 1842</LINE>
+	  <LINE>&pr; download_chandra_obsid -m ftp://cda.cfa.harvard.edu/pub 1842</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -214,7 +214,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 	  </PARA>
 	  <PARA>
 	    <SYNTAX>
-	      <LINE>&pr; setenv &cdaenv; ftp://cdaftp.cfa.harvard.edu/pub</LINE>
+	      <LINE>&pr; setenv &cdaenv; ftp://cda.cfa.harvard.edu/pub</LINE>
 	      <LINE>&pr; download_chandra_obsid 1842</LINE>
 	    </SYNTAX>
 	  </PARA>
@@ -243,7 +243,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
         (the leading ftp:// is required) and the path up to, but not including,
         the byobsid/ directory. So, for the Chandra Data Archive itself
         you would use
-        <EQUATION>ftp://cdaftp.cfa.harvard.edu/pub</EQUATION>
+        <EQUATION>ftp://cda.cfa.harvard.edu/pub</EQUATION>
         (although obviously in this case you do not need to use the mirror
         option).
         Please see the documentation for the mirror site to find out
@@ -254,9 +254,16 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
         setting, following 
         <HREF link="http://tools.ietf.org/html/rfc3986">RFC3986</HREF>,
         for instance
-        <EQUATION>ftp://anonymous:foo@bar.com@cdaftp.cfa.harvard.edu/pub</EQUATION>
+        <EQUATION>ftp://anonymous:foo@bar.com@cda.cfa.harvard.edu/pub</EQUATION>
       </PARA>
     </ADESC>
+
+    <ADESC title="Changes in the scripts 4.9.3 (May 2017) release">
+      <PARA>
+        Updated to use ftp://cda.cfa.harvard.edu as the default FTP server.
+      </PARA>
+    </ADESC>
+
 
     <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
       <PARA>

--- a/ciao-4.9/contrib/share/doc/xml/download_obsid_caldb.xml
+++ b/ciao-4.9/contrib/share/doc/xml/download_obsid_caldb.xml
@@ -358,6 +358,12 @@ they are skipped and only the background files are actually retrieved.
     
     </PARAMLIST>
     
+
+    <ADESC title="Changes in the scripts 4.9.3 (May 2017) release">
+      <PARA>
+        Updated to use ftp://cda.cfa.harvard.edu as the default FTP server.
+      </PARA>
+    </ADESC>
     
     <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
       <PARA>

--- a/ciao-4.9/contrib/share/doc/xml/find_chandra_obsid.xml
+++ b/ciao-4.9/contrib/share/doc/xml/find_chandra_obsid.xml
@@ -374,7 +374,7 @@ Download [y, n, q, a, h]: y
 
       <QEXAMPLE>
 	<SYNTAX>
-	  <LINE>&pr; &tool; 350.86 58.81 mirror=ftp://cdaftp.cfa.harvard.edu/pub</LINE>
+	  <LINE>&pr; &tool; 350.86 58.81 mirror=ftp://cda.cfa.harvard.edu/pub</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -393,7 +393,7 @@ Download [y, n, q, a, h]: y
 	  </PARA>
 	  <PARA>
 	    <SYNTAX>
-	      <LINE>&pr; setenv &cdaenv; ftp://cdaftp.cfa.harvard.edu/pub</LINE>
+	      <LINE>&pr; setenv &cdaenv; ftp://cda.cfa.harvard.edu/pub</LINE>
 	      <LINE>&pr; &tool; 350.86 58.81</LINE>
 	    </SYNTAX>
 	  </PARA>
@@ -734,7 +734,7 @@ Download [y, n, q, a, h]: y
             (the leading ftp:// is required) and the path up to, but not including,
             the byobsid/ directory. So, for the Chandra Data Archive itself
             you would use
-            <EQUATION>ftp://cdaftp.cfa.harvard.edu/pub</EQUATION>
+            <EQUATION>ftp://cda.cfa.harvard.edu/pub</EQUATION>
             (although obviously in this case you do not need to use the mirror
             option).
             Please see the documentation for the mirror site to find out
@@ -745,7 +745,7 @@ Download [y, n, q, a, h]: y
             setting, following 
             <HREF link="http://tools.ietf.org/html/rfc3986">RFC3986</HREF>,
             for instance
-            <EQUATION>ftp://anonymous:foo@bar.com@cdaftp.cfa.harvard.edu/pub</EQUATION>
+            <EQUATION>ftp://anonymous:foo@bar.com@cda.cfa.harvard.edu/pub</EQUATION>
           </PARA>
 	</DESC>
       </PARAM>
@@ -792,6 +792,13 @@ Download [y, n, q, a, h]: y
 	Use pset 
         if you wish to permanently set options, for instance to set 
         instrument to acis to exclude HRC observations.
+      </PARA>
+    </ADESC>
+
+
+    <ADESC title="Changes in the scripts 4.9.3 (May 2017) release">
+      <PARA>
+        Updated to use ftp://cda.cfa.harvard.edu as the default FTP server.
       </PARA>
     </ADESC>
 


### PR DESCRIPTION
with DS10.6, ftp://cdaftp.cfa.harvard.edu will be decommissioned.  This changes the default FTP site to use 'cda' instead of 'cdaftp' in 
- download_chandra_obsid
- find_chandra_obsid
- download_obsid_caldb

