### PR TITLE
work around pixlib float32 issue

### DIFF
--- a/ciao-4.10/contrib/lib/python3.5/site-packages/coords/chandra.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/coords/chandra.py
@@ -50,11 +50,12 @@ def _setup_sim( keyword_list ):
     # Get mean sim offset if all keys are present
     #
     if all( [x in keyword_list for x in ["DY_AVG", "DZ_AVG", "DTH_AVG" ] ]):
-        dsim = [0.0, -1*keyword_list["DY_AVG"], -1*keyword_list["DZ_AVG"] ]
-        droll = keyword_list["DTH_AVG"]
+        dsim = (float(0.0), -1*float(keyword_list["DY_AVG"]), -1*float(keyword_list["DZ_AVG"]) )
+        droll = float(keyword_list["DTH_AVG"])
     else:
-        dsim = [0.0]*3
-        droll = 0.0
+        _f = float(0.0)
+        dsim = (_f,_f,_f)
+        droll = -f
     
     return sim, dsim, droll
 
@@ -128,8 +129,7 @@ def _setup( keyword_list ):
 
     if sim: 
         pix.aimpoint = sim
-
-    pix.mirror = (dsim, droll )
+    pix.mirror = (tuple(dsim), droll )
     
     # get center of DET coord system by asking for on-axis
     # location (0,0)


### PR DESCRIPTION
This fixes the problem where pixlib's set_mirror method is only accepting float32, not np.float32 which is
what pycrates is returning.

