### PR TITLE
typos in srcflux ahelp

### DIFF
--- a/ciao-4.9/contrib/share/doc/xml/srcflux.xml
+++ b/ciao-4.9/contrib/share/doc/xml/srcflux.xml
@@ -533,7 +533,7 @@ Position                               0.5 - 1.2 keV                           1
     </QEXAMPLELIST>
 
     <PARAMLIST>
-      <PARAM name="infile" type="file" filetype="input" reqd="yes" stacks="no">
+      <PARAM name="infile" type="file" filetype="input" reqd="yes" stacks="yes">
 	<SYNOPSIS>Input Chandra event file</SYNOPSIS>
 	<DESC>
 	  <PARA>
@@ -542,6 +542,14 @@ Position                               0.5 - 1.2 keV                           1
 	    The file should be for a single observation (see
 	    note about merged observations below). 
 	  </PARA>
+      <PARA>
+        Multiple event files can be input.  The script will 
+        iterate over each event file individually, producing the 
+        same set of properties and data products.  The results 
+        are not merged.      
+      </PARA>
+
+
 	</DESC>        
       </PARAM>
       <PARAM name="pos" type="string" reqd="yes" stacks="no">

--- a/ciao-4.9/contrib/share/doc/xml/srcflux.xml
+++ b/ciao-4.9/contrib/share/doc/xml/srcflux.xml
@@ -950,7 +950,7 @@ bounds(region(my.reg))
 	  <PARA>
 	    <SYNTAX>
 	      <LINE>&pr; pset srcflux absmodel="xsphabs.abs1"</LINE>
-	      <LINE>&pr; pset asbparams="abs1.nH=&gal;"</LINE>
+	      <LINE>&pr; pset absparams="abs1.nH=&gal;"</LINE>
 	    </SYNTAX>
 	  </PARA>
 	  <PARA>
@@ -1805,7 +1805,7 @@ bounds(region(my.reg))
             method=arfcorr - the model PSF.</ITEM>
 
             <ITEM>The special tokens &gal;, &nrao; and &bell; 
-            can be used in the paramvals and absparam parameters.
+            can be used in the paramvals and absparams parameters.
             These indicate that the nH column density value calculated by prop_colden
 	      should be used.
             </ITEM>


### PR DESCRIPTION
fix typos in srcflux ahelp.

Note; `absparam` in the examples are valid without the `s` 