### PR TITLE
WIP: chandra_repro support obc

### DIFF
--- a/ciao-4.9/contrib/Changes.CIAO_scripts
+++ b/ciao-4.9/contrib/Changes.CIAO_scripts
@@ -15,6 +15,16 @@
       processed. This only changes the error message, and not how
       the tools run.
 
+    chandra_repro
+      
+      Fixed internal problem when the observation being processed
+      does not have a standard aspect solution (restricted to Earth 
+      and Moon observations).  chandra_repro still cannot be used 
+      with these observations but now the error message is 
+      more informative.
+    
+
+
 ## 4.9.3 - May 2017 ##
 
   Updated scripts

--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -554,6 +554,8 @@ def event1_inputs(params):
                 #msg = "ASPTYPE='{}' mode data is not currently supported."
                 #raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
                 params["__obc_mode__"] = True
+                v0("\nThis observation did not use any guide-stars; the on-board-computer determined aspect solution will be used\n")
+
             else:
                 params["__obc_mode__"] = False
 
@@ -1776,8 +1778,21 @@ def get_asol_times( params ):
     
     outroot = os.path.join( params["outdir"], params["root"])
 
-    dmtcalc( params["flt1_file"], outroot+"_addcol_flt1.fits", "time=0", clobber=params["clobber"])    
-    dmcopy( dmtcalc.outfile+"[time={}:{}]".format(min_a,max_a), outroot+"_repro_flt1.fits", clobber=params["clobber"] )
+
+    if params["__obc_mode__"] is True:
+        new_limits = outroot+"_obc_lim1.fits"
+        new_gti = outroot+"_repro_flt1.fits"
+
+        filter_obc_gti_limit( params["mtl1_file"], new_limits, clobber=params["clobber"])
+        make_new_obc_gti( params["mtl1_file"], new_limits, new_gti, clobber=params["clobber"])
+        params["cleanup_files"].append(new_limits)
+
+    else:
+        dmtcalc( params["flt1_file"], outroot+"_addcol_flt1.fits", "time=0", clobber=params["clobber"])    
+        dmcopy( dmtcalc.outfile+"[time={}:{}]".format(min_a,max_a), outroot+"_repro_flt1.fits", clobber=params["clobber"] )
+
+
+
 
     # CC times cannot be fixed with the gti_align script since times are
     # affected by _TARG coordinates.
@@ -1790,9 +1805,125 @@ def get_asol_times( params ):
     params["cleanup_files"].append( outroot+"_addcol_flt1.fits" )
     params["cleanup_files"].append( outroot+"_repro_flt1.fits" )
 
+
+
     
     return outroot+"_repro_flt2.fits"
     
