### PR TITLE
Use ROLL_PNT in preference to ROLL_NOM and pixlib for plate scales (fix #23)

### DIFF
--- a/ciao-4.10/contrib/Changes.CIAO_scripts
+++ b/ciao-4.10/contrib/Changes.CIAO_scripts
@@ -49,6 +49,14 @@
     
         Force script to use bash shell to fix issue on Ubuntu which 
         defaults to using 'dash'.
+
+    make_psf_asymmetry_region
+
+        The roll is now taken from the ROLL_PNT keyword in preference
+        to the ROLL_NOM keyword (as was previously always used). This
+        will only make a difference for data that has been corrected
+        for astrometry shifts or reprojected, and the small number of
+        multi-obi data sets.
         
     simulate_psf
     

--- a/ciao-4.10/contrib/Changes.CIAO_scripts
+++ b/ciao-4.10/contrib/Changes.CIAO_scripts
@@ -56,7 +56,9 @@
         to the ROLL_NOM keyword (as was previously always used). This
         will only make a difference for data that has been corrected
         for astrometry shifts or reprojected, and the small number of
-        multi-obi data sets.
+        multi-obi data sets. The plate scale is now taken from the
+        pixlib settings rather than hard coded, which means that radii
+        for HRC values will decrease by ~0.05%.
         
     simulate_psf
     

--- a/ciao-4.10/contrib/bin/make_psf_asymmetry_region
+++ b/ciao-4.10/contrib/bin/make_psf_asymmetry_region
@@ -42,6 +42,7 @@ import subprocess as sbp
 
 import paramio as pio
 import pycrates
+import pixlib
 
 from ciao_contrib.logger_wrapper import handle_ciao_errors, \
     initialize_logger, make_verbose_level, set_verbosity
@@ -149,17 +150,21 @@ def get_data_from_file(fname):
 
     v3("{}={} DETNAM={}".format(keyword, roll, detnam))
 
+    p = pixlib.Pixlib()
     if detnam.startswith("ACIS-"):
-        scale = 0.492
+        p.detector = "ACIS"
+        # scale = 0.492
 
     elif detnam.startswith("HRC-"):
-        scale = 0.13175
+        p.detector = detnam
+        # scale = 0.13175
 
     else:
         # e.g. Merged?
         raise IOError("Unexpected DETNAM of '{0}' in\n{1}".format(detnam,
                                                                   fname))
 
+    scale = p.fp_scale
     return {"roll": roll, "scale": scale}
 
 

--- a/ciao-4.10/contrib/bin/make_psf_asymmetry_region
+++ b/ciao-4.10/contrib/bin/make_psf_asymmetry_region
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010, 2011, 2015
+# Copyright (C) 2010, 2011, 2015, 2018
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -32,7 +32,7 @@ For more information, see
 """
 
 toolname = "make_psf_asymmetry_region"
-version = "12 November 2015"
+version = "30 March 2018"
 
 import sys
 import os
@@ -125,18 +125,29 @@ def location_to_region(anom, filename=None, regformat="ciao"):
 def get_data_from_file(fname):
     """Return the information we need for calculating the
     location of the anomaly.
+
+    The roll is taken from ROLL_PNT (if present) otherwise it
+    falls back to ROLL_NOM.
+
     """
 
     cr = pycrates.read_file(fname)
-    roll = cr.get_key_value("ROLL_NOM")
+
+    keyword = None
+    for sfx in ["PNT", "NOM"]:
+        keyword = "ROLL_{}".format(sfx)
+        roll = cr.get_key_value(keyword)
+        if roll is not None:
+            break
+
     if roll is None:
-        raise IOError("No ROLL_NOM keyword in {}".format(fname))
+        raise IOError("No ROLL_PNT/NOM keyword in {}".format(fname))
 
     detnam = cr.get_key_value("DETNAM")
     if detnam is None:
         raise IOError("No DETNAM keyword in {}".format(fname))
 
-    v3("ROLL_NOM={} DETNAM={}".format(roll, detnam))
+    v3("{}={} DETNAM={}".format(keyword, roll, detnam))
 
     if detnam.startswith("ACIS-"):
         scale = 0.492
@@ -156,7 +167,7 @@ def create_anomaly_region(infile, x, y, outfile, regformat="ciao",
                           clobber=False):
     """Create a regionfile called outfile that highlights the
     PSF anomaly location for the observation stored in infile (needs
-    ROLL_NOM and DETNAM keywords) for a source with sky coordinates
+    ROLL_PNT/NOM and DETNAM keywords) for a source with sky coordinates
     of (x,y).
 
     If clobber is False then outfile will not be overwritten if it

