### PR TITLE
Support current view in search CSC scripts

### DIFF
--- a/ciao-4.10/contrib/bin/obsid_search_csc
+++ b/ciao-4.10/contrib/bin/obsid_search_csc
@@ -1,26 +1,26 @@
 #!/usr/bin/env python
-#
-# Copyright (C) 2013,2016,2018 Smithsonian Astrophysical Observatory
-#
+# 
+# Copyright (C) 2013,2016 Smithsonian Astrophysical Observatory
+# 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-#
+# 
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#
+# 
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
+# 
 from __future__ import print_function
 
 
 toolname = "obsid_search_csc"
-__revision__ = "6 March 2018"
+__revision__ = "05 Dec 2017"
 
 import sys
 # This is only needed for development.
@@ -28,15 +28,13 @@ import os
 try:
     if not __file__.startswith(os.environ['ASCDS_INSTALL']):
         _thisdir = os.path.dirname(__file__)
-        _libname = "python{}.{}".format(sys.version_info.major,
-                                        sys.version_info.minor)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
+        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib/python2.7/site-packages'))
         if os.path.isdir(_pathdir):
-            os.sys.path.insert(1, _pathdir)
+            os.sys.path.insert(0, _pathdir)
         else:
             print("*** WARNING: no {}".format(_pathdir))
         del _pathdir
-        del _thisdir
+        del _thisdir        
 except KeyError:
     raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
 
@@ -65,18 +63,22 @@ def parse_inputs( pars ):
 
     if not all( [x.isdigit() for x in retval["obsid"].split(",")]):
         raise ValueError("obsid must be a list of individual integers")
-
+    
     if "INDEF" == pars["columns"] or len(pars["columns"]) == 0:
-        retval["columns"] = csc.get_default_columns()
+        retval["columns"] = csc.get_default_columns(pars["catalog"])
     else:
         retval["columns"] = stk.build( pars["columns"] )
-        retval["columns"] = csc.check_required_names( retval["columns"] )
+        retval["columns"] = csc.check_required_names( retval["columns"], pars["catalog"] )
 
     if 'none' == pars["outfile"].lower():
         retval["outfile"] = None
     else:
         retval["outfile"] = pars["outfile"]
 
+    if "cur" == pars["catalog"] and "none" != pars["download"]:
+        pars["download"] = "none"
+        verb0("WARNING: files cannot yet be retrieved using the current catalog release")
+    
     if "none" == pars["download"]:
         retval["getfiles"] = False
         retval["myfiles"] = None
@@ -87,13 +89,13 @@ def parse_inputs( pars ):
         retval["root"] = pars["root"]
 
         if len(pars["filetypes"] ) == 0:
-            # if filetypes is blank, use all of them
+            # if filetypes is blank, use all of them 
             retval["myfiles"] = ",".join( csc.fileTypes.keys() )
         else:
             retval["myfiles"] = csc.check_filetypes( pars["filetypes"] )
             if len(retval["myfiles"]) == 0:
                 raise ValueError("No recognized file types supplied")
-
+        
         if len(pars["bands"]) == 0:
             # if bands is blank, use all of them
             retval["mybands"] = ",".join(csc.all_bands())
@@ -102,9 +104,10 @@ def parse_inputs( pars ):
             if len(retval["mybands"]) == 0:
                 raise ValueError("No recognized energy band supplied")
 
-
+    
     retval["clobber"] = ( pars["clobber"] == "yes" )
-
+    retval["catalog"] = pars["catalog"]
+    
     return retval
 
 
@@ -116,26 +119,26 @@ def main():
     """
     """
     # get parameters
