### PR TITLE
Fix broken map() in mktgresp which fails to iterate over both HEG and

### DIFF
--- a/ciao-4.10/contrib/bin/mktgresp
+++ b/ciao-4.10/contrib/bin/mktgresp
@@ -119,7 +119,7 @@ def parse_orderlist( orderlist, parts, ids, xx, yy ):
         return None
 
     try:
-        ol = map(int, ss)
+        ol = int(map(int, ss))
     except:
         verb0("Cannot convert orderlist values to integers.  Using orders in input pha file")
         return None

--- a/ciao-4.10/contrib/bin/mktgresp
+++ b/ciao-4.10/contrib/bin/mktgresp
@@ -119,7 +119,7 @@ def parse_orderlist( orderlist, parts, ids, xx, yy ):
         return None
 
     try:
-        ol = int(map(int, ss))
+        ol = list(map(int, ss))
     except:
         verb0("Cannot convert orderlist values to integers.  Using orders in input pha file")
         return None


### PR DESCRIPTION
… MEG parts

From HD ticket 21345, the MEG responses are not created in the py3 build.

Users can set `orders=` (blank string) and it works.


