### PR TITLE
Fix #53

### DIFF
--- a/ciao-4.9/contrib/Changes.CIAO_scripts
+++ b/ciao-4.9/contrib/Changes.CIAO_scripts
@@ -15,6 +15,12 @@
       processed. This only changes the error message, and not how
       the tools run.
 
+    srcflux
+
+      Added an internal optimization for the case where a large number of 
+      positions are used, especially when using psfmethod=psffile. 
+      There is no change to the output.
+
     chandra_repro
 
       Fixed internal problem when the observation being processed

--- a/ciao-4.9/contrib/bin/srcflux
+++ b/ciao-4.9/contrib/bin/srcflux
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 #
-# Copyright (C) 2013-2016 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013-2017 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/ciao-4.9/contrib/bin/srcflux
+++ b/ciao-4.9/contrib/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "06 Mar 2017"
+__revision__ = "11 July 2017"
 
 import os
 

--- a/ciao-4.9/contrib/bin/srcflux
+++ b/ciao-4.9/contrib/bin/srcflux
@@ -636,7 +636,7 @@ def get_psf_from_file( myparams, at_energy, src, bkg, simulate=None ):
 
         all_files.append( tfile )
 
-    just_counts = [ x+"[cols COUNTS,BG_COUNTS]" for x in all_files ]
+    just_counts = [ x+"[cols COUNTS,BG_COUNTS][subspace -sky]" for x in all_files ]
 
     outfile = delme(myroot+".pf")
 
@@ -819,7 +819,7 @@ def get_psf_from_model( myparams, at_energy, src, bkg):
     taskrunner = TaskRunner()
     for ii in range(1, len(src_stk)+1 ):
         taskrunner.add_task( "arfcorr_{:04d}".format(ii), "", run_arfcorr_and_dme, myparams, at_energy, src_stk[ii-1], bkg_stk[ii-1],ii )
-        outfiles.append(myroot+"{:04d}_model.psffrac[cols PSFFRAC=counts,BG_PSFFRAC=bg_counts]".format(ii) )
+        outfiles.append(myroot+"{:04d}_model.psffrac[cols PSFFRAC=counts,BG_PSFFRAC=bg_counts][subspace -sky]".format(ii) )
 
     taskrunner.run_tasks(processes=myparams.nproc, label=False)
 
@@ -1248,7 +1248,7 @@ def add_photflux_to_outfile( myparams, at_energy, photfiles ):
     from ciao_contrib.runtool import dmmerge
     from ciao_contrib.runtool import dmpaste
 
-    zz = [ z+"[cols SRC_PHOTFLUX=counts,BG_PHOTFLUX=bg_counts,MEAN_SRC_EXP,MEAN_BG_EXP]" for z in photfiles ]
+    zz = [ z+"[cols SRC_PHOTFLUX=counts,BG_PHOTFLUX=bg_counts,MEAN_SRC_EXP,MEAN_BG_EXP][subspace -sky]" for z in photfiles ]
 
     dmmerge.infile=zz
     dmmerge.outfile=delme(myroot+"_photflux")
@@ -1282,13 +1282,13 @@ def add_effevt_to_outfile( myparams, at_energy, srcfiles, bkgfiles ):
     sdat = delme(myroot+"_src.dat")
     bdat = delme(myroot+"_bkg.dat")
 
-    dmmerge.infile=srcfiles
+    dmmerge.infile=[s+"[subspace -sky]" for s in srcfiles]
     dmmerge.outfile=sdat
     dmmerge.clobber = myparams.clobber
     dmmerge.verbose = myparams.verbose
     verb2(dmmerge())
 
-    dmmerge.infile=bkgfiles
+    dmmerge.infile=[b+"[subspace -sky]" for b in bkgfiles]
     dmmerge.outfile=bdat
     dmmerge.clobber = myparams.clobber
     dmmerge.verbose = myparams.verbose

--- a/ciao-4.9/contrib/share/doc/xml/srcflux.xml
+++ b/ciao-4.9/contrib/share/doc/xml/srcflux.xml
@@ -1724,6 +1724,15 @@ bounds(region(my.reg))
 
     </ADESC>
 
+    <ADESC title="Changes in the script 4.9.4 (July 2017) release">
+      <PARA>
+      Added an optimization for input stacks with large number of positions; 
+      especially when supplying externally created PSF images which may
+      have exhausted system memory.  There is no change in the output.
+      
+      </PARA>    
+    </ADESC>
+
 
     <ADESC title="Changes in the script 4.9.2 (April 2017) release">
       <PARA>
@@ -1839,6 +1848,6 @@ bounds(region(my.reg))
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>March 2017</LASTMODIFIED>
+    <LASTMODIFIED>July 2017</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Dong-Woo ran into a problem when using a source list as input with >450 sources ; they are inputting their own PSF files and their own regions. 

I use `dmextract` to extract the PSF fractions from the files, individually for each source; the `dmextract` output has the region in the subspace.  Then to combine those I use `dmmerge`. The problem they were finding was that `dmmerge` was running the machine out of memory as it was trying to merge the subspaces.  It was also wasting a lot of time (hours) trying to do this [the input regions are mildly complicated].

Since we don't need the subspace, just the values, the easiest thing is to just remove the subspace from the `dmextract` output as it's being input to `dmmerge`.  There are a couple other places where I do something similar so those other instances of `dmmerge` are also updated.

This has no effect on the output; just the performance.

Regression tests pass.  Dong-Woo's dataset ran to completion in a reasonable 1.5hrs.