-    pars = get_params(toolname, "rw", sys.argv,
+    pars = get_params(toolname, "rw", sys.argv, 
       verbose={"set":lw.set_verbosity, "cmd":verb1} )
     pp = parse_inputs( pars )
 
     #
     # Query catalog by position
     #
-    mypage = csc.search_src_by_obsid( pp["obsid"], pp["columns"] )
-    csc.save_results( mypage, pp["outfile"], pp["clobber"] )
+    mypage = csc.search_src_by_obsid( pp["obsid"], pp["columns"], pp["catalog"] )
+    csc.save_results( mypage, pp["outfile"], pp["clobber"] )    
 
     #
     # Print results
     #
     mysrcs = csc.parse_csc_result( mypage )
-    xtra = csc.extra_cols_to_summarize( mysrcs, pars["columns"])
+    xtra = csc.extra_cols_to_summarize( mysrcs, pars["columns"], pp["catalog"])
     csc.summarize_results( mysrcs, extracols=xtra )
-
+    
     #
     # Retrieve the files if asked
-    #
+    # 
     if pp["getfiles"]:
         csc.retrieve_files( mysrcs, pp["root"], pp["myfiles"], pp["mybands"], pp["getfiles"], byObi=True )
 
@@ -147,3 +150,4 @@ if __name__ == "__main__":
         print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
+    

--- a/ciao-4.10/contrib/bin/obsid_search_csc
+++ b/ciao-4.10/contrib/bin/obsid_search_csc
@@ -1,26 +1,26 @@
 #!/usr/bin/env python
-# 
-# Copyright (C) 2013,2016 Smithsonian Astrophysical Observatory
-# 
+#
+# Copyright (C) 2013,2016,2018 Smithsonian Astrophysical Observatory
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 from __future__ import print_function
 
 
 toolname = "obsid_search_csc"
-__revision__ = "05 Dec 2017"
+__revision__ = "6 March 2018"
 
 import sys
 # This is only needed for development.
@@ -28,13 +28,16 @@ import os
 try:
     if not __file__.startswith(os.environ['ASCDS_INSTALL']):
         _thisdir = os.path.dirname(__file__)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib/python2.7/site-packages'))
+        _libname = "python{}.{}".format(sys.version_info.major,
+                                        sys.version_info.minor)
+        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
         if os.path.isdir(_pathdir):
-            os.sys.path.insert(0, _pathdir)
+            os.sys.path.insert(1, _pathdir)
         else:
             print("*** WARNING: no {}".format(_pathdir))
         del _pathdir
-        del _thisdir        
+        del _libname
+        del _thisdir
 except KeyError:
     raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
 

--- a/ciao-4.10/contrib/bin/obsid_search_csc
+++ b/ciao-4.10/contrib/bin/obsid_search_csc
@@ -93,9 +93,9 @@ def parse_inputs( pars ):
 
         if len(pars["filetypes"] ) == 0:
             # if filetypes is blank, use all of them 
-            retval["myfiles"] = ",".join( csc.fileTypes.keys() )
+            retval["myfiles"] = ",".join( csc.fileTypes[pars["catalog"]].keys() )
         else:
-            retval["myfiles"] = csc.check_filetypes( pars["filetypes"] )
+            retval["myfiles"] = csc.check_filetypes( pars["filetypes"], pars["catalog"] )
             if len(retval["myfiles"]) == 0:
                 raise ValueError("No recognized file types supplied")
         
@@ -143,7 +143,7 @@ def main():
     # Retrieve the files if asked
     # 
     if pp["getfiles"]:
-        csc.retrieve_files( mysrcs, pp["root"], pp["myfiles"], pp["mybands"], pp["getfiles"], byObi=True )
+        csc.retrieve_files( mysrcs, pp["root"], pp["myfiles"], pp["mybands"], pp["getfiles"], pp["catalog"], byObi=True )
 
 
 if __name__ == "__main__":

--- a/ciao-4.10/contrib/bin/obsid_search_csc
+++ b/ciao-4.10/contrib/bin/obsid_search_csc
@@ -78,9 +78,9 @@ def parse_inputs( pars ):
     else:
         retval["outfile"] = pars["outfile"]
 
-    if "cur" == pars["catalog"] and "none" != pars["download"]:
-        pars["download"] = "none"
-        verb0("WARNING: files cannot yet be retrieved using the current catalog release")
+    #~ if "cur" == pars["catalog"] and "none" != pars["download"]:
+        #~ pars["download"] = "none"
+        #~ verb0("WARNING: files cannot yet be retrieved using the current catalog release")
     
     if "none" == pars["download"]:
         retval["getfiles"] = False

--- a/ciao-4.10/contrib/bin/search_csc
+++ b/ciao-4.10/contrib/bin/search_csc
@@ -110,9 +110,9 @@ def parse_inputs( pars ):
         retval["limsens"] = False
         verb0("WARNING: limiting sensitivity data is not available for the current catalog release")
 
-    if "cur" == pars["catalog"] and "none" != pars["download"]:
-        pars["download"] = "none"
-        verb0("WARNING: files cannot yet be retrieved using the current catalog release")
+    #~ if "cur" == pars["catalog"] and "none" != pars["download"]:
+        #~ pars["download"] = "none"
+        #~ verb0("WARNING: files cannot yet be retrieved using the current catalog release")
 
     if "none" == pars["download"]:
         retval["getfiles"] = False

--- a/ciao-4.10/contrib/bin/search_csc
+++ b/ciao-4.10/contrib/bin/search_csc
@@ -1,26 +1,26 @@
 #!/usr/bin/env python
-#
-# Copyright (C) 2013, 2018 Smithsonian Astrophysical Observatory
-#
+# 
+# Copyright (C) 2013 Smithsonian Astrophysical Observatory
+# 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-#
+# 
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-#
+# 
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
+# 
 
 from __future__ import print_function
 
 toolname = "search_csc"
-__revision__ = "06 March 2018"
+__revision__ = "05 December 2017"
 
 import sys
 
@@ -29,17 +29,13 @@ import os
 try:
     if not __file__.startswith(os.environ['ASCDS_INSTALL']):
         _thisdir = os.path.dirname(__file__)
-        _libname = "python{}.{}".format(sys.version_info.major,
-                                        sys.version_info.minor)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
+        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib/python2.7/site-packages'))
         if os.path.isdir(_pathdir):
-            os.sys.path.insert(1, _pathdir)
+            os.sys.path.insert(0, _pathdir)
         else:
             print("*** WARNING: no {}".format(_pathdir))
-
-        del _libname
         del _pathdir
-        del _thisdir
+        del _thisdir        
 except KeyError:
     raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
 
@@ -65,13 +61,13 @@ def parse_inputs( pars ):
     import coords.resolver as resolver
     retval = {}
 
-    if not ',' in pars["pos"]:
+    if not ',' in pars["pos"]:        
         (ra_deg,dec_deg,csys) = resolver.identify_name( pars["pos"] )
         if not 'ICRS' == csys:
             raise ValueError("Unsupported format '{}' returned by the name resolver. Please contact the CXC HelpDesk.".format(csys))
         verb2("Resolved {} to ra={} dec={}".format(pars["pos"],ra_deg, dec_deg))
     else:
-        ra_deg,dec_deg = pars["pos"].split(',') #map(float, pars["pos"].split(","))
+        ra_deg,dec_deg = pars["pos"].split(',') #map(float, pars["pos"].split(",")) 
     retval["ra_deg"] = str(ra_deg).strip()
     retval["dec_deg"] = str(dec_deg).strip()
 
@@ -84,12 +80,12 @@ def parse_inputs( pars ):
     retval["radunit"] = pars["radunit"]
 
     if "INDEF" == pars["columns"] or len(pars["columns"]) == 0:
-        retval["columns"] = csc.get_default_columns()
+        retval["columns"] = csc.get_default_columns(pars["catalog"])
     else:
         import stk as stk
         retval["columns"] = stk.build( pars["columns"] )
-        retval["columns"] = csc.check_required_names( retval["columns"] )
-
+        retval["columns"] = csc.check_required_names( retval["columns"], pars["catalog"] )
+    
     if 'none' == pars["outfile"].lower():
         retval["outfile"] = None
     else:
@@ -104,7 +100,15 @@ def parse_inputs( pars ):
         if len(retval["mybands"]) == 0:
             raise ValueError("No recognized energy band supplied")
 
+
     retval["limsens"] = ("yes" == pars["sensitivity"] )
+    if "cur" == pars["catalog"] and retval["limsens"] is True:
+        retval["limsens"] = False
+        verb0("WARNING: limiting sensitivity data is not available for the current catalog release")
+
+    if "cur" == pars["catalog"] and "none" != pars["download"]:
+        pars["download"] = "none"
+        verb0("WARNING: files cannot yet be retrieved using the current catalog release")
 
     if "none" == pars["download"]:
         retval["getfiles"] = False
@@ -116,24 +120,25 @@ def parse_inputs( pars ):
 
         #-- Check file types
         if len(pars["filetypes"] ) == 0:
-            # if filetypes is blank, use all of them
+            # if filetypes is blank, use all of them 
             retval["myfiles"] = ",".join( csc.fileTypes.keys() )
         else:
             retval["myfiles"] = csc.check_filetypes( pars["filetypes"] )
             if len(retval["myfiles"]) == 0:
                 raise ValueError("No recognized file types supplied")
-
+    
     retval["clobber"] = ( pars["clobber"] == "yes" )
-
+    retval["catalog"] = pars["catalog"]
+    
     return retval
 
 def summarize_sensitivity( ra, dec, bands ):
     """
-
+    
     """
     from coords.format import sex2deg
-    ra_deg,dec_deg = sex2deg(ra, dec )
-
+    ra_deg,dec_deg = sex2deg(ra, dec ) 
+    
     page = csc.query_csc1_limsens( ra_deg, dec_deg )
     vals, units = csc.parse_limsens( page )
 
@@ -141,13 +146,13 @@ def summarize_sensitivity( ra, dec, bands ):
     for b in bands.split(","):
         if b in vals:
             verb0("  "+b+' band : {} [{}]'.format( vals[b], units ))
+    
+    
 
+    
 
-
-
-
-
-
+    
+    
 
 #
 # Main Routine
@@ -157,15 +162,16 @@ def main():
     """
     """
     # get parameters
-    pars = get_params(toolname, "rw", sys.argv,
+    pars = get_params(toolname, "rw", sys.argv, 
       verbose={"set":lw.set_verbosity, "cmd":verb1} )
     pp = parse_inputs( pars )
 
     #
     # Query catalog by position
     #
-    mypage = csc.search_src_by_ra_dec( pp["ra_deg"], pp["dec_deg"], pp["radius_arcmin"], pp["columns"] )
-    csc.save_results( mypage, pp["outfile"], pp["clobber"] )
+    mypage = csc.search_src_by_ra_dec( pp["ra_deg"], pp["dec_deg"], 
+        pp["radius_arcmin"], pp["columns"], pp["catalog"] )
+    csc.save_results( mypage, pp["outfile"], pp["clobber"] )    
 
     #
     # Print results
@@ -175,12 +181,12 @@ def main():
 
 
     mysrcs = csc.parse_csc_result( mypage )
-    xtra = csc.extra_cols_to_summarize( mysrcs, pars["columns"])
+    xtra = csc.extra_cols_to_summarize( mysrcs, pars["columns"], pp["catalog"])
     csc.summarize_results( mysrcs, units=pp["radunit"], extracols=xtra )
 
     #
     # Retrieve the files if asked
-    #
+    # 
     if pp["getfiles"]:
         csc.retrieve_files( mysrcs, pp["root"], pp["myfiles"], pp["mybands"], pp["getfiles"] )
 
@@ -192,3 +198,4 @@ if __name__ == "__main__":
         print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
+    

--- a/ciao-4.10/contrib/bin/search_csc
+++ b/ciao-4.10/contrib/bin/search_csc
@@ -125,9 +125,9 @@ def parse_inputs( pars ):
         #-- Check file types
         if len(pars["filetypes"] ) == 0:
             # if filetypes is blank, use all of them 
-            retval["myfiles"] = ",".join( csc.fileTypes.keys() )
+            retval["myfiles"] = ",".join( csc.fileTypes[pars["catalog"]].keys() )
         else:
-            retval["myfiles"] = csc.check_filetypes( pars["filetypes"] )
+            retval["myfiles"] = csc.check_filetypes( pars["filetypes"], pars["catalog"] )
             if len(retval["myfiles"]) == 0:
                 raise ValueError("No recognized file types supplied")
     
@@ -192,7 +192,7 @@ def main():
     # Retrieve the files if asked
     # 
     if pp["getfiles"]:
-        csc.retrieve_files( mysrcs, pp["root"], pp["myfiles"], pp["mybands"], pp["getfiles"] )
+        csc.retrieve_files( mysrcs, pp["root"], pp["myfiles"], pp["mybands"], pp["getfiles"], pp["catalog"] )
 
 
 if __name__ == "__main__":

--- a/ciao-4.10/contrib/bin/search_csc
+++ b/ciao-4.10/contrib/bin/search_csc
@@ -1,26 +1,26 @@
 #!/usr/bin/env python
-# 
-# Copyright (C) 2013 Smithsonian Astrophysical Observatory
-# 
+#
+# Copyright (C) 2013, 2018 Smithsonian Astrophysical Observatory
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 
 from __future__ import print_function
 
 toolname = "search_csc"
-__revision__ = "05 December 2017"
+__revision__ = "06 March 2018"
 
 import sys
 
@@ -29,13 +29,17 @@ import os
 try:
     if not __file__.startswith(os.environ['ASCDS_INSTALL']):
         _thisdir = os.path.dirname(__file__)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib/python2.7/site-packages'))
+        _libname = "python{}.{}".format(sys.version_info.major,
+                                        sys.version_info.minor)
+        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
         if os.path.isdir(_pathdir):
-            os.sys.path.insert(0, _pathdir)
+            os.sys.path.insert(1, _pathdir)
         else:
             print("*** WARNING: no {}".format(_pathdir))
+
+        del _libname
         del _pathdir
-        del _thisdir        
+        del _thisdir
 except KeyError:
     raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
 

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
@@ -148,93 +148,110 @@ o.var_index_b,
 o.var_index_w
 """.replace("\n", "").split(",")
 
-master_source_basic_summary="""
-m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,
-m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,
-m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,
-m.flux_aper_hilim_w
-""".replace("\n", "").split(",")
 
-master_source_summary="""
-m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
-m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
-m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.extent_flag,
-m.hard_hm,m.hard_hm_lolim,m.hard_hm_hilim,m.hard_ms,m.hard_ms_lolim,
-m.hard_ms_hilim,m.var_intra_index_b,m.var_inter_index_b,
-m.var_intra_index_w,m.var_inter_index_w 
-""".replace("\n", "").split(",")
+csc1_columns = { 
+    'master_source_basic_summary' : """
+    m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,
+    m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,
+    m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,
+    m.flux_aper_hilim_w
+    """.replace("\n", "").replace(" ","").split(",") ,
+    
+    'master_source_summary' : """
+    m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
+    m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
+    m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.extent_flag,
+    m.hard_hm,m.hard_hm_lolim,m.hard_hm_hilim,m.hard_ms,m.hard_ms_lolim,
+    m.hard_ms_hilim,m.var_intra_index_b,m.var_inter_index_b,
+    m.var_intra_index_w,m.var_inter_index_w 
+    """.replace("\n", "").replace(" ","").split(",") ,
 
-master_source_photometry="""
-m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
-m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
-m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.flux_aper_s,
-m.flux_aper_lolim_s,m.flux_aper_hilim_s,m.flux_aper_m,
-m.flux_aper_lolim_m,m.flux_aper_hilim_m,m.flux_aper_h,
-m.flux_aper_lolim_h,m.flux_aper_hilim_h,m.flux_powlaw_aper_b,
-m.flux_powlaw_aper_lolim_b,m.flux_powlaw_aper_hilim_b,
-m.flux_powlaw_aper_w,m.flux_powlaw_aper_lolim_w,
-m.flux_powlaw_aper_hilim_w,m.flux_bb_aper_b,m.flux_bb_aper_lolim_b,
-m.flux_bb_aper_hilim_b,m.flux_bb_aper_w,m.flux_bb_aper_lolim_w,
-m.flux_bb_aper_hilim_w 
-""".replace("\n", "").split(",")
+    'master_source_photometry':"""
+    m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
+    m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
+    m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.flux_aper_s,
+    m.flux_aper_lolim_s,m.flux_aper_hilim_s,m.flux_aper_m,
+    m.flux_aper_lolim_m,m.flux_aper_hilim_m,m.flux_aper_h,
+    m.flux_aper_lolim_h,m.flux_aper_hilim_h,m.flux_powlaw_aper_b,
+    m.flux_powlaw_aper_lolim_b,m.flux_powlaw_aper_hilim_b,
+    m.flux_powlaw_aper_w,m.flux_powlaw_aper_lolim_w,
+    m.flux_powlaw_aper_hilim_w,m.flux_bb_aper_b,m.flux_bb_aper_lolim_b,
+    m.flux_bb_aper_hilim_b,m.flux_bb_aper_w,m.flux_bb_aper_lolim_w,
+    m.flux_bb_aper_hilim_w 
+    """.replace("\n", "").replace(" ","").split(","),
 
-master_source_variability="""
-m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
-m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
-m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,
-m.var_intra_prob_b,m.var_intra_index_b,m.var_inter_prob_b,
-m.var_inter_index_b,m.var_intra_prob_w,m.var_intra_index_w,
-m.var_inter_prob_w,m.var_inter_index_w,m.var_intra_prob_s,
-m.var_intra_index_s,m.var_inter_prob_s,m.var_inter_index_s,
-m.var_intra_prob_m,m.var_intra_index_m,m.var_inter_prob_m,
-m.var_inter_index_m,m.var_intra_prob_h,m.var_intra_index_h,
-m.var_inter_prob_h,m.var_inter_index_h
-""".replace("\n", "").split(",")
+    'master_source_variability': """
+    m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
+    m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
+    m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,
+    m.var_intra_prob_b,m.var_intra_index_b,m.var_inter_prob_b,
+    m.var_inter_index_b,m.var_intra_prob_w,m.var_intra_index_w,
+    m.var_inter_prob_w,m.var_inter_index_w,m.var_intra_prob_s,
+    m.var_intra_index_s,m.var_inter_prob_s,m.var_inter_index_s,
+    m.var_intra_prob_m,m.var_intra_index_m,m.var_inter_prob_m,
+    m.var_inter_index_m,m.var_intra_prob_h,m.var_intra_index_h,
+    m.var_inter_prob_h,m.var_inter_index_h
+    """.replace("\n", "").replace(" ","").split(","),
 
-source_observation_summary="""
-m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
-m.significance,m.flux_aper_b,m.flux_aper_lolim_b,
-m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,
-m.flux_aper_hilim_w,o.obsid,o.obi,o.region_id,o.theta,o.phi,o.livetime,
-o.conf_code,o.sat_src_flag,o.flux_significance_b,
-o.flux_significance_w,o.detector,o.extent_code,o.mjr_axis_raw_b,
-o.mnr_axis_raw_b,o.pos_angle_raw_b,o.mjr_axis_raw_w,o.mnr_axis_raw_w,
-o.pos_angle_raw_w,o.cnts_aper_b,o.cnts_aper_w,o.src_rate_aper_b,
-o.src_rate_aper_w,o.flux_aper_b,o.flux_aper_lolim_b,
-o.flux_aper_hilim_b,o.flux_aper_w,o.flux_aper_lolim_w,
-o.flux_aper_hilim_w,o.hard_hm,o.hard_hm_lolim,o.hard_hm_hilim,
-o.hard_ms,o.hard_ms_hilim,o.hard_ms_lolim,o.var_index_b,o.var_index_w 
-""".replace("\n", "").split(",")
+    'source_observation_summary': """
+    m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
+    m.significance,m.flux_aper_b,m.flux_aper_lolim_b,
+    m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,
+    m.flux_aper_hilim_w,o.obsid,o.obi,o.region_id,o.theta,o.phi,o.livetime,
+    o.conf_code,o.sat_src_flag,o.flux_significance_b,
+    o.flux_significance_w,o.detector,o.extent_code,o.mjr_axis_raw_b,
+    o.mnr_axis_raw_b,o.pos_angle_raw_b,o.mjr_axis_raw_w,o.mnr_axis_raw_w,
+    o.pos_angle_raw_w,o.cnts_aper_b,o.cnts_aper_w,o.src_rate_aper_b,
+    o.src_rate_aper_w,o.flux_aper_b,o.flux_aper_lolim_b,
+    o.flux_aper_hilim_b,o.flux_aper_w,o.flux_aper_lolim_w,
+    o.flux_aper_hilim_w,o.hard_hm,o.hard_hm_lolim,o.hard_hm_hilim,
+    o.hard_ms,o.hard_ms_hilim,o.hard_ms_lolim,o.var_index_b,o.var_index_w 
+    """.replace("\n", "").replace(" ","").split(","), 
 
-source_observation_photometry="""
-m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
-m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
-m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,o.obsid,o.obi,
-o.region_id,o.theta,o.phi,o.livetime,o.conf_code,o.sat_src_flag,
-o.flux_significance_b,o.flux_significance_w,o.cnts_aper_b,
-o.cnts_aper_w,o.cnts_aper_s,o.cnts_aper_m,o.cnts_aper_h,
-o.src_rate_aper_b,o.src_rate_aper_w,o.src_rate_aper_s,
-o.src_rate_aper_m,o.src_rate_aper_h,o.flux_aper_b,o.flux_aper_lolim_b,
-o.flux_aper_hilim_b,o.flux_aper_w,o.flux_aper_lolim_w,
-o.flux_aper_hilim_w,o.flux_aper_s,o.flux_aper_lolim_s,
-o.flux_aper_hilim_s,o.flux_aper_m,o.flux_aper_lolim_m,
-o.flux_aper_hilim_m,o.flux_aper_h,o.flux_aper_lolim_h,
-o.flux_aper_hilim_h 
-""".replace("\n", "").split(",")
+    'source_observation_photometry' : """
+    m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
+    m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
+    m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,o.obsid,o.obi,
+    o.region_id,o.theta,o.phi,o.livetime,o.conf_code,o.sat_src_flag,
+    o.flux_significance_b,o.flux_significance_w,o.cnts_aper_b,
+    o.cnts_aper_w,o.cnts_aper_s,o.cnts_aper_m,o.cnts_aper_h,
+    o.src_rate_aper_b,o.src_rate_aper_w,o.src_rate_aper_s,
+    o.src_rate_aper_m,o.src_rate_aper_h,o.flux_aper_b,o.flux_aper_lolim_b,
+    o.flux_aper_hilim_b,o.flux_aper_w,o.flux_aper_lolim_w,
+    o.flux_aper_hilim_w,o.flux_aper_s,o.flux_aper_lolim_s,
+    o.flux_aper_hilim_s,o.flux_aper_m,o.flux_aper_lolim_m,
+    o.flux_aper_hilim_m,o.flux_aper_h,o.flux_aper_lolim_h,
+    o.flux_aper_hilim_h 
+    """.replace("\n", "").replace(" ","").split(","), 
 
-source_observation_variability="""
-m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
-m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
-m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,o.obsid,o.obi,
-o.region_id,o.theta,o.phi,o.livetime,o.conf_code,o.sat_src_flag,
-o.flux_significance_b,o.flux_significance_w,o.dither_warning_flag,
-o.ks_prob_b,o.kp_prob_b,o.var_prob_b,o.var_index_b,o.var_mean_b,
-o.var_sigma_b,o.ks_prob_w,o.kp_prob_w,o.var_prob_w,o.var_index_w,
-o.var_mean_w,o.var_sigma_w,o.ks_prob_s,o.kp_prob_s,o.var_prob_s,
-o.var_index_s,o.var_mean_s,o.var_sigma_s,o.ks_prob_m,o.kp_prob_m,
-o.var_prob_m,o.var_index_m,o.var_mean_m,o.var_sigma_m,o.ks_prob_h,
-o.kp_prob_h,o.var_prob_h,o.var_index_h,o.var_mean_h,o.var_sigma_h 
-""".replace("\n", "").split(",")
+    'source_observation_variability' :"""
+    m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
+    m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
+    m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,o.obsid,o.obi,
+    o.region_id,o.theta,o.phi,o.livetime,o.conf_code,o.sat_src_flag,
+    o.flux_significance_b,o.flux_significance_w,o.dither_warning_flag,
+    o.ks_prob_b,o.kp_prob_b,o.var_prob_b,o.var_index_b,o.var_mean_b,
+    o.var_sigma_b,o.ks_prob_w,o.kp_prob_w,o.var_prob_w,o.var_index_w,
+    o.var_mean_w,o.var_sigma_w,o.ks_prob_s,o.kp_prob_s,o.var_prob_s,
+    o.var_index_s,o.var_mean_s,o.var_sigma_s,o.ks_prob_m,o.kp_prob_m,
+    o.var_prob_m,o.var_index_m,o.var_mean_m,o.var_sigma_m,o.ks_prob_h,
+    o.kp_prob_h,o.var_prob_h,o.var_index_h,o.var_mean_h,o.var_sigma_h 
+    """.replace("\n", "").replace(" ","").split(",")
+}
+
+
+csc2_columns = { 
+  'master_source_basic_summary' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w'.split(","),
+  'master_source_summary' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.extent_flag,m.hard_hm,m.hard_hm_lolim,m.hard_hm_hilim,m.hard_ms,m.hard_ms_lolim,m.hard_ms_hilim,m.var_intra_index_b,m.var_inter_index_b,m.var_intra_index_w,m.var_inter_index_w'.split(","),
+  'master_source_photometry' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.flux_aper_s,m.flux_aper_lolim_s,m.flux_aper_hilim_s,m.flux_aper_m,m.flux_aper_lolim_m,m.flux_aper_hilim_m,m.flux_aper_h,m.flux_aper_lolim_h,m.flux_aper_hilim_h,m.flux_powlaw_aper_b,m.flux_powlaw_aper_lolim_b,m.flux_powlaw_aper_hilim_b,m.flux_powlaw_aper_w,m.flux_powlaw_aper_lolim_w,m.flux_powlaw_aper_hilim_w,m.flux_bb_aper_b,m.flux_bb_aper_lolim_b,m.flux_bb_aper_hilim_b,m.flux_bb_aper_w,m.flux_bb_aper_lolim_w,m.flux_bb_aper_hilim_w'.split(","),
+  'master_source_variability' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.var_intra_prob_b,m.var_intra_index_b,m.var_inter_prob_b,m.var_inter_index_b,m.var_intra_prob_w,m.var_intra_index_w,m.var_inter_prob_w,m.var_inter_index_w,m.var_intra_prob_s,m.var_intra_index_s,m.var_inter_prob_s,m.var_inter_index_s,m.var_intra_prob_m,m.var_intra_index_m,m.var_inter_prob_m,m.var_inter_index_m,m.var_intra_prob_h,m.var_intra_index_h,m.var_inter_prob_h,m.var_inter_index_h'.split(","),
+  'stack_source_summary' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,s.detect_stack_id,s.region_id,s.livetime,s.conf_code,s.sat_src_flag,s.flux_significance_b,s.flux_significance_w,s.extent_code,s.major_axis_b,s.minor_axis_b,s.pos_angle_b,s.major_axis_w,s.minor_axis_w,s.pos_angle_w,s.src_rate_aper_b,s.src_rate_aper_w,s.flux_aper_b,s.flux_aper_lolim_b,s.flux_aper_hilim_b,s.flux_aper_w,s.flux_aper_lolim_w,s.flux_aper_hilim_w,s.hard_hm,s.hard_hm_lolim,s.hard_hm_hilim,s.hard_ms,s.hard_ms_hilim,s.hard_ms_lolim'.split(","),
+  'stack_source_photometry' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,s.detect_stack_id,s.region_id,s.livetime,s.conf_code,s.sat_src_flag,s.flux_significance_b,s.flux_significance_w,s.src_rate_aper_b,s.src_rate_aper_w,s.src_rate_aper_s,s.src_rate_aper_m,s.src_rate_aper_h,s.flux_aper_b,s.flux_aper_lolim_b,s.flux_aper_hilim_b,s.flux_aper_w,s.flux_aper_lolim_w,s.flux_aper_hilim_w,s.flux_aper_s,s.flux_aper_lolim_s,s.flux_aper_hilim_s,s.flux_aper_m,s.flux_aper_lolim_m,s.flux_aper_hilim_m,s.flux_aper_h,s.flux_aper_lolim_h,s.flux_aper_hilim_h'.split(","),
+  'source_observation_summary' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,o.obsid,o.obi,o.region_id,o.theta,o.phi,o.livetime,o.conf_code,o.sat_src_flag,o.flux_significance_b,o.flux_significance_w,o.detector,o.extent_code,o.major_axis_b,o.minor_axis_b,o.pos_angle_b,o.major_axis_w,o.minor_axis_w,o.pos_angle_w,o.cnts_aper_b,o.cnts_aper_w,o.src_rate_aper_b,o.src_rate_aper_w,o.flux_aper_b,o.flux_aper_lolim_b,o.flux_aper_hilim_b,o.flux_aper_w,o.flux_aper_lolim_w,o.flux_aper_hilim_w,o.hard_hm,o.hard_hm_lolim,o.hard_hm_hilim,o.hard_ms,o.hard_ms_hilim,o.hard_ms_lolim,o.var_index_b,o.var_index_w'.split(","),
+  'source_observation_photometry' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,o.obsid,o.obi,o.region_id,o.theta,o.phi,o.livetime,o.conf_code,o.sat_src_flag,o.flux_significance_b,o.flux_significance_w,o.cnts_aper_b,o.cnts_aper_w,o.cnts_aper_s,o.cnts_aper_m,o.cnts_aper_h,o.src_rate_aper_b,o.src_rate_aper_w,o.src_rate_aper_s,o.src_rate_aper_m,o.src_rate_aper_h,o.flux_aper_b,o.flux_aper_lolim_b,o.flux_aper_hilim_b,o.flux_aper_w,o.flux_aper_lolim_w,o.flux_aper_hilim_w,o.flux_aper_s,o.flux_aper_lolim_s,o.flux_aper_hilim_s,o.flux_aper_m,o.flux_aper_lolim_m,o.flux_aper_hilim_m,o.flux_aper_h,o.flux_aper_lolim_h,o.flux_aper_hilim_h'.split(","),
+  'source_observation_variability' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,o.obsid,o.obi,o.region_id,o.theta,o.phi,o.livetime,o.conf_code,o.sat_src_flag,o.flux_significance_b,o.flux_significance_w,o.dither_warning_flag,o.ks_prob_b,o.kp_prob_b,o.var_prob_b,o.var_index_b,o.var_mean_b,o.var_sigma_b,o.ks_prob_w,o.kp_prob_w,o.var_prob_w,o.var_index_w,o.var_mean_w,o.var_sigma_w,o.ks_prob_s,o.kp_prob_s,o.var_prob_s,o.var_index_s,o.var_mean_s,o.var_sigma_s,o.ks_prob_m,o.kp_prob_m,o.var_prob_m,o.var_index_m,o.var_mean_m,o.var_sigma_m,o.ks_prob_h,o.kp_prob_h,o.var_prob_h,o.var_index_h,o.var_mean_h,o.var_sigma_h'.split(",")
+}
+
 
 
 required_cols="""
@@ -277,9 +294,9 @@ def get_radec_lim( ra_deg, dec_deg, radius_arcmin ):
         # Need to change query ra between A and B to
         # ra > (A mod 360) OR ra < (B mod 360)
         #
-        ra_condition = "ra > {0:.8f} OR ra < {1:.8f}".format( ra_min % 360.0, ra_max % 360.0 )
+        ra_condition = "m.ra > {0:.8f} OR m.ra < {1:.8f}".format( ra_min % 360.0, ra_max % 360.0 )
     else:
-        ra_condition = "ra BETWEEN {0:.8f} AND {1:.8f}".format( ra_min, ra_max )
+        ra_condition = "m.ra BETWEEN {0:.8f} AND {1:.8f}".format( ra_min, ra_max )
 
     dec_min = dec_deg - radius_deg
     dec_max = dec_deg + radius_deg
@@ -287,8 +304,8 @@ def get_radec_lim( ra_deg, dec_deg, radius_arcmin ):
     if ( dec_min < -90 ) | ( dec_max > 90 ):
         #Crosses pole, so all ra's are allowed.  
         #CSCView is OK w/ dec outside -90:90 
-        ra_condition = "ra >= 0"    
-    dec_condition = "dec BETWEEN {0:.8f} AND {1:.8f}".format( dec_min, dec_max)
+        ra_condition = "m.ra >= 0"    
+    dec_condition = "m.dec BETWEEN {0:.8f} AND {1:.8f}".format( dec_min, dec_max)
     
     return ra_condition, dec_condition
 
@@ -365,6 +382,56 @@ def cone_query_cli_cscview( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_co
     return page,cols
 
 
+def cone_query_cli_cscview_ver2( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_condition, columns):
+    """
+    Perform the cone search query on the CSC using the getProperties API.
+
+    Because we add the dbo.separation column, sepn, that add +1 to all
+
+    """
+
+    resource="http://cda.cfa.harvard.edu/csccli/getProperties"
+
+    selstr="dbo.separation(m.ra,m.dec,{0},{1}) as sepn,".format(ra_deg, dec_deg)
+    selstr+=",".join(columns)
+
+    query_string="""
+        SELECT 
+          {5}
+        FROM 
+          master_source m , master_stack_assoc a , observation_source o , stack_observation_assoc b , stack_source s 
+        WHERE 
+          ((( ({3}) AND 
+          ({4})) AND   
+          dbo.cone_distance(m.ra,m.dec,{0:.8f},{1:.8f})<={2:.8f})) AND
+          (m.name = a.name) AND (s.detect_stack_id = a.detect_stack_id and s.region_id = a.region_id) AND (s.detect_stack_id = b.detect_stack_id and s.region_id = b.region_id) AND (o.obsid = b.obsid and o.obi = b.obi and o.region_id = b.region_id)
+        ORDER BY
+          name ASC
+        """.format( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_condition, selstr)
+
+    verb5("CSCCLI query string is {}\n".format(query_string))
+
+    vals = {
+        'query' : " ".join(query_string.split()) , # removes excess white spaces
+        'version' : 'cur',
+        'coordFormat' : 'decimal',
+        'nullAppearance' : 'NaN',
+        } 
+
+
+
+    page = make_URL_request( resource, vals )
+    page = page.decode("ascii")
+    
+    if "Error executing query:" in page:
+        k=page.replace( "\n", " ")
+        raise Exception( k )
+        
+    cols = ["sep"]
+    cols.extend( columns )
+    return page,cols
+
+
 def obsid_query_cli_cscview( obsid, columns ):
     """
     Perform the cone search query on the CSC using the getProperties API.
@@ -393,6 +460,49 @@ def obsid_query_cli_cscview( obsid, columns ):
         'query' : " ".join(query_string.split()) , # removes excess white spaces
         'coordFormat' : 'decimal',
         'nullAppearance' : 'NaN'        
+        } 
+
+    page = make_URL_request( resource, vals )
+    page = page.decode("ascii")
+    if "Error executing query:" in page:
+        k=page.replace( "\n", " ")
+        raise Exception( k )
+        
+
+    cols = columns
+    
+    return page,cols
+
+
+def obsid_query_cli_cscview_ver2( obsid, columns ):
+    """
+    Perform the cone search query on the CSC using the getProperties API.
+    
+    """
+
+    resource="http://cda.cfa.harvard.edu/csccli/getProperties"
+
+    selstr = ",".join(columns)
+
+    query_string="""
+        SELECT
+          {1}
+        FROM 
+          master_source m , master_stack_assoc a , observation_source o , stack_observation_assoc b , stack_source s 
+        WHERE 
+          ((o.obsid IN ({0}))) AND 
+          (m.name = a.name) AND (s.detect_stack_id = a.detect_stack_id and s.region_id = a.region_id) AND (s.detect_stack_id = b.detect_stack_id and s.region_id = b.region_id) AND (o.obsid = b.obsid and o.obi = b.obi and o.region_id = b.region_id)
+        ORDER BY
+          name ASC
+        """.format( obsid, selstr)
+
+    verb5("CSCCLI query string is {}\n".format(query_string))
+
+    vals = {
+        'query' : " ".join(query_string.split()) , # removes excess white spaces
+        'coordFormat' : 'decimal',
+        'nullAppearance' : 'NaN',
+        'version' : 'cur'
         } 
 
     page = make_URL_request( resource, vals )
@@ -491,7 +601,7 @@ def summarize_source_short( results, units, extracols=None ):
     summarize_properties( cols, results )
 
 
-def extra_cols_to_summarize( mysrcs, requested_cols ):
+def extra_cols_to_summarize( mysrcs, requested_cols, cat_ver ):
     """
     Match requested cols to mypage[1] (columns) returned by cscview.
     The 'm.' and 'o.' are dropped and/or replaced by obi_ or mstr_
@@ -502,7 +612,7 @@ def extra_cols_to_summarize( mysrcs, requested_cols ):
     if "INDEF" == requested_cols or len(requested_cols) == 0:
         return None
 
-    rc_stk = expand_standard_cols(stk.build( requested_cols ))
+    rc_stk = expand_standard_cols(stk.build( requested_cols ), cat_ver)
 
     if len(mysrcs) == 0:
         return None
@@ -527,6 +637,8 @@ def extra_cols_to_summarize( mysrcs, requested_cols ):
             retval.append( "obi_"+rc_parts[1])
         elif rc_parts[0] == 'm' and "mstr_"+rc_parts[1] in row:
             retval.append( "mstr_"+rc_parts[1])
+        elif rc_parts[0] == 's' and "stk_"+rc_parts[1] in row:
+            retval.append( "stk_"+rc_parts[1])
         else:
             raise IOError("Column {} was not returned by cscview".format( rc ))
 
@@ -646,22 +758,35 @@ def save_results( page_and_cols, outfile, clobber ):
         fp.write( p2 )
     
 
-def search_src_by_ra_dec( ra, dec, radius_arcmin, columns ):
+def search_src_by_ra_dec( ra, dec, radius_arcmin, columns, cat_ver ):
     """
     Perform a cone search on CSC CLI.
     """    
     from coords.format import sex2deg
     ra_deg,dec_deg = sex2deg(ra, dec ) 
     ra_condition, dec_condition = get_radec_lim( ra_deg, dec_deg, radius_arcmin )
-    page = cone_query_cli_cscview( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_condition, columns)
+
+    if "csc1" == cat_ver:
+        page = cone_query_cli_cscview( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_condition, columns)
+    elif "cur" == cat_ver:
+        page = cone_query_cli_cscview_ver2( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_condition, columns)
+    else:
+        raise ValueError("Unknown catalog version")
+
     return page
     
 
-def search_src_by_obsid( obsid, columns ):
+def search_src_by_obsid( obsid, columns, cat_ver ):
     """
     Perform a obsid search on CSC CLI.
     """    
-    page = obsid_query_cli_cscview( obsid, columns )
+
+    if 'csc1' == cat_ver :
+        page = obsid_query_cli_cscview( obsid, columns )
+    elif 'cur' == cat_ver :
+        page = obsid_query_cli_cscview_ver2( obsid, columns )
+    else:
+        raise ValueError("Unknown catalog version")
     return page
 
 
@@ -1028,10 +1153,15 @@ def check_bandtypes( alist ):
     
     return rr
 
-def get_default_columns():
+def get_default_columns(cat_version=None):
     """
     The default set of columns to return
     """
+    retval = default_cols
+
+    if "cur" == cat_version:
+        retval = default_cols # may be diff for ver2
+
     return default_cols
 
 
@@ -1044,15 +1174,31 @@ def append_cols_check_conflict( retval, val ):
     it will not cause conflict.    
     """
     vv = val.split(".")
+
+    ## TODO: replace dups in likely stack, detect stack, ...
     
     if vv[0] == 'o':
         if "m.{}".format(vv[1]) in retval:
             verb2( "OBI column {} has same name as master column and has been renamed obi_{}".format(vv[1],vv[1]))
             val = val + " as obi_{}".format(vv[1])
+        elif "s.{}".format(vv[1]) in retval:
+            verb2( "OBI column {} has same name as stack column and has been renamed obi_{}".format(vv[1],vv[1]))
+            val = val + " as obi_{}".format(vv[1])
+
     elif vv[0] == 'm':
         if "o.{}".format(vv[1]) in retval:
             verb2( "Master column {} has same name as obi column and has been rename mstr_{}".format(vv[1],vv[1]))
             val = val + " as mstr_{}".format(vv[1])
+        if "s.{}".format(vv[1]) in retval:
+            verb2( "Master column {} has same name as stack column and has been rename mstr_{}".format(vv[1],vv[1]))
+            val = val + " as mstr_{}".format(vv[1])
+    elif vv[0] == 's':
+        if "o.{}".format(vv[1]) in retval:
+            verb2( "Stack column {} has same name as obi column and has been rename stk_{}".format(vv[1],vv[1]))
+            val = val + " as stk_{}".format(vv[1])
+        if "m.{}".format(vv[1]) in retval:
+            verb2( "Stack column {} has same name as master column and has been rename stk_{}".format(vv[1],vv[1]))
+            val = val + " as stk_{}".format(vv[1])
     else:
         pass
     
@@ -1060,19 +1206,32 @@ def append_cols_check_conflict( retval, val ):
         retval.append(val)
     
 
-def expand_standard_cols( cols ):
+def expand_standard_cols( cols, cat_version=None ):
     """
     The catalog contains some default column definitions.  These
     are avialable as tokens
     """
-    check_list = { "MSBS" : master_source_basic_summary ,
-                   "MSS"  : master_source_summary,
-                   "MSP"  : master_source_photometry,
-                   "MSV"  : master_source_variability,
-                   "SOS"  : source_observation_summary,
-                   "SOP"  : source_observation_photometry,
-                   "SOV"  : source_observation_variability
+    check_list = { "MSBS" : csc1_columns["master_source_basic_summary"] ,
+                   "MSS"  : csc1_columns["master_source_summary"],
+                   "MSP"  : csc1_columns["master_source_photometry"],
+                   "MSV"  : csc1_columns["master_source_variability"],
+                   "SOS"  : csc1_columns["source_observation_summary"],
+                   "SOP"  : csc1_columns["source_observation_photometry"],
+                   "SOV"  : csc1_columns["source_observation_variability"]
                    }
+
+    if "cur" == cat_version:
+        check_list = { "MSBS" : csc2_columns["master_source_basic_summary"] ,
+                       "MSS"  : csc2_columns["master_source_summary"],
+                       "MSP"  : csc2_columns["master_source_photometry"],
+                       "MSV"  : csc2_columns["master_source_variability"],
+                       "SOS"  : csc2_columns["source_observation_summary"],
+                       "SOP"  : csc2_columns["source_observation_photometry"],
+                       "SOV"  : csc2_columns["source_observation_variability"],
+                       "SSS"  : csc2_columns["stack_source_summary"],
+                       "SSP"  : csc2_columns["stack_source_photometry"]
+                       }
+
     retval = []
     for cc in cols:
         # if column is special token, then expand it
@@ -1086,13 +1245,13 @@ def expand_standard_cols( cols ):
         
 
 
-def check_required_names( cols ):
+def check_required_names( cols, cat_version=None ):
     """
     The returned columns must include a subset that are needed to
     do the rest of the parsing/etc, especially to retrieve
     files.
     """
-    c2 = expand_standard_cols( cols )
+    c2 = expand_standard_cols( cols, cat_version )
 
     required_cols.reverse()
     for mm in required_cols:

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
@@ -50,7 +50,7 @@ __all__ = (
     )
 
 
-fileTypes = {
+fileTypes_csc1 = {
     # Note: reg3 aka srcreg is unique in that it is per source, but has det version number
     # HRC does not have pha nor rmf files
     "evt"    : { "extn" : "evt3",    "filetype" : "evt3",       "version" : "cal", "obilevel" : True,  "bands" : False,  "acisonly" : False },
@@ -72,6 +72,18 @@ fileTypes = {
     "lc"     : { "extn" : "lc3",     "filetype" : "lightcurve", "version" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False }
     }
     
+
+fileTypes_cur = {
+
+
+}
+
+fileTypes = {
+    "csc1" : fileTypes_csc1,
+    "cur"  : fileTypes_cur
+}
+
+
 bands = { 
     "ACIS" : { 'broad' : 'b', 'soft' : 's', 'medium' : 'm', 'hard' : 'h', 'ultrasoft' : 'u' },
     "HRC"  : { 'wide' : 'w' }
@@ -791,42 +803,42 @@ def search_src_by_obsid( obsid, columns, cat_ver ):
 
 
 
-def find_filename_match_in_rows( rows, filetype, obsid, obi, region, band, instrume):
-    """
-    Look for file name in a list of file names
-    """
-    if region:
-        # Look for r????_ in the name
-        regs = filter( lambda x: "r{0:04d}".format(int(region)) in x, rows)
-    else:
-        regs = rows
+#~ def find_filename_match_in_rows( rows, filetype, obsid, obi, region, band, instrume):
+    #~ """
+    #~ Look for file name in a list of file names
+    #~ """
+    #~ if region:
+        #~ # Look for r????_ in the name
+        #~ regs = filter( lambda x: "r{0:04d}".format(int(region)) in x, rows)
+    #~ else:
+        #~ regs = rows
 
-    if band:
-        # Look for band_ 
-        bnds = filter( lambda x: "{0}_".format(band) in x, regs)
-    else:
-        bnds = regs
+    #~ if band:
+        #~ # Look for band_ 
+        #~ bnds = filter( lambda x: "{0}_".format(band) in x, regs)
+    #~ else:
+        #~ bnds = regs
 
-    # Filter on file type since cached list may contain many
-    myfile = fileTypes[ filetype ]
-    ftyp = filter( lambda x: "_{0}.fits".format( myfile["extn"] ) in x, bnds )
+    #~ # Filter on file type since cached list may contain many
+    #~ myfile = fileTypes[ filetype ]
+    #~ ftyp = filter( lambda x: "_{0}.fits".format( myfile["extn"] ) in x, bnds )
 
-    # Finally filter on obi number, usually a no-op
-    obis = filter( lambda x: "f{0:05d}_{1:03d}N".format(int(obsid),int(obi)) in x, ftyp )
+    #~ # Finally filter on obi number, usually a no-op
+    #~ obis = filter( lambda x: "f{0:05d}_{1:03d}N".format(int(obsid),int(obi)) in x, ftyp )
 
 
-    # Check return, should have 1 row left from service
-    if len(obis) > 1:
-        oo = [ o.split("\t")[0] for o in obis ]
-        oo.sort()
-        obis=[oo[-1]]  # sort, take last one, highest version
-        verb2("Found multiple files for {0}\n".format( (filetype, obsid, obi, region, band, instrume)))        
-        #raise IOError("Only 1 file should be found")
-    if len(obis) == 0 :
-        raise IOError("No files found matching query")
+    #~ # Check return, should have 1 row left from service
+    #~ if len(obis) > 1:
+        #~ oo = [ o.split("\t")[0] for o in obis ]
+        #~ oo.sort()
+        #~ obis=[oo[-1]]  # sort, take last one, highest version
+        #~ verb2("Found multiple files for {0}\n".format( (filetype, obsid, obi, region, band, instrume)))        
+        #~ #raise IOError("Only 1 file should be found")
+    #~ if len(obis) == 0 :
+        #~ raise IOError("No files found matching query")
 
-    filename = obis[0].split("\t")[0]
-    return filename
+    #~ filename = obis[0].split("\t")[0]
+    #~ return filename
 
 
 
@@ -835,7 +847,7 @@ def find_filename_match_in_rows( rows, filetype, obsid, obi, region, band, instr
 
 def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
     """
-    
+    This is only for catalog='csc1'
     
     """
     global __filename_version_db__
@@ -856,78 +868,78 @@ def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
         print("Version info not available for {}".format(obistr))
         return None
         
-    if fileTypes[ filetype]["version"] == "cal":
+    if fileTypes['csc1'][filetype]["version"] == "cal":
         ver = __filename_version_db__[obistr]["calver"]
-    elif fileTypes[filetype]["version"] == "det":
+    elif fileTypes['csc1'][filetype]["version"] == "det":
         ver = __filename_version_db__[obistr]["detver"]
-    elif fileTypes[filetype]["version"] == "src":
+    elif fileTypes['csc1'][filetype]["version"] == "src":
         ver = __filename_version_db__[obistr]["srcver"]
     else:
         raise ValueError("Internal error: unknown filetype")
 
     filename += ver+"_"
 
-    if fileTypes[filetype]["obilevel"]:
+    if fileTypes['csc1'][filetype]["obilevel"]:
         pass
     else:
         filename += "r{:04d}".format( int(region))
     
-    if fileTypes[filetype]["bands"]:
+    if fileTypes['csc1'][filetype]["bands"]:
         
         filename += band
     
-    filename += "_"+fileTypes[filetype]["extn"]+".fits"
+    filename += "_"+fileTypes['csc1'][filetype]["extn"]+".fits"
     
     return filename.replace("__", "_")
     
         
 
 
-def discover_filename_from_archive( filetype, obsid, obi, region, band, instrume):
-    """
-    Use the archiveFileList service to file the filename to use
-    in the query to retrive the file based on the filetype and
-    observation info
-    """
+#~ def discover_filename_from_archive( filetype, obsid, obi, region, band, instrume):
+    #~ """
+    #~ Use the archiveFileList service to file the filename to use
+    #~ in the query to retrive the file based on the filetype and
+    #~ observation info
+    #~ """
 
 
 
     
-    filename = ""
-    try:
-        # try cache of filenames 1st
-        filename = find_filename_match_in_rows(__filename_cache__, filetype, obsid, obi, region, band, instrume)
-        verb2( "Found {0} in cache".format(filename))
-    except IOError:
-        # if not found, then query archive
-        myfile = fileTypes[filetype]
-        resource = "http://cda.harvard.edu/srservices/archiveFileList.do"
-        vals = {
-            "obsid"    : obsid,
-            "detector" : instrume,
-            "filetype" : myfile["filetype"],
-            "dataset"  : "flight",
-            "level"    : "3"
-            }
-        qry = make_URL_request( resource, vals )
-        qry = qry.decode("ascii")
-        # parse string
-        rows = qry.split("\n")
-        __filename_cache__.extend( rows ) # add rows to cache
-        filename = find_filename_match_in_rows(rows, filetype, obsid, obi, region, band, instrume)
+    #~ filename = ""
+    #~ try:
+        #~ # try cache of filenames 1st
+        #~ filename = find_filename_match_in_rows(__filename_cache__, filetype, obsid, obi, region, band, instrume)
+        #~ verb2( "Found {0} in cache".format(filename))
+    #~ except IOError:
+        #~ # if not found, then query archive
+        #~ myfile = fileTypes[filetype]
+        #~ resource = "http://cda.harvard.edu/srservices/archiveFileList.do"
+        #~ vals = {
+            #~ "obsid"    : obsid,
+            #~ "detector" : instrume,
+            #~ "filetype" : myfile["filetype"],
+            #~ "dataset"  : "flight",
+            #~ "level"    : "3"
+            #~ }
+        #~ qry = make_URL_request( resource, vals )
+        #~ qry = qry.decode("ascii")
+        #~ # parse string
+        #~ rows = qry.split("\n")
+        #~ __filename_cache__.extend( rows ) # add rows to cache
+        #~ filename = find_filename_match_in_rows(rows, filetype, obsid, obi, region, band, instrume)
 
-    return filename
+    #~ return filename
 
 
 
-def discover_filenames_per_type( mysrc, myfile, mybands ):
+def discover_filenames_per_type( mysrc, myfile, mybands, catalog ):
     """
     To discover the filename we need to make a wide query to the
     archive for data products associated with the obisid
     for the filetype.  Then we will parse by band, obi, and
     region id.    
     """
-    myfileType = fileTypes[myfile]
+    myfileType = fileTypes[catalog][myfile]
     myinst = mysrc["instrument"].replace(" ", "")
 
 
@@ -979,7 +991,7 @@ def check_existing( ff, off ):
     return False
 
 
-def retrieve_files_per_type( filenames, filetype, root ):
+def retrieve_files_per_type( filenames, filetype, root, catalog ):
     """
     Retrieve the files using the retrieveFile interface.
     
@@ -1000,9 +1012,12 @@ def retrieve_files_per_type( filenames, filetype, root ):
 
         resource = "http://cda.cfa.harvard.edu/csccli/retrieveFile"
         vals = { 
-            "filetype" : fileTypes[filetype]["filetype"],
+            "filetype" : fileTypes[catalog][filetype]["filetype"],
             "filename" : ff,
             }
+        if 'cur' == 'catalog':
+            vals['version'] = catalog
+
 
         try:
             page = make_URL_request( resource, vals )
@@ -1020,7 +1035,7 @@ def retrieve_files_per_type( filenames, filetype, root ):
         __all_retieved_files__[ff] = root
 
 
-def create_output_dir( inroot, mysrc, myfiletype, byObi ):
+def create_output_dir( inroot, mysrc, myfiletype, byObi, catalog ):
     """
     To make managing the files easier, the files are retrieved into
     directories based on the master source name and obsid_obi
@@ -1028,11 +1043,11 @@ def create_output_dir( inroot, mysrc, myfiletype, byObi ):
 
     if byObi:
         root = (inroot+os.sep+mysrc["obsid"]).replace(" ","")
-        if not fileTypes[myfiletype]["obilevel"]:
+        if not fileTypes[catalog][myfiletype]["obilevel"]:
             root += (os.sep+mysrc["name"]).replace(" ", "")
     else:    
         root = (inroot+os.sep+mysrc["name"]+os.sep+mysrc["tag"] ).replace(" ","") # remove space in name
-        if not fileTypes[myfiletype]["obilevel"]:
+        if not fileTypes[catalog][myfiletype]["obilevel"]:
             root += os.sep+"r{0:04d}".format(int(mysrc["region_id"]))
 
 
@@ -1073,7 +1088,7 @@ def process_ask( ask, pp ):
             verb0("Unrecognized option '{}'".format( resp ))
 
 
-def retrieve_files( mysrcs, root, myfiles, mybands, ask, byObi=False ):
+def retrieve_files( mysrcs, root, myfiles, mybands, ask, catalog, byObi=False ):
     """
     Loop over sources and retrieve files
     """
@@ -1093,12 +1108,12 @@ def retrieve_files( mysrcs, root, myfiles, mybands, ask, byObi=False ):
             raise NotImplementedError("Internal Error: invalid ask value")
         
         try:
-            retrieve_files_per_src( mysrc, root, myfiles, mybands, byObi )
+            retrieve_files_per_src( mysrc, root, myfiles, mybands, catalog, byObi )
         except ValueError as e:
             verb0( str(e) )
             verb0("  Continuing")
 
-def retrieve_files_per_src( mysrc, inroot, myfiles, mybands, byObi=False ): 
+def retrieve_files_per_src( mysrc, inroot, myfiles, mybands, catalog, byObi=False ): 
     """
     For a single source, loop over file types and retrieve each
     """    
@@ -1107,15 +1122,15 @@ def retrieve_files_per_src( mysrc, inroot, myfiles, mybands, byObi=False ):
     #
     # Loop overy file types
     #
-    for ft in fileTypes:
+    for ft in fileTypes[catalog]:
         # compare full list to those requested
         if ft not in myfiles.split(","):
             continue
-        root = create_output_dir( inroot, mysrc, ft, byObi )
-        fnames = discover_filenames_per_type( mysrc, ft, mybands )
-        retrieve_files_per_type( fnames, ft, root )
+        root = create_output_dir( inroot, mysrc, ft, byObi, catalog )
+        fnames = discover_filenames_per_type( mysrc, ft, mybands, catalog )
+        retrieve_files_per_type( fnames, ft, root, catalog )
 
-def check_filetypes( alist ):
+def check_filetypes( alist, catalog ):
     """
     Check list of files against those input and shorten list
     """
@@ -1123,7 +1138,7 @@ def check_filetypes( alist ):
     retval=[]
     for aa in alist.split(","):
         aa=aa.strip()
-        if aa in fileTypes:
+        if aa in fileTypes[catalog]:
             retval.append(aa)
         else:
             verb1("Unrecongnized file type '{0}', skipping it".format(aa))

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
@@ -116,9 +116,9 @@ fileTypes_cur = {
     "stkdraws"    : { "extn" : "draws3",  "filetype" : "stkdraws",   "prodlevel" : "stk", "obilevel" : False, "bands" : True,   "acisonly" : False },
     "stkaperphot" : { "extn" : "phot3",   "filetype" : "stkaperphot","prodlevel" : "stk", "obilevel" : False, "bands" : True,   "acisonly" : False },
 
-    # master -- FIXME!!! extn are wrong
-    "mrgsrc"      : { "extn" : "phot3",   "filetype" : "mrgsrc",     "prodlevel" : "mst", "obilevel" : False, "bands" : False,   "acisonly" : False },
-    "bayesblks"   : { "extn" : "phot3",   "filetype" : "bayesblks",  "prodlevel" : "mst", "obilevel" : False, "bands" : False,   "acisonly" : False },
+    # master
+    "mrgsrc"      : { "extn" : "mrgsrc3", "filetype" : "mrgsrc",     "prodlevel" : "stk", "obilevel" : False, "bands" : False,   "acisonly" : False },
+    "bayesblks"   : { "extn" : "blocks3", "filetype" : "bayesblks",  "prodlevel" : "mst", "obilevel" : False, "bands" : False,   "acisonly" : False },
     "srcaperphot" : { "extn" : "phot3",   "filetype" : "srcaperphot","prodlevel" : "mst", "obilevel" : False, "bands" : True,    "acisonly" : False },
 
 
@@ -601,7 +601,7 @@ def summarize_properties( cols, results ):
             retstr += "\t"
         verb1( retstr)
         
-    verb1("\nIf you use this data, please cite Evans et al 2010, ApJS 189, 37\n")
+    #verb1("\nIf you use this data, please cite Evans et al 2010, ApJS 189, 37\n")
 
 
 def __arcsec_to_deg( val ):
@@ -977,6 +977,35 @@ def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
     #~ return filename
 
 
+def discover_filename_via_archive(myfile, obsid, obi, region, band, instrume):
+    """
+    Use the csccli browse interface for release 2 file names.
+    
+    """
+
+    pkg = "{obs}.{obi}.{reg}/{typ}/{band}".format( 
+        obs=obsid.strip(), obi=obi.strip(), 
+        reg=region.strip(), typ=myfile, band=band)
+
+    resource = "http://cda.cfa.harvard.edu/csccli/browse"
+    vals = {
+        "packageset" : pkg,
+        "version" : "cur",
+        }
+
+    try:
+        qry = make_URL_request( resource, vals )
+        qry = qry.decode("ascii")
+
+        import json as json
+        retval = json.loads(qry)
+        filename = [ f["filename"] for f in retval ]
+    except:
+        filename = [None]
+
+    return filename[0]    
+
+
 
 def discover_filenames_per_type( mysrc, myfile, mybands, catalog ):
     """
@@ -1005,10 +1034,17 @@ def discover_filenames_per_type( mysrc, myfile, mybands, catalog ):
             # compare list of all bands to those requested 
             if name not in mybands.split(","):
                 continue            
-            ff = discover_filename_by_force( myfile, mysrc["obsid"], mysrc["obi"], rr, abbrv, myinst )
+
+            if 'csc1' == catalog:
+                ff = discover_filename_by_force( myfile, mysrc["obsid"], mysrc["obi"], rr, abbrv, myinst )
+            else:
+                ff = discover_filename_via_archive( myfileType["filetype"], mysrc["obsid"], mysrc["obi"], rr, abbrv, myinst )
             filenames.append( ff )
     else:
-        ff = discover_filename_by_force( myfile , mysrc["obsid"], mysrc["obi"], rr, "", myinst )
+        if 'csc1' == catalog:
+            ff = discover_filename_by_force( myfile , mysrc["obsid"], mysrc["obi"], rr, "", myinst )
+        else:
+            ff = discover_filename_via_archive( myfileType["filetype"], mysrc["obsid"], mysrc["obi"], rr, "", myinst )
         filenames = [ ff ]    
     
     return filenames
@@ -1051,6 +1087,9 @@ def retrieve_files_per_type( filenames, filetype, root, catalog ):
     """
 
     for ff in filenames:
+        if ff is None:
+            continue
+
         off = root + os.sep + ff # path + filename
     
         if check_existing( ff, off ):
@@ -1061,7 +1100,7 @@ def retrieve_files_per_type( filenames, filetype, root, catalog ):
             "filetype" : fileTypes[catalog][filetype]["filetype"],
             "filename" : ff,
             }
-        if 'cur' == 'catalog':
+        if 'cur' == catalog:
             vals['version'] = catalog
 
 
@@ -1087,16 +1126,34 @@ def create_output_dir( inroot, mysrc, myfiletype, byObi, catalog ):
     directories based on the master source name and obsid_obi
     """
 
-    if byObi:
-        root = (inroot+os.sep+mysrc["obsid"]).replace(" ","")
-        if not fileTypes[catalog][myfiletype]["obilevel"]:
-            root += (os.sep+mysrc["name"]).replace(" ", "")
-    else:    
-        root = (inroot+os.sep+mysrc["name"]+os.sep+mysrc["tag"] ).replace(" ","") # remove space in name
-        if not fileTypes[catalog][myfiletype]["obilevel"]:
-            root += os.sep+"r{0:04d}".format(int(mysrc["region_id"]))
+    if 'csc1' == catalog:
+        if byObi:
+            root = (inroot+os.sep+mysrc["obsid"]).replace(" ","")
+            if not fileTypes[catalog][myfiletype]["obilevel"]:
+                root += (os.sep+mysrc["name"]).replace(" ", "")
 
+        else:    
+            root = (inroot+os.sep+mysrc["name"]+os.sep+mysrc["tag"] ).replace(" ","") # remove space in name
+            if not fileTypes[catalog][myfiletype]["obilevel"]:
+                root += os.sep+"r{0:04d}".format(int(mysrc["region_id"]))
 
+    else:  # csc2, aka cur
+        if byObi:
+            root = os.path.join(inroot,mysrc["obsid"])
+            if fileTypes[catalog][myfiletype]["prodlevel"] == 'stk':
+                root = os.path.join(root, mysrc["detect_stack_id"])
+            elif fileTypes[catalog][myfiletype]["prodlevel"] == 'mst':
+                root = os.path.join( root, mysrc["name"])
+            elif fileTypes[catalog][myfiletype]["prodlevel"] == 'src':
+                root = os.path.join( root, "r{:04d}".format(int(mysrc["region_id"])))
+        else:    
+            root = os.path.join( inroot, mysrc["name"] )
+            if fileTypes[catalog][myfiletype]["prodlevel"] == 'stk':
+                root = os.path.join(root, mysrc["detect_stack_id"])
+            elif fileTypes[catalog][myfiletype]["prodlevel"] in ['obi','src']:
+                root = os.path.join( root, mysrc["tag"])
+                    
+    root=root.replace(" ","")
 
     if not os.path.exists( root ):
         os.makedirs( root )
@@ -1174,7 +1231,9 @@ def retrieve_files_per_src( mysrc, inroot, myfiles, mybands, catalog, byObi=Fals
             continue
         root = create_output_dir( inroot, mysrc, ft, byObi, catalog )
         fnames = discover_filenames_per_type( mysrc, ft, mybands, catalog )
-        retrieve_files_per_type( fnames, ft, root, catalog )
+        if fnames:
+            retrieve_files_per_type( fnames, ft, root, catalog )
+        
 
 def check_filetypes( alist, catalog ):
     """
@@ -1221,6 +1280,7 @@ def get_default_columns(cat_version=None):
     retval = default_cols
 
     if "cur" == cat_version:
+        default_cols.append("s.detect_stack_id")
         retval = default_cols # may be diff for ver2
 
     return default_cols
@@ -1314,7 +1374,11 @@ def check_required_names( cols, cat_version=None ):
     """
     c2 = expand_standard_cols( cols, cat_version )
 
+    if 'cur' == cat_version and 's.detect_stack_id' not in required_cols:
+        required_cols.append( 's.detect_stack_id' )
+
     required_cols.reverse()
+
     for mm in required_cols:
         if mm not in c2:
             verb2( "Required column {} was added to columns".format(mm))

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
@@ -74,6 +74,52 @@ fileTypes_csc1 = {
     
 
 fileTypes_cur = {
+    "evt"    : { "extn" : "evt3",    "filetype" : "evt3",       "prodlevel" : "obi", "obilevel" : True,  "bands" : False,  "acisonly" : False },
+    "asol"   : { "extn" : "asol3",   "filetype" : "aspsol3",    "prodlevel" : "obi", "obilevel" : True,  "bands" : False,  "acisonly" : False },
+    "ahst"   : { "extn" : "ahst3",   "filetype" : "asphist",    "prodlevel" : "obi", "obilevel" : True,  "bands" : False , "acisonly" : False },
+    "bpix"   : { "extn" : "bpix3",   "filetype" : "badpix3",    "prodlevel" : "obi", "obilevel" : True,  "bands" : False , "acisonly" : False },
+    "fov"    : { "extn" : "fov3",    "filetype" : "fov3",       "prodlevel" : "obi", "obilevel" : True,  "bands" : False , "acisonly" : False },
+    "pixmask": { "extn" : "pixmask3","filetype" : "pixmask",    "prodlevel" : "obi", "obilevel" : True,  "bands" : False , "acisonly" : False },
+
+    "img"    : { "extn" : "img3",    "filetype" : "ecorrimg",   "prodlevel" : "obi", "obilevel" : True,  "bands" : True ,  "acisonly" : False },
+    "bkgimg" : { "extn" : "bkgimg3", "filetype" : "bkgimg",     "prodlevel" : "obi", "obilevel" : True,  "bands" : True ,  "acisonly" : False },
+    "exp"    : { "extn" : "exp3",    "filetype" : "expmap",     "prodlevel" : "obi", "obilevel" : True,  "bands" : True ,  "acisonly" : False },
+    "poly"   : { "extn" : "poly3",   "filetype" : "poly3",      "prodlevel" : "obi", "obilevel" : True,  "bands" : True ,  "acisonly" : False },
+
+    # Per obi, per region,     HRC does not have pha nor rmf files
+    "regevt" : { "extn" : "regevt3", "filetype" : "regevt3",    "prodlevel" : "src", "obilevel" : False, "bands" : False , "acisonly" : False },
+    "pha"    : { "extn" : "pha3",    "filetype" : "spectrum",   "prodlevel" : "src", "obilevel" : False, "bands" : False , "acisonly" : True  },
+    "arf"    : { "extn" : "arf3",    "filetype" : "arf",        "prodlevel" : "src", "obilevel" : False, "bands" : False , "acisonly" : False },
+    "rmf"    : { "extn" : "rmf3",    "filetype" : "rmf",        "prodlevel" : "src", "obilevel" : False, "bands" : False , "acisonly" : True  },
+    "reg"    : { "extn" : "reg3",    "filetype" : "srcreg",     "prodlevel" : "src", "obilevel" : False, "bands" : False , "acisonly" : False },
+
+    "regimg"  : { "extn" : "regimg3", "filetype" : "regimg",     "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
+    "psf"     : { "extn" : "psf3",    "filetype" : "psf",        "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
+    "regexp"  : { "extn" : "regexp3", "filetype" : "regexpmap",  "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
+    "lc"      : { "extn" : "lc3",     "filetype" : "lightcurve", "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
+    "draws"   : { "extn" : "draws3",  "filetype" : "draws",      "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
+    "aperphot": { "extn" : "phot3",   "filetype" : "aperphot",   "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
+
+    # Stack 
+    "stkevt"      : { "extn" : "evt3",    "filetype" : "stkevt3",    "prodlevel" : "stk", "obilevel" : True , "bands" : False,  "acisonly" : False },
+    "stkfov"      : { "extn" : "fov3",    "filetype" : "stkfov3",    "prodlevel" : "stk", "obilevel" : True , "bands" : False,  "acisonly" : False },
+    "stkecorrimg" : { "extn" : "img3",    "filetype" : "stkecorrimg","prodlevel" : "stk", "obilevel" : True , "bands" : True ,  "acisonly" : False },
+    "stkbkgimg"   : { "extn" : "bkgimg3", "filetype" : "stkbkgimg",  "prodlevel" : "stk", "obilevel" : True , "bands" : True ,  "acisonly" : False },
+    "stkexpmap"   : { "extn" : "exp3",    "filetype" : "stkexpmap",  "prodlevel" : "stk", "obilevel" : True , "bands" : True ,  "acisonly" : False },
+    "sensity"     : { "extn" : "sens3",   "filetype" : "sensity",    "prodlevel" : "stk", "obilevel" : True , "bands" : True ,  "acisonly" : False },
+
+    # These are per region too
+    "stkregevt"   : { "extn" : "regevt3", "filetype" : "stkregevt3", "prodlevel" : "stk", "obilevel" : False, "bands" : False,  "acisonly" : False },
+    "stksrcreg"   : { "extn" : "reg3",    "filetype" : "stksrcreg",  "prodlevel" : "stk", "obilevel" : False, "bands" : False,  "acisonly" : False },
+    "stkregimg"   : { "extn" : "regimg3", "filetype" : "stkregimg",  "prodlevel" : "stk", "obilevel" : False, "bands" : True,   "acisonly" : False },
+    "stkregexp"   : { "extn" : "regexp3", "filetype" : "stkregexp",  "prodlevel" : "stk", "obilevel" : False, "bands" : True,   "acisonly" : False },
+    "stkdraws"    : { "extn" : "draws3",  "filetype" : "stkdraws",   "prodlevel" : "stk", "obilevel" : False, "bands" : True,   "acisonly" : False },
+    "stkaperphot" : { "extn" : "phot3",   "filetype" : "stkaperphot","prodlevel" : "stk", "obilevel" : False, "bands" : True,   "acisonly" : False },
+
+    # master -- FIXME!!! extn are wrong
+    "mrgsrc"      : { "extn" : "phot3",   "filetype" : "mrgsrc",     "prodlevel" : "mst", "obilevel" : False, "bands" : False,   "acisonly" : False },
+    "bayesblks"   : { "extn" : "phot3",   "filetype" : "bayesblks",  "prodlevel" : "mst", "obilevel" : False, "bands" : False,   "acisonly" : False },
+    "srcaperphot" : { "extn" : "phot3",   "filetype" : "srcaperphot","prodlevel" : "mst", "obilevel" : False, "bands" : True,    "acisonly" : False },
 
 
 }

--- a/ciao-4.10/contrib/param/obsid_search_csc.par
+++ b/ciao-4.10/contrib/param/obsid_search_csc.par
@@ -5,7 +5,7 @@ download,s,h,"none","none|ask|all",,"Download data products for which sources?"
 root,f,h,"./",,,"Output root for data products"
 bands,s,h,"broad,wide",,,"Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all"
 filetypes,s,h,"regevt,pha,arf,rmf,lc,psf,regexp",,,"Comma separated list of CSC filetypes.  Blank retrieves all"
-catalog,s,h,"csc1","csc1",,"Version of catalog"
+catalog,s,h,"csc1","csc1|cur",,"Version of catalog"
 verbose,i,h,1,0,5,"Tool chatter level"
 clobber,b,h,no,,,"Remove existing outfile if it exists?"
 mode,s,h,ql,,,

--- a/ciao-4.10/contrib/param/search_csc.par
+++ b/ciao-4.10/contrib/param/search_csc.par
@@ -8,7 +8,7 @@ download,s,h,"none","none|ask|all",,"Download data products for which sources?"
 root,f,h,"./",,,"Output root for data products"
 bands,s,h,"broad,wide",,,"Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all"
 filetypes,s,h,"regevt,pha,arf,rmf,lc,psf,regexp",,,"Comma separated list of CSC filetypes.  Blank retrieves all"
-catalog,s,h,"csc1","csc1",,"Version of catalog"
+catalog,s,h,"csc1","csc1|cur",,"Version of catalog"
 verbose,i,h,1,0,5,"Tool chatter level"
 clobber,b,h,no,,,"Remove existing outfile if it exists?"
 mode,s,h,ql,,,


### PR DESCRIPTION
These change fold in previous changes to allow the `search_csc` and `obsids_search_csc` scripts to access the current, aka `csc2` , tables **and** data products.

Both scripts now support

 `catalog=cur`

which allows access to the current database.  For example:

```bash
search_csc 3c273 out=3c273.tsv radius=0.1 radunit=arcmin download=all \
      file=regimg,regexp,regevt,reg,psf,arf,rmf,pha,lc clob+  cat=cur
```

> Note:  There will be some work when `csc2` is _released_ to update the parameter file and update a few `cur` conditionals.

I wanted to get this pull request in sooner-rather-than-later so folks could test with it.  Once we have a release plan, I'll update the ahelp files.