+
+
+
+def filter_obc_gti_limit( mtlfile, outlimfile, clobber=True ):
+    """Filters the LIMITS block of the mission time line file
+    to remove the limits associated with OBC (on-board-computer)
+    mode.
+    
+    The LIMITS extension is just a single string column in the mtl1.fits
+    file.  Each row is a separate limit.  The 'limit_status' column
+    in the MTL_S extension of the mtl1.fits file maps to the LIMITS block.
+    Each bit in the limit_status maps to a row.  Here we count
+    bits left-to-right starting at 1. [Ugh!]
+    
+    So if we have
+    
+    % dmlist "acisf02469_001N004_mtl1.fits[mtl_s][cols limit_status][#row=1]" data,clean
+    #  limit_status[3]
+                                                     01000000000000000010000
+
+    we see that bits #2 and bits #19 are set.  Looking at the LIMITS blocks we see
+
+    % dmlist "acisf02469_001N004_mtl1.fits[limits][#row=2,19]" data,clean
+    #  gti_limits
+    (fabs(Point_MoonLimbAng:1)>=6.0)
+    (ASPTYPE:1!="OBC") 
+
+    We want to remove these limits -- but we can't rely on the row numbers.
+    We need to check (regex) the contents of each line to look for the lines
+    to remove.    
+    """
+
+    from re import search
+    from pycrates import read_file
+
+    def is_point_limbang( limit ):
+        """Remove the Earth, Sun, Moon limb angle pointing limits.
+        We could try to be clever here and pick the right one, 
+        but its just as easy to remove them all"""
+        if search('point_.*limbang', limit) is None:
+            return False
+        return True
+
+
+    def is_asptype( limit ):
+        """Remove the check on ASPTYPE"""
+        if search( 'asptype.*=.*obc.*', limit) is None:
+            return False
+        return True
+
+
+    def obc_limits( limit ):
+        """Combine the two limit checks above"""
+        ul = limit.lower()
+        return (is_point_limbang(ul) or is_asptype(ul))
+
+
+    limits = read_file(mtlfile+"[limits]").get_column("gti_limits").values
+    mod_limits = [ l for l in limits if obc_limits(l) is False]
+
+    write_new_limits( mod_limits, outlimfile, clobber)
+
+    
+
+def write_new_limits( mod_limits, outlimfile, clobber=True ):
+    """Write the output limits file.  We don't need all the
+    header meta data, just the single column with the 
+    subset of the filter strings"""
+
+    from crates_contrib.utils import write_columns
+    write_columns( outlimfile, mod_limits, format="fits", clobber=clobber, colnames=["gti_limits"])
+
+
+def make_new_obc_gti( mtlfile, outlimfile, outgtifile, clobber=True):
+    """Compute the new GTI; write out new filter 
+    """
+    from ciao_contrib.runtool import make_tool
+    dmgti = make_tool("dmgti")
+    dmgti.infile=mtlfile
+    dmgti.outfile=outgtifile
+    dmgti.mtlfile=""
+    dmgti.userlimit=""  # The limits are input via the lkupfile parameter
+    dmgti.lkupfile=outlimfile
+    vv = dmgti( clobber=clobber)
+    if (vv): v3(vv)
+
+    summarize_results( outgtifile)
+
+
+    
+def summarize_results(outgtifile):
+    """Show a summary of the GTI information"""
+    from pycrates import read_file
+    gti=read_file(outgtifile)
+    ontime = gti.get_key_value("ONTIME")
+    dss = gti.get_subspace_data(1, "TIME")
+    num_gti = len( dss.range_max)
+    msg="Total recovered OBC ONTIME={:.2f}ks in {} time interval(s)"
+    v1(msg.format( ontime/1000.0, num_gti))
+    
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 def l2_acis_events(params):
@@ -2185,10 +2316,7 @@ def remake_fov1_file( pars ):
     skyfov.punlearn()
     skyfov.infile= pars["evt2_file"]
     skyfov.outfile = os.path.join(pars["outdir"], pars["root"] + '_repro_fov1.fits')
-    if pars["__obc_mode__"] is False:
-        skyfov.aspect = "@{}[@{}]".format(pars["asol1_file"], pars["evt2_file"])
-    else:
-        skyfov.aspect = "@"+pars["asol1_file"]
+    skyfov.aspect = "@{}[@{}]".format(pars["asol1_file"], pars["evt2_file"])
     skyfov.mskfile = pars["msk1_file"]
     skyfov.clobber = pars["clobber"]
     skyfov.verbose = pars["verbose"]

--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "06 March 2017"
+version = "11 July 2017"
 
 # import standard python modules as required
 #

--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -551,9 +551,11 @@ def event1_inputs(params):
             # right now.
             
             if 'KALMAN' != keys["ASPTYPE"].value:
-                msg = "ASPTYPE='{}' mode data is not currently supported."
-                raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
-                 
+                #msg = "ASPTYPE='{}' mode data is not currently supported."
+                #raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
+                params["__obc_mode__"] = True
+            else:
+                params["__obc_mode__"] = False
 
             if params["instrume"] == 'ACIS':  
                 params["readmode"] = keys["READMODE"].value
@@ -747,7 +749,11 @@ def get_inputs(params):
     #!### Now check for secondary data products to use ###
     try:
         secondary_products=os.listdir(params["secondarydir"])
-    except:
+        if params["__obc_mode__"] is True:
+            asp_sec = os.path.join( params["secondarydir"],"aspect")
+            asp_sec_dir = os.listdir( asp_sec )
+            secondary_products.extend( asp_sec_dir)
+    except Exception as e:
         error_out(params,"Could not read input directory '%s'" % params["secondarydir"], 'read error')
 
     v2("Using products found in secondary data directory: " + params["secondarydir"])
@@ -893,6 +899,47 @@ def get_inputs(params):
             #!### In both cases above we write current bias file to list ###
             biaslist.write(newbias + '\n')
             biaslist.close()
