### PR TITLE
srcflux deal with blank/NULL regions as before

### DIFF
--- a/ciao-4.10/contrib/bin/srcflux
+++ b/ciao-4.10/contrib/bin/srcflux
@@ -313,7 +313,13 @@ def save_regions( myparams, regions, flavor ):
     """    
     from ciao_contrib.runtool import dmmakereg
     from tempfile import NamedTemporaryFile    
-    ss = stk.build(regions)
+
+    # CIAO 4.10 changes to NULL regions no longer creates a fake
+    # "point(0,0)" -- I'm using that so we'll put it back.
+    try:
+        ss = stk.build(regions)
+    except ValueError as ve:
+        ss = [ "point(0,0)" ]
     
     with open( regions[2:], "w" ) as oo:  # 2 => skip "@-"
         for ii in range( len(ss)):


### PR DESCRIPTION
Before ciao-4.10, a 0 row FITS region was read in as "point(0,0)" .  This happens in srcflux when the regions doesn't overlap with the FOV (a null intersection).  

In CIAO 4.10, a 0 row FITS region file is "" (blank|NULL); but srcflux is setup to look for the point(0,0).  

Without this change, there is a ValueError exception thrown when the source stack is expanded because expanding a stack file with 0 non-blank rows is an error.

 