### PR TITLE
deflare ahelp typos

### DIFF
--- a/ciao-4.9/contrib/share/doc/xml/deflare.xml
+++ b/ciao-4.9/contrib/share/doc/xml/deflare.xml
@@ -19,7 +19,7 @@
     <SYNTAX>
       <LINE>
 	deflare infile method [outfile] [nsigma] [minlength] [mean]
-	[stdev] [scale] [minfrac] [plot] [save] [rateaxis] [pattern] 
+	[stddev] [scale] [minfrac] [plot] [save] [rateaxis] [pattern] 
 	[good_color] [exclude_color] [verbose]
       </LINE>
     </SYNTAX>
@@ -83,7 +83,7 @@
 	The 'mean', 'clip', 'sigma', 'scale', and 'minfrac'
 	options control the behavior of the routine, and are
 	represented in deflare by the parameters 'mean', 'nsigma',
-	'stdev', 'scale', and 'minfrac', respectively.
+	'stddev', 'scale', and 'minfrac', respectively.
 	If 'mean' is set then the value is taken as the initial
 	guess, otherwise the level is calculated from the data,
 	with outliers clipped using the 'nsigma' parameter
@@ -91,14 +91,14 @@
 	clipping scheme - as used in lc_sigma_clip() - since the
 	variance of the lightcurve is assumed to be
 	<EQUATION>var = mean-rate / bin-width</EQUATION>
-	(where sqrt(var) represents 'sigma' in lc_clean and 'stdev' in
+	(where sqrt(var) represents 'sigma' in lc_clean and 'stddev' in
 	deflare). Once the mean level has been calculated, the limits
-	are given by (if 'stdev' is changed from its default
+	are given by (if 'stddev' is changed from its default
 	value of None).
 
-	<EQUATION>mean - nsigma * stdev</EQUATION>
+	<EQUATION>mean - nsigma * stddev</EQUATION>
 	to
-	<EQUATION>mean + nsigma * stdev</EQUATION>
+	<EQUATION>mean + nsigma * stddev</EQUATION>
 	otherwise they are
 	<EQUATION>mean / scale</EQUATION>
 	to
@@ -454,17 +454,17 @@
             </PARA>
          </DESC>
       </PARAM>     
-      <PARAM name="stdev" type="real" reqd="no" def="None">
+      <PARAM name="stddev" type="real" reqd="no" def="None">
          <SYNOPSIS>
             Standard deviation of signal, as determined by lc_clean.
          </SYNOPSIS>
          <DESC>
             <PARA>
-             The 'stdev' parameter is the lc_clean 'sigma' parameter,
+             The 'stddev' parameter is the lc_clean 'sigma' parameter,
              which is calculated from the 'mean' value as
-             sqrt(mean-rate/bin width). When stdev is 'None', then the
+             sqrt(mean-rate/bin width). When stddev is 'None', then the
              limits used for clipping the light curve are mean/scale
-             to min*scale, otherwise they are mean - nsigma*stdev to
+             to min*scale, otherwise they are mean - nsigma*stddev to
              mean + nsigma*stddev.
             </PARA>
          </DESC>
@@ -476,10 +476,10 @@
          </SYNOPSIS>
          <DESC>
             <PARA>
-              When the 'stdev' parameter is 'None', then the limits
+              When the 'stddev' parameter is 'None', then the limits
               used by lc_clean for clipping the light curve are
               mean/scale to min*scale, otherwise they are mean -
-              nsigma*stdev to mean + nsigma*stddev.
+              nsigma*stddev to mean + nsigma*stddev.
             </PARA>
          </DESC>
       </PARAM>      


### PR DESCRIPTION
fixed typos replacing references to 'stdev' parameter name to 'stddev' in the ahelp