+
+        elif params["__obc_mode__"] is True and re.search(".*osol1.fits.*",ff) is not None:
+            #
+            # For OBC mode, we look for the osol files and use them for the asol
+            #
+            params["asol1_file"] = os.path.join(params["outdir"], params["root"] + '_asol1.lis')
+
+            if reset_asol_list:
+                datestamp_existing_file(params["asol1_file"])
+                reset_asol_list=0
+
+            sec_asp_dir = os.path.join( params["secondarydir"], "aspect")
+            if indir_is_outdir:
+                newasol = os.path.basename(gunzip(ff))
+            else:
+                newasol = gunzip(os.path.join( sec_asp_dir,ff))
+
+                path=os.path.join(params["outdir"], os.path.basename(newasol))
+                link_or_copy(newasol, path)
+                
+            #!### always make sorted asol list ###
+            if os.path.isfile(params["asol1_file"]):
+                #!### Just append to existing list ###
+                try:
+                    asollist = open(params["asol1_file"],'a')
+                except:
+                    error_out(params,"Could not open list file '%s'" % params["asol1_file"], 'read error')
+            else:
+                #!### Create list ###
+                try:
+                    asollist = open(params["asol1_file"], 'w')
+                except:
+                    error_out(params,"Could not create list file '%s'" % params["asol1_file"], 'write error')
+                        
+            #!### In both cases above we write current file to list ###
+            asollist.write(newasol + '\n')
+            asollist.close() 
+
+            check_name_in_hdr( "asol1", newasol, params["hdr_asolfile"] )
+
+
 
     #!### Verify we have required input files and copy handy files to outdir ###
     if not os.path.isfile(params["bpix1_file"]):
@@ -2138,7 +2185,10 @@ def remake_fov1_file( pars ):
     skyfov.punlearn()
     skyfov.infile= pars["evt2_file"]
     skyfov.outfile = os.path.join(pars["outdir"], pars["root"] + '_repro_fov1.fits')
-    skyfov.aspect = "@{}[@{}]".format(pars["asol1_file"], pars["evt2_file"])
+    if pars["__obc_mode__"] is False:
+        skyfov.aspect = "@{}[@{}]".format(pars["asol1_file"], pars["evt2_file"])
+    else:
+        skyfov.aspect = "@"+pars["asol1_file"]
     skyfov.mskfile = pars["msk1_file"]
     skyfov.clobber = pars["clobber"]
     skyfov.verbose = pars["verbose"]

--- a/ciao-4.9/contrib/bin/chandra_repro
+++ b/ciao-4.9/contrib/bin/chandra_repro
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # 
-# Copyright (C) 2010-2016  Smithsonian Astrophysical Observatory
+# Copyright (C) 2010-2017  Smithsonian Astrophysical Observatory
 # 
 # 
 # 
@@ -544,6 +544,17 @@ def event1_inputs(params):
             params["date-obs"] = keys["DATE-OBS"].value
             params["grating"]  = keys["GRATING"].value
 
+            # Only standard datasets taken in KALMAN lock are supported.
+            # Other modes such as OBC use the on-board-computer 
+            # aspect solution and don't have *_asol1.fits files. They
+            # only have the *_osol1.fits files.  We can't handle that
+            # right now.
+            
+            if 'KALMAN' != keys["ASPTYPE"].value:
+                msg = "ASPTYPE='{}' mode data is not currently supported."
+                raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
+                 
+
             if params["instrume"] == 'ACIS':  
                 params["readmode"] = keys["READMODE"].value
             if params["instrume"] == 'HRC':  
@@ -860,7 +871,7 @@ def get_inputs(params):
                 newbias = gunzip(params["secondarydir"] + ff)
 
                 path=os.path.join(params["outdir"], os.path.basename(newbias))
-                link_or_copy(newasol, path)
+                link_or_copy(newbias, path)
   
                 uff=ff.split(".gz")[0]
                 params["cleanup_files"].append(os.path.join(params["outdir"], uff))

--- a/ciao-4.9/contrib/share/doc/xml/chandra_repro.xml
+++ b/ciao-4.9/contrib/share/doc/xml/chandra_repro.xml
@@ -751,6 +751,16 @@ acisf084244478N003_2_bias0.fits.gz
     </PARAMLIST>
 
 
+<ADESC title="Change in scripts 4.9.4 (July 2017) release">
+  <PARA>
+    Internal fix for uninitialized variable ("newasol") when processing
+    an observation that does not have any aspect solution files.  This 
+    is limited to observations of the Moon and the Earth.  These observations
+    still cannot be processed at this time but the error message is more informative.
+  </PARA>
+</ADESC>
+
+
 
 <ADESC title="Changes in scripts 4.9.2 (April 2017) release">
   <PARA>
@@ -1021,6 +1031,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>March 2017</LASTMODIFIED>
+    <LASTMODIFIED>July 2017</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
# Do not merge this PR

This allows for the `ASPTYPE='OBC'` datasets to be processed by using the `_osol1.fits` files and by recomputing the `_flt1.fits` files to drop the GTI limits on limb-angles and aspect-type.

The asol/osol stuff is messy -- but messy in the same way as was already there so at least it's consistent.

