### PR TITLE
Handle error handling on 504 response (find_chandra_obsid)

### DIFF
--- a/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/cda/search.py
+++ b/ciao-4.9/contrib/lib/python2.7/site-packages/ciao_contrib/cda/search.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016
+#  Copyright (C) 2011, 2015, 2016, 2018
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -359,13 +359,17 @@ def search_chandra_archive(ra, dec, size=0.1,
         rsp = urllib.request.urlopen(url)
 
     except urllib.error.URLError as ue:
-        # Is this a sufficient check?
         v3("Error opening URL: {0}".format(ue))
         v3("error.reason = {0}".format(ue.reason))
-        if ue.reason.errno == 8:
-            raise IOError("Unable to connect to the Chandra Simple Image Access Server")
-        else:
-            raise
+
+        # There used to be a check on the reason for the error,
+        # converting it into a "user-friendly" message, but this
+        # was error prone (the check itself was faulty) and
+        # potentially hid useful error information. So just
+        # re-raise the error here after logging it: is it really
+        # worth logging this error condition?
+        #
+        raise
 
     # It appears you can not filter on grating using the SIA interface,
     # so do it manually


### PR DESCRIPTION
Rather than trying to provide a nice error (as we actually do
in find_chandra_obsid when querying OCAT), ditch the idea and just
re-raise it after logging the error. The error handler had erronously
assumed that the reason field would have an errno attribute which
it isn't guaranteed to have.

Rather than try to provide a "nice" reason for the error (at the
expense of losing potentially-useful low-level details) just
re-throw.

The script now errors out with

````
% find_chandra_obsid 'ngc113'
# find_chandra_obsid (22 May 2017): ERROR HTTP Error 504: Gateway Time-out
````