### PR TITLE
dax fixes found during ds9v8 testing

### DIFF
--- a/ciao-4.10/contrib/bin/ds9_aper.sh
+++ b/ciao-4.10/contrib/bin/ds9_aper.sh
@@ -19,8 +19,8 @@ fi
 
 
 
-src=`xpaget ${ds9} regions -format ciao source -strip -selected | tr ";" "+" | sed 's,\+$,,;s,\+\-,\-,g' `
-bkg=`xpaget ${ds9} regions -format ciao background -strip -selected | tr ";" "+" | sed 's,\+$,,;s,\+\-,\-,g'` 
+src=`xpaget ${ds9} regions -format ciao source -strip yes selected | tr ";" "+" | sed 's,\+$,,;s,\+\-,\-,g' `
+bkg=`xpaget ${ds9} regions -format ciao background -strip yes selected | tr ";" "+" | sed 's,\+$,,;s,\+\-,\-,g'` 
 
 
 fmt=`xpaget ${ds9} fits type`

--- a/ciao-4.10/contrib/bin/ds9_imgfit.sh
+++ b/ciao-4.10/contrib/bin/ds9_imgfit.sh
@@ -37,7 +37,7 @@ fi
 
 
 
-src=`xpaget ${ds9} regions -format ciao -system physical source -strip -selected | tr -d ";"`
+src=`xpaget ${ds9} regions -format ciao -system physical source -strip yes selected | tr -d ";"`
 
 if test "x${src}" = x
 then

--- a/ciao-4.10/contrib/bin/ds9_radial.sh
+++ b/ciao-4.10/contrib/bin/ds9_radial.sh
@@ -33,7 +33,7 @@ fi
 
 
 \rm -f $ASCDS_WORK_PATH/$$_ds9.reg
-xpaget $xpa regions -format ds9 -coord physical | cut -d"#" -f1 | sed 's, *$,,' | \
+xpaget $xpa regions -format ds9 -system physical | cut -d"#" -f1 | sed 's, *$,,' | \
   awk -f $ASCDS_CONTRIB/config/ds9_region_expand.awk > $ASCDS_WORK_PATH/$$_ds9.reg
 
 dmextract "${file}[bin sky=@$ASCDS_WORK_PATH/$$_ds9.reg]" - op=generic | \

--- a/ciao-4.10/contrib/bin/ds9_specfit.sh
+++ b/ciao-4.10/contrib/bin/ds9_specfit.sh
@@ -38,11 +38,8 @@ fi
 echo "--------------------------------------------------------"
 echo " (1/4) Parsing Regions" 
 
-#
-# -selected doesn't seem to robustly work with CIAO regions :(
-#
-src=`xpaget ${ds9} regions -format ciao source -strip -selected | tr -d ";"`
-bkg=`xpaget ${ds9} regions -format ciao background -strip -selected | tr -d ";" ` 
+src=`xpaget ${ds9} regions -format ciao source -strip yes selected | tr -d ";"`
+bkg=`xpaget ${ds9} regions -format ciao background -strip yes selected | tr -d ";" ` 
 
 
 if test "x$src" = x


### PR DESCRIPTION
This includes the fixes for  #139  .

ds9 v8 parser is now more strict.  We were using `-selected` which was never a flag and never worked but until now was ignored.  It now triggers an error.  Now fixed to use `selected` (no dash).  Also the old `-coord` switch from probably pre-v7 days was deprecated long ago in lieu of the `-system` switch.  dax needed to update.
