### PR TITLE
Python 3.5 fixes for deflare and lightcurve

### DIFF
--- a/ciao-4.9/contrib/bin/deflare
+++ b/ciao-4.9/contrib/bin/deflare
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2014, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -36,7 +36,7 @@ ciao% deflare method=clean infile=lc.fits outfile=gti.fits
 """
 
 toolname = "deflare"
-__revision__ = "12 September 2016"
+__revision__ = "22 May 2017"
 
 import os
 import sys
@@ -44,6 +44,8 @@ import sys
 import paramio
 
 import pychips
+
+import six
 
 # This is only needed for development.
 try:
@@ -135,7 +137,7 @@ def get_par(args):
 
 
 def pause():
-    raw_input("Press ENTER to close the ChIPS window and exit:")
+    six.moves.input("Press ENTER to close the ChIPS window and exit:")
 
 
 def wrapup(params):

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/lightcurves.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/lightcurves.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2008, 2009, 2010, 2011, 2014, 2015, 2016
+#  Copyright (C) 2008, 2009, 2010, 2011, 2014, 2015, 2016, 2017
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -36,7 +36,7 @@ Threads:
 
 """
 
-import os
+# import os
 import tempfile
 
 import six
@@ -52,7 +52,7 @@ from ciao_contrib.runtool import dmcopy, dmgti
 # __all__ = ("lc_sigma_clip", "lc_sigma_uclip", "lc_clean")
 __all__ = ("lc_sigma_clip", "lc_clean")
 
-__revision = "October 2016"
+__revision = "May 2017"
 
 
 def _get_default_depth():
@@ -108,14 +108,17 @@ def _write_gti_text(outfile, tstart, tend):
     # (since crates does not, as of CIAO 4.4, propagate
     # subspace information), so do it manually. This should
     # be fixed in more-recent CIAO versions, so need to
-    # review to see if can remove this.
+    # review to see if can remove this step.
     #
-    (ofd, tname) = tempfile.mkstemp(text=True)
-    os.write(ofd, "#TEXT/DTF\n")
+    # (ofd, tname) = tempfile.mkstemp(text=True)
+    tfile = tempfile.NamedTemporaryFile(suffix=".gti", mode='w+')
+    tname = tfile.name
+
+    tfile.write("#TEXT/DTF\n")
 
     def card(name, value, comment=None, unit=None):
         "Add the record card to the file"
-        os.write(ofd, "{:<8s}= ".format(name))
+        tfile.write("{:<8s}= ".format(name))
 
         # following checks not ideal but sufficient for now
         if isinstance(value, six.string_types):
@@ -127,7 +130,7 @@ def _write_gti_text(outfile, tstart, tend):
                 svalue = "T"
             else:
                 svalue = "F"
-        elif isinstance(value, (int, long)):
+        elif isinstance(value, six.integer_types):
             sfmt = "{:20d}"
             svalue = value
         else:
@@ -135,17 +138,17 @@ def _write_gti_text(outfile, tstart, tend):
             sfmt = "{:20.13e}"
             svalue = value
 
-        os.write(ofd, sfmt.format(svalue))
+        tfile.write(sfmt.format(svalue))
         if comment is None and unit is None:
-            os.write(ofd, "\n")
+            tfile.write("\n")
             return
 
-        os.write(ofd, " /")
+        tfile.write(" /")
         if unit is not None:
-            os.write(ofd, " [{}]".format(unit))
+            tfile.write(" [{}]".format(unit))
         if comment is not None:
-            os.write(ofd, " " + comment)
-        os.write(ofd, "\n")
+            tfile.write(" " + comment)
+        tfile.write("\n")
 
     card("XTENSION", "TABLE")
     card("HDUNAME", "FILTER")
@@ -165,7 +168,7 @@ def _write_gti_text(outfile, tstart, tend):
     card("DSFORM1", "D", comment="DM Keyword: Descriptor datatype.")
     card("DSUNIT1", "s", comment="DM Keyword: Descriptor unit.")
     card("DSREF1", ":GTI")
-    os.write(ofd, "END\n\n\n")
+    tfile.write("END\n\n\n")
 
     card("XTENSION", "TABLE")
     card("HDUNAME", "GTI")
@@ -189,20 +192,18 @@ def _write_gti_text(outfile, tstart, tend):
     card("DSFORM1", "D", comment="DM Keyword: Descriptor datatype.")
     card("DSUNIT1", "s", comment="DM Keyword: Descriptor unit.")
     card("DSREF1", ":GTI")
-    os.write(ofd, "END\n\n")
+    tfile.write("END\n\n")
 
     for (tlo, thi) in zip(tstart, tend):
-        os.write(ofd, "{:19.13e} {:19.13e}\n".format(tlo, thi))
+        tfile.write("{:19.13e} {:19.13e}\n".format(tlo, thi))
 
-    os.fsync(ofd)
-    os.close(ofd)
+    tfile.flush()
 
-    # Convert to FITS format and clean up, note that mkstemp makes no
-    # guarantees that the filename is "clean", ie needs no protection.
+    # Convert to FITS format and clean up.
     #
     dmcopy.punlearn()
     dmcopy(tname, outfile, clobber=True)
-    os.unlink(tname)
+    # os.unlink(tname)
 
 
 # We stick pretty-much everything in a class which is a


### PR DESCRIPTION
Use of six.moves.input rather than raw_input and change to
NamedTemporaryFile rather than mkstemp from tempfile, along
with explicit mode setting, to avoid byte/str confusion.