### PR TITLE
example added to intersect the extraction region with FOV file

### DIFF
--- a/ciao-4.9/contrib/share/doc/xml/specextract.xml
+++ b/ciao-4.9/contrib/share/doc/xml/specextract.xml
@@ -1705,7 +1705,7 @@ unix% cat output.lis
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>April 2017</LASTMODIFIED>
+    <LASTMODIFIED>March 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.9/contrib/share/doc/xml/specextract.xml
+++ b/ciao-4.9/contrib/share/doc/xml/specextract.xml
@@ -220,6 +220,24 @@ unix% cat output.lis
 	</DESC>
       </QEXAMPLE>
 
+      <QEXAMPLE>
+	<SYNTAX>
+	  <LINE>&pr; punlearn specextract</LINE>
+	  <LINE>&pr; specextract "acis_evt2.fits[sky=region(fov.fits)][sky=region(src.reg)]" extract/spec_off-chip \</LINE>
+	  <LINE>bkgfile="acis_evt2.fits[sky=region(bg.reg)]" \</LINE>
+	  <LINE>grouptype=NONE binspec=NONE</LINE>
+	</SYNTAX>
+	<DESC>
+	  <PARA>
+	    The extraction region is intersected with
+	    the observation's FITS field-of-view file.  This is useful
+	    when the extraction region includes parts of the sky that
+	    fall off the chip so that the appropriate BACKSCAL value
+	    can be calculated, excluding the portion of the
+	    extraction region that is not exposed to the detector.
+	  </PARA>
+	</DESC>
+      </QEXAMPLE>
     </QEXAMPLELIST>
     
     <PARAMLIST>


### PR DESCRIPTION
example added to intersect the extraction region with a FOV file in order to calculate the correct BACKSCAL value for regions that fall off the chip