### PR TITLE
Fix #50 

### DIFF
--- a/ciao-4.9/contrib/bin/mktgresp
+++ b/ciao-4.9/contrib/bin/mktgresp
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # 
-# Copyright (C) 2013,2016 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013,2016,2017 Smithsonian Astrophysical Observatory
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 from __future__ import print_function
 
 toolname = "mktgresp"
-__revision__ = "06 March 2017"
+__revision__ = "07 July 2017"
 
 
 import os
@@ -479,7 +479,8 @@ def main():
 
     finally:
         # Always clean up asphsit files
-        map( os.remove, asphist_list )
+        for f in asphist_list:
+            os.remove(f)
     
 
 if __name__ == "__main__":

--- a/ciao-4.9/contrib/share/doc/xml/mktgresp.xml
+++ b/ciao-4.9/contrib/share/doc/xml/mktgresp.xml
@@ -403,6 +403,15 @@ parameter is angstroms.
     </PARAM>
     </PARAMLIST>
 
+
+  <ADESC title="Changes in the scripts 4.9.4 (July 2017) release">
+    <PARA>
+        Fix problem cleaning up temporary aspect histogram files 
+        under Python 3.
+    </PARA>
+  </ADESC>
+
+
   <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
     <PARA>
       The script can now work on TYPE:I (ie single spectra) PHA files.
@@ -446,7 +455,7 @@ parameter is angstroms.
         for this tool</HREF>
         on the CIAO website for an up-to-date listing of known bugs.
       </PARA></BUGS>
-   <LASTMODIFIED>March 2017</LASTMODIFIED>
+   <LASTMODIFIED>July 2017</LASTMODIFIED>
 
 
 </ENTRY>


### PR DESCRIPTION
This is the problem with mktgresp not cleaning up temporary aspect histogram files under Python3.

Regression tests pass; in particular test 08.MAIN which runs mktgresp twice.  Before I would get warnings about unable to clobber existing files during the 2nd run; this fixes that.

