### PR TITLE
WIP deflare: only load ChIPS when needed

### DIFF
--- a/ciao-4.10/contrib/Changes.CIAO_scripts
+++ b/ciao-4.10/contrib/Changes.CIAO_scripts
@@ -36,6 +36,14 @@
         extracted.  Internal updates to use standard wrapper for tgsplit 
         tool. 
 
+    deflare
+
+        ChIPS is now only started if the plot parameter is set. This
+        should allow users to use this script to create a GTI file
+        on systems without an X Display, such as in High Performance
+        Computer systsms, or when ChIPS does not work over a remote
+        connection.
+        
     download_obsid_caldb
     
         Updated to allow it to work with file names containing DM filters.

--- a/ciao-4.10/contrib/bin/deflare
+++ b/ciao-4.10/contrib/bin/deflare
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2014, 2015, 2016, 2017  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015, 2016, 2017, 2018
+#                Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -36,14 +37,25 @@ ciao% deflare method=clean infile=lc.fits outfile=gti.fits
 """
 
 toolname = "deflare"
-__revision__ = "22 May 2017"
+__revision__ = "29 March 2018"
 
 import os
 import sys
 
 import paramio
 
-import pychips
+# Delay importing pychips until we need it, to allow the script to
+# be run in a non-interactive mode. Unfortunately we do want to
+# import ChIPS and then catch an error because
+#
+#   a) ChIPS goes through a long re-try loop to check that it
+#      can't start up the server, which wastes a lot of time
+#
+#   b) doesn't raise an ImportError in this case, instead a
+#      RuntimeError (which could be caught, but not worth it
+#      due to the above).
+#
+# import pychips
 
 import six
 
@@ -78,7 +90,10 @@ v1 = make_verbose_level(toolname, 1)
 
 
 def get_par(args):
-    """Get parameters from parameter file """
+    """Get parameters from parameter file.
+
+    This can also load/start up ChIPS, if plotting is requested.
+    """
 
     pinfo = open_param_file(args, toolname=toolname)
     pfile = pinfo["fp"]
@@ -106,6 +121,13 @@ def get_par(args):
 
     if not params["plot"] and params["save"] is not None:
         params["plot"] = True
+
+        # Importing ChIPS here only when we need it, so that the
+        # script can be run without an X server (when importing
+        # ChIPS fails to produce a working system). Note that
+        # it can fail with a RuntimeError.
+        #
+        import pychips
         pychips.set_preference("window.display", "false")
 
     if params["outfile"] == "" or params["outfile"].lower() == 'none':

--- a/ciao-4.10/contrib/share/doc/xml/deflare.xml
+++ b/ciao-4.10/contrib/share/doc/xml/deflare.xml
@@ -620,6 +620,20 @@
     </ADESC>
     -->
 
+    <ADESC title="Changes in the scripts 4.10.1 (April 2018) release">
+      <PARA title="Turning off plotting support">
+        A long-standing issue with this script was its inability to
+        run if ChIPS - the CIAO plotting and imaging package - could
+        not be started. This could happen when no XDisplay was set
+        up - e.g. when run in a High Performance Computing environment -
+        or when run on a remote machine with incompatible OpenGL
+        implementations. The script has been changed so that ChIPS
+        is now only started when needed, so if you have previously
+        had problems with this script then please re-try and ensure
+        that the plot parameter is set to no.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.9.3 (May 2017) release">
       <PARA>
 	The script has been updated so that it will run under Python
@@ -656,7 +670,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>May 2017</LASTMODIFIED>
+    <LASTMODIFIED>March 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This is a simple, but ugly, hack. See #113 for motivation.

**EDITED TO ADD** we are planning to move to Matplotlib for deflare, so this isn't needed, but I'm leaving it up for the moment so we don't forget about it.