### PR TITLE
Fix #47

### DIFF
--- a/ciao-4.9/contrib/Changes.CIAO_scripts
+++ b/ciao-4.9/contrib/Changes.CIAO_scripts
@@ -8,12 +8,20 @@
       Fixed an error message when given a FOV file with a region that
       can not be handled by skyfov (e.g. when processing the output
       of a MARX simulation when the roll value is constant).
-    
+
     flux_obs, merge_obs, reproject_obs
 
       Fixed an error message when no input event files could not be
       processed. This only changes the error message, and not how
       the tools run.
+
+    chandra_repro
+
+      Fixed internal problem when the observation being processed
+      does not have a standard aspect solution (restricted to Earth 
+      and Moon observations).  chandra_repro still cannot be used 
+      with these observations but now the error message is 
+      more informative.
 
   Updated Python modules
 
@@ -25,6 +33,7 @@
        multiple copies trying to edit the same parameter file; it is
        strongly suggested that the new_pfiles_environment context
        manager is used when running these tools.
+
 
 ## 4.9.3 - May 2017 ##
 

--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -860,7 +860,7 @@ def get_inputs(params):
                 newbias = gunzip(params["secondarydir"] + ff)
 
                 path=os.path.join(params["outdir"], os.path.basename(newbias))
-                link_or_copy(newasol, path)
+                link_or_copy(newbias, path)
   
                 uff=ff.split(".gz")[0]
                 params["cleanup_files"].append(os.path.join(params["outdir"], uff))

--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -544,6 +544,17 @@ def event1_inputs(params):
             params["date-obs"] = keys["DATE-OBS"].value
             params["grating"]  = keys["GRATING"].value
 
+            # Only standard datasets taken in KALMAN lock are supported.
+            # Other modes such as OBC use the on-board-computer 
+            # aspect solution and don't have *_asol1.fits files. They
+            # only have the *_osol1.fits files.  We can't handle that
+            # right now.
+            
+            if 'KALMAN' != keys["ASPTYPE"].value:
+                msg = "ASPTYPE='{}' mode data is not currently supported."
+                raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
+                 
+
             if params["instrume"] == 'ACIS':  
                 params["readmode"] = keys["READMODE"].value
             if params["instrume"] == 'HRC':  

--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # 
-# Copyright (C) 2010-2016  Smithsonian Astrophysical Observatory
+# Copyright (C) 2010-2017  Smithsonian Astrophysical Observatory
 # 
 # 
 # 
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "06 March 2017"
+version = "07 July 2017"
 
 # import standard python modules as required
 #

--- a/ciao-4.9/contrib/share/doc/xml/chandra_repro.xml
+++ b/ciao-4.9/contrib/share/doc/xml/chandra_repro.xml
@@ -751,6 +751,16 @@ acisf084244478N003_2_bias0.fits.gz
     </PARAMLIST>
 
 
+<ADESC title="Change in scripts 4.9.4 (July 2017) release">
+  <PARA>
+    Internal fix for uninitialized variable ("newasol") when processing
+    an observation that does not have any aspect solution files.  This 
+    is limited to observations of the Moon and the Earth.  These observations
+    still cannot be processed at this time but the error message is more informative.
+  </PARA>
+</ADESC>
+
+
 
 <ADESC title="Changes in scripts 4.9.2 (April 2017) release">
   <PARA>
@@ -1021,6 +1031,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>March 2017</LASTMODIFIED>
+    <LASTMODIFIED>July 2017</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
The issues being fixed here is that the wrong files are being copied to the output directory and a check is added to error out when dealing with _on-board-computer_ (OBC) mode datasets.  

Specifically, the aspect solution file is being copied to output directory with the name of the bias files.  However, the `bias0.lis` file, used by `acis_build_badpix` , lists the files in the `secondary/` directory.  Therefore, even though the wrong files are copied to the wrong file names, those files are not used by `chandra_repro` (and they are not used by any other tools).

In addition, a new check is added for the `ASPTYPE` keyword value.  Normally, this value is `KALMAN` which means that the ground computed aspect solution from SDP is used.  However, for observations where there are no guide stars, there is another processing mode which uses the _on-board-computer_ aspect solution :  the `osol1.fits` files.   Since we don't currently support that mode, the script will now error out.






