### PR TITLE
Fix issue #48

### DIFF
--- a/ciao-4.9/contrib/Changes.CIAO_scripts
+++ b/ciao-4.9/contrib/Changes.CIAO_scripts
@@ -1,4 +1,15 @@
 
+## 4.9.4 - TBD ##
+
+  Updated scripts
+
+    flux_obs, merge_obs, reproject_obs
+
+      Fixed an error message when no input event files could not be
+      processed. This only changes the error message, and not how
+      the tools run.
+
+    
 ## 4.9.3 - May 2017 ##
 
   Updated scripts

--- a/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/_tools/merging.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/_tools/merging.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016
+#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017
 #    Smithsonian Astrophysical Observatory
 #
 #
@@ -1114,6 +1114,11 @@ def validate_obsinfo(infiles, colcheck=True):
 
     else:
         v3("No multi-obi datasets found")
+
+    # the obsinfos array can be shortened by the above, so re-compute.
+    ninfiles = len(obsinfos)
+    if ninfiles == 0:
+        raise IOError("No valid event files were found.")
 
     nskip = norig - ninfiles
     if nskip == 1:


### PR DESCRIPTION
The problem case now fails with:

```
Running flux_obs
Version: 12 September 2016

Found repro/acisf16294e1_repro_evt2.fits
Found repro/acisf16294e2_repro_evt2.fits
Verifying 2 observations.
Found one multi-OBI observation:
Skipping repro/acisf16294e1_repro_evt2.fits as it has no OBI_NUM keyword
Skipping repro/acisf16294e2_repro_evt2.fits as it has no OBI_NUM keyword
# flux_obs (12 September 2016): ERROR No valid event files were found.
```

Note that the version number of the script hasn't updated, since this change is at a lower level.