### PR TITLE
added checks for interleaved observations so they're mergeable with merge_obs

### DIFF
--- a/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/_tools/merging.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/_tools/merging.py
@@ -1071,9 +1071,9 @@ def validate_obsinfo(infiles, colcheck=True):
     if ninfiles == 0:
         raise IOError("No valid event files were found.")
 
-    # Now do a multi-obi check
+    # Now do a multi-obi/interleaved check
     #
-    v3("Looking for multi-obi datasets")
+    v3("Looking for interleaved/multi-OBI datasets")
     nobsids = {}
     for oi in obsinfos:
         obsidval = oi[1].obsid.obsid
@@ -1084,11 +1084,32 @@ def validate_obsinfo(infiles, colcheck=True):
 
     multis = [k for (k, v) in six.iteritems(nobsids) if v > 1]
     if len(multis) > 0:
-        v3("Found multi-obi ObsIds: {}".format(multis))
+        v3("Found interleaved/multi-OBI ObsIds: {}".format(multis))
         if len(multis) == 1:
-            v1("Found one multi-OBI observation:")
+            v1("Found one interleaved/multi-OBI observation:")
         else:
-            v1("Found {} multi-OBI observations:".format(len(multis)))
+            v1("Found {} interleaved/multi-OBI observations:".format(len(multis)))
+
+        # check for interleaved observations; remove them from the 'multis' multi-obi list
+        obs_cycle = {}
+        for oi in list(obsinfos):
+            obsinfo = oi[1]
+            obsid = obsinfo.obsid
+
+            if obsid.obsid in multis:
+                try:
+                    obs_cycle[obsid.obsid] += obsid.cycle
+                except KeyError:
+                    obs_cycle[obsid.obsid] = obsid.cycle
+                except TypeError:
+                    continue
+                                    
+        for obsid in obs_cycle.keys():
+            # if ObsID has both cycle=P and cycle=S files, then remove it from the multi-obi list
+            if obs_cycle[obsid] in ["PS","SP"]:
+                v3("ObsID {} is an interleaved observation".format(obsid))
+                multis.remove(obsid)
+
 
         # Mark the observations as being "multi obi"
         # and remove any such observation which has no
@@ -1102,7 +1123,7 @@ def validate_obsinfo(infiles, colcheck=True):
             if obsid.obsid in multis:
                 v3("Setting {} as multi-OBI".format(obsinfo))
                 try:
-                    obsid.is_multi_obi = True
+                    obsid.is_multi_obi = True  
                     v1("  - using label {}".format(obsid))
                 except ValueError as ve:
                     # oops, this has no OBI value so should be rejected
@@ -1113,7 +1134,7 @@ def validate_obsinfo(infiles, colcheck=True):
                     obsinfos.remove(oi)
 
     else:
-        v3("No multi-obi datasets found")
+        v3("No interleaved/multi-OBI datasets found")
 
     # the obsinfos array can be shortened by the above, so re-compute.
     ninfiles = len(obsinfos)


### PR DESCRIPTION
added checks for interleaved observations so they aren't treated as as multi-obi observations, since they will be removed from merging due to changes between CIAO 4.6 and 4.7, affecting merge_obs.