### PR TITLE
Dax path fix

### DIFF
--- a/ciao-4.10/contrib/config/chips_startup.tk
+++ b/ciao-4.10/contrib/config/chips_startup.tk
@@ -1,7 +1,8 @@
 global chipsPID
 global ds9
 
-set chipsPID [exec ciaorun startchips $ds9(title) &]
+global env
+set chipsPID [exec env PATH=$env(ASCDS_INSTALL)/bin:$env(PATH) startchips $ds9(title) &]
 
 
 proc CleanUp {chipsPID windowPath} {

--- a/ciao-4.10/contrib/config/chips_startup.tk
+++ b/ciao-4.10/contrib/config/chips_startup.tk
@@ -1,7 +1,7 @@
 global chipsPID
 global ds9
 
-set chipsPID [exec startchips $ds9(title) &]
+set chipsPID [exec ciaorun startchips $ds9(title) &]
 
 
 proc CleanUp {chipsPID windowPath} {

--- a/ciao-4.10/contrib/config/chips_startup.tk
+++ b/ciao-4.10/contrib/config/chips_startup.tk
@@ -2,7 +2,11 @@ global chipsPID
 global ds9
 
 global env
-set chipsPID [exec env PATH=$env(ASCDS_INSTALL)/bin:$env(PATH) startchips $ds9(title) &]
+
+set env(PATH) $env(ASCDS_INSTALL)/bin:$env(PATH)
+
+#set chipsPID [exec env PATH=$env(ASCDS_INSTALL)/bin:$env(PATH) startchips $ds9(title) &]
+set chipsPID [exec startchips $ds9(title) &]
 
 
 proc CleanUp {chipsPID windowPath} {


### PR DESCRIPTION
ds9 add the directory where it finds any analysis files to the `PATH`.  It looks in various dirs including `/usr/local/bin`, `/opt/local/bin/`, `./`, and `$HOME`.  

This suddenly broke dax (specifically, the chips plotting via dax) when `funtools.ds9` was added to `/usr/local/bin`.  

This change adds `$env(ASCDS_INSTALL)/bin/`  back to the beginning of the path.

This is not likely going to affect many users outside of CfA -- they will have had to installed funtools into those dirs for the `autoload` to work.