--- a/ciao-4.10/contrib/share/doc/xml/make_psf_asymmetry_region.xml
+++ b/ciao-4.10/contrib/share/doc/xml/make_psf_asymmetry_region.xml
@@ -47,7 +47,8 @@
 	  highlights the location of the PSF asymmetry for a source
 	  located at the sky coordinates of (16278.23,16415.09).
 	  The input file (hrc.fits) is used to determine the roll
-	  of the observation (the ROLL_NOM keyword) and the detector
+	  of the observation (the ROLL_PNT or ROLL_NOM keyword)
+          and the detector
 	  scale (the DETNAM keyword).
 	</PARA>
 	<PARA>
@@ -120,7 +121,8 @@
        </SYNOPSIS>
        <DESC>
 	 <PARA>
-	   This file is used to determine the observation roll (the ROLL_NOM
+	   This file is used to determine the observation roll
+           (the ROLL_PNT or ROLL_NOM
 	   keyword) and the plate scale - the width of a sky pixel in arcseconds - 
 	   using the DETNAM keyword. It can be any file which contains these
 	   two keywords but it is suggested you use an image or event file
@@ -217,7 +219,17 @@
      </PARAM>
    </PARAMLIST>
 
-       <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
+   <ADESC title="Changes in the scripts 4.10.1 (April 2018) release">
+     <PARA>
+       The roll is now taken from the ROLL_PNT keyword if it
+       exists, otherwise ROLL_NOM is used. Previously ROLL_NOM
+       was always used. This only makes a difference for data that
+       has been corrected for astrometry shifts or reprojected,
+       and for the small number of multi-obi observations.
+      </PARA>
+    </ADESC>
+
+   <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
       <PARA>
         The code has been updated to avoid warning messages from
         NumPy version 1.9. There is no difference to how the
@@ -251,6 +263,6 @@
      </PARA>
    </BUGS>
    
-   <LASTMODIFIED>November 2015</LASTMODIFIED>
+   <LASTMODIFIED>March 2018</LASTMODIFIED>
  </ENTRY>
 </cxchelptopics>

--- a/ciao-4.10/contrib/share/doc/xml/make_psf_asymmetry_region.xml
+++ b/ciao-4.10/contrib/share/doc/xml/make_psf_asymmetry_region.xml
@@ -220,22 +220,27 @@
    </PARAMLIST>
 
    <ADESC title="Changes in the scripts 4.10.1 (April 2018) release">
-     <PARA>
+     <PARA title="Roll values">
        The roll is now taken from the ROLL_PNT keyword if it
        exists, otherwise ROLL_NOM is used. Previously ROLL_NOM
        was always used. This only makes a difference for data that
        has been corrected for astrometry shifts or reprojected,
        and for the small number of multi-obi observations.
-      </PARA>
+     </PARA>
+     <PARA title="HRC radii">
+       The plate scale is now taken from the pixlib module rather
+       than hardcoded, which has resulted in a ~0.05% decrease
+       in the radii in the region files for HRC data.
+     </PARA>
     </ADESC>
 
    <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
-      <PARA>
-        The code has been updated to avoid warning messages from
-        NumPy version 1.9. There is no difference to how the
-        script behaves.
-      </PARA>
-    </ADESC>
+     <PARA>
+       The code has been updated to avoid warning messages from
+       NumPy version 1.9. There is no difference to how the
+       script behaves.
+     </PARA>
+   </ADESC>
 
    <ADESC title="Changes in the December 2011 Release">
       <PARA>


### PR DESCRIPTION
This does change the plate scale used for HRC data from 0.13175 to 0.1318, which results in a ~0.05% reduction in HRC radii, which has been mentioned in the documentation.