### PR TITLE
Cobmine grating spectra fix when no bkg

### DIFF
--- a/ciao-4.9/contrib/bin/combine_grating_spectra
+++ b/ciao-4.9/contrib/bin/combine_grating_spectra
@@ -181,7 +181,11 @@ def split_II_to_I( instk, arfs, rmfs, outroot, verbose, clobber ):
         bkgs = [delme(x) for x in glob.glob( tmproot+"_?eg_??_bkg.pha")]
 
         retsrc.extend(outs)
-        retbkg.extend(bkgs)
+
+        if ( 0 == len(bkgs) ):
+            retbkg.extend([None]*len(outs))
+        else:
+            retbkg.extend(bkgs)
     
     retsrc.sort()
     retbkg.sort()
@@ -274,27 +278,13 @@ def try_nonstd_files( instk, arfs, rmfs, outroot ):
         #Not tgcat files
         return None, None
 
-    # TODO: Replace with runtool
     import ciao_contrib.runtool as rt
-    newtool = {
-        'istool' : True,
-        'req' : [
-                rt.ParValue("infile", "f", "Input TYPE:II pha file", None),
-                rt.ParValue("arffile","f", "Input ARF files", None),
-                rt.ParValue("rmffile","f", "Input RMF files", None),
-                rt.ParValue("outroot", "f", "Output root file name", None),
-                ],
-        'opt' : [                
-                rt.ParValue("clobber","b","Overwrite if file exists",False),
-                rt.ParRange("verbose","i","Debug level",0,0,5)
-                ]}
-    tgsplit = rt.CIAOToolParFile( "tgsplit", newtool["req"], newtool["opt"])
+    tgsplit = rt.make_tool("tgsplit")
     tmproots = [ outroot+"_tmp{:02d}".format(ii) for ii in range( len(instk)) ]    
 
     try:
         for ii,tt in zip(instk, tmproots):
             tgsplit( ii, arfs, rmfs, tt )
-        #map( tgsplit, instk, [arfs]*len(instk), [rmfs]*len(instk), tmproots )
         src = [ delme(i) for tt in tmproots for i in glob.glob(tt+"_?eg_??.pha") ]
         bkg = [ delme(i) for tt in tmproots for i in glob.glob(tt+"_?eg_??_bkg.pha") ]
         return src,bkg

--- a/ciao-4.9/contrib/bin/combine_grating_spectra
+++ b/ciao-4.9/contrib/bin/combine_grating_spectra
@@ -153,21 +153,9 @@ def split_II_to_I( instk, arfs, rmfs, outroot, verbose, clobber ):
 
     verb1("Splitting TYPE:II pha files into TYPE:I")
 
-    # TODO: Replace with runtool
     import ciao_contrib.runtool as rt
-    newtool = {
-        'istool' : True,
-        'req' : [
-                rt.ParValue("infile", "f", "Input TYPE:II pha file", None),
-                rt.ParValue("arffile","f", "Input ARF files", None),
-                rt.ParValue("rmffile","f", "Input RMF files", None),
-                rt.ParValue("outroot", "f", "Output root file name", None),
-                ],
-        'opt' : [                
-                rt.ParValue("clobber","b","Overwrite if file exists",False),
-                rt.ParRange("verbose","i","Debug level",0,0,5)
-                ]}
-    tgsplit = rt.CIAOToolParFile( "tgsplit", newtool["req"], newtool["opt"])
+
+    tgsplit = rt.make_tool("tgsplit")
     
 
     retsrc = []

--- a/ciao-4.9/contrib/share/doc/xml/combine_grating_spectra.xml
+++ b/ciao-4.9/contrib/share/doc/xml/combine_grating_spectra.xml
@@ -729,6 +729,13 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 </ADESC>
       
 
+<ADESC title="Changes in the script 4.10.1 (April 2018) release">
+  <PARA>
+    Fixed a bug when the TYPE:II grating spectra do not have background.  
+  </PARA>
+</ADESC>
+
+
 <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
   <PARA>
     If the input spectra contain a STAT_ERR column, the script will


### PR DESCRIPTION
This fixes #94 , when TYPE:II pha files do not contain background.  
