### PR TITLE
Add a way to export spectra to MARX

### DIFF
--- a/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/all.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/all.py
@@ -29,9 +29,11 @@ This loads in the following modules
   sherpa_contrib.utils
   sherpa_contrib.profiles
   sherpa_contrib.chart
+  sherpa_contrib.marx
 
 """
 
 from .utils import *
 from .profiles import *
 from .chart import *
+from .marx import *

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
@@ -1,0 +1,166 @@
+#
+# Copyright (C) 2009, 2010, 2015, 2016
+#           Smithsonian Astrophysical Observatory
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+
+"""Create a spectrum file for use in MARX.
+
+Helper routines for creating a spectrum file for use with
+`MARX <http://space.mit.edu/cxc/marx/>`_.
+
+Examples
+--------
+
+>>> load_pha('src.pi')
+>>> notice(0.5, 7)
+>>> set_source(xsphabs.gal * xsapec.src)
+>>> set_stat('wstat')
+>>> fit()
+>>> plot_marx_spectrum()
+>>> save_marx_spectrum(outfile='marx.dat', clobber=True)
+
+"""
+
+import pychips.all as c
+
+from crates_contrib.utils import write_columns
+
+from .chart import _get_chart_spectrum, plot_chart_spectrum
+
+__all__ = ("get_marx_spectrum",
+           "save_marx_spectrum",
+           "plot_marx_spectrum")
+
+
+def get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
+                      norm=None):
+    """Return the spectrum in the form needed by MARX.
+
+    Parameters
+    ----------
+    id : int or string or None
+        If id is None then the default Sherpa id is used. This
+        dataset must have a grid and source model defined.
+    elow, ehigh, ewidth : number or None
+        Only used if all three are given, otherwise the grid
+        of the data set is used. The elo value is the start
+        of the low-energy bin, ehigh is the end of the high-energy
+        bin, and ewidth the bin width, all in keV.
+    norm : number or None
+        Multiply the flux values by this value, if set.
+
+    Returns
+    -------
+    (energ_hi, flux_bins)
+       The energies are in keV and fluxes in photons/cm^2/s.
+
+    Notes
+    -----
+    The bins are supposed to be continuous and the value of energ_hi
+    for one bin is use as the lower boundary of the next bin. MARX
+    ignores the first bin the input file since its lower boundary is
+    not specified.
+
+    It is possible for the start or end bin to exceed the
+    desired energy limit. For example, if::
+
+        elow=2
+        ehigh=2.5
+        ewidth=0.2
+
+    then the bins will be 2-2.2, 2.2-2.4, 2.4-2.6. The error
+    introduced by this is assumed to be significantly smaller than
+    other errors in the calculation (such as how well the source
+    spectrum is actually known).
+
+    The source model is assumed to be defined on an energy grid,
+    with units of keV, and evaluate to photon/cm**2/s per bin.
+    This is true of the XSpec models and 1D Sherpa models.
+
+
+    Examples
+    --------
+
+    >>> load_pha('src.pi')
+    >>> set_source(xsphabs.gal * powlaw1d.pl)
+    >>> gal.nh = 0.09
+    >>> pl.gamma = 1.25
+    >>> pl.ampl = 8.432e-5
+    >>> (xlo, xhi, y) = get_chart_spectrum()
+
+    """
+
+    vals = _get_chart_spectrum(id, elow, ehigh, ewidth, norm)
+    return (vals["xhi"], vals["y"])
+
+
+def save_marx_spectrum(outfile, clobber=True, verbose=True,
+                       **kwargs):
+    """Create a spectrum file in the format used by ChART2.
+
+    See `get_chart_spectrum` for information on the other
+    arguments supported by this function.
+
+    Parameters
+    ----------
+    outfile : string
+        The name of the file to create. It is no-longer possible
+        to use None to get the output displayed to the screen.
+    clobber : bool, optional
+        If the output file already exists, should it be deleted
+        (``True``) or an IOError raised? The default is ``True``.
+    verbose : bool, optional
+        Should a message be displayed indicating that the file
+        has been created? This is only used when outfile is not
+        ``None``.
+
+    Notes
+    -----
+    The format needed for ChART2 is three columns - low and
+    high energy values along with the spectrum - and can be in
+    any Data-Model supported format (so both ASCII and FITS).
+    This is different to version 1, which required a 2 column
+    ASCII file.
+    """
+
+    if outfile is None:
+        raise ValueError("The outfile argument must be specified")
+
+    # Chart2 uses
+    #  - 3 columns (energ_lo, energ_hi, spectrum)
+    #  - can accept ascii or FITS format
+    #
+    (ehi, flux) = get_marx_spectrum(**kwargs)
+    write_columns(outfile, ehi, flux,
+                  format='raw', clobber=clobber)
+
+    if verbose:
+        print ("Created: {}".format(outfile))
+
+
+def plot_marx_spectrum(**kwargs):
+    """Plots the spectrum as used by MARX.
+
+    See `get_marx_spectrum` for information on the
+    arguments supported by this function.
+    """
+    plot_chart_spectrum(**kwargs)
+    c.open_undo_buffer()
+    c.set_plot_title("MARX Source Spectrum")
+    c.close_undo_buffer()

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2009, 2010, 2015, 2016
-#           Smithsonian Astrophysical Observatory
+# Copyright (C) 2018
+#           Massachusetts Institute of Technology
 #
 #
 # This program is free software; you can redistribute it and/or modify

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
@@ -112,9 +112,9 @@ def get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
 
 def save_marx_spectrum(outfile, clobber=True, verbose=True,
                        **kwargs):
-    """Create a spectrum file in the format used by ChART2.
+    """Create a spectrum file in the format used by MARX.
 
-    See `get_chart_spectrum` for information on the other
+    See `get_marx_spectrum` for information on the other
     arguments supported by this function.
 
     Parameters
@@ -132,20 +132,13 @@ def save_marx_spectrum(outfile, clobber=True, verbose=True,
 
     Notes
     -----
-    The format needed for ChART2 is three columns - low and
-    high energy values along with the spectrum - and can be in
-    any Data-Model supported format (so both ASCII and FITS).
-    This is different to version 1, which required a 2 column
-    ASCII file.
+    The format needed for MARX is two columns - the upper
+    energy value along with the spectrum.
     """
 
     if outfile is None:
         raise ValueError("The outfile argument must be specified")
 
-    # Chart2 uses
-    #  - 3 columns (energ_lo, energ_hi, spectrum)
-    #  - can accept ascii or FITS format
-    #
     (ehi, flux) = get_marx_spectrum(**kwargs)
     write_columns(outfile, ehi, flux,
                   format='raw', clobber=clobber)

--- a/ciao-4.10/contrib/share/doc/xml/get_marx_spectrum.xml
+++ b/ciao-4.10/contrib/share/doc/xml/get_marx_spectrum.xml
@@ -2,26 +2,26 @@
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
   <!ENTITY pr  'sherpa>'>
 
-  <!ENTITY chart2 '<HREF link="http://cxc.harvard.edu/ciao/PSFs/chart2">ChaRT2</HREF>'>
+  <!ENTITY marx '<HREF link="http://space.mit.edu/cxc/marx/index.html">MARX</HREF>'>
 
 ]>
 <cxchelptopics>
-  <ENTRY key="get_chart_spectrum" context="contrib" pkg="sherpa"
-	 refkeywords="get access read chart spectrum spectra file psf simulate simulation"
-	 seealsogroups="sh.get sh.chart">
+  <ENTRY key="get_marx_spectrum" context="contrib" pkg="sherpa"
+	 refkeywords="get access read marx spectrum spectra file psf simulate simulation"
+	 seealsogroups="sh.get sh.marx">
 
     <SYNOPSIS>
-      Return the model spectrum in the form required by ChaRT2
+      Return the model spectrum in the form required by MARX
     </SYNOPSIS>
 
     <SYNTAX>
-      <LINE>(xlo, xhi, y) = get_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None, norm=None)</LINE>
+      <LINE>(xlo, xhi, y) = get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None, norm=None)</LINE>
     </SYNTAX>
 
     <DESC>
       <PARA>
-	The get_chart_spectrum() command turns the current model
-	values into the form expected by &chart2;
+	The get_marx_spectrum() command turns the current model
+	values into the form expected by &marx;
 	(the Chandra Ray Tracer).
 	The x values are the low and high edges of each bin, and are in keV;
 	the y values are the model flux in units of photon/cm^2/s
@@ -30,7 +30,9 @@
       </PARA>
       <PARA>
 	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/threads/prep_chart/">ChaRT preparation thread</HREF>
+	<HREF
+	    link="http://space.mit.edu/cxc/marx/indetail/models.html#spectrum-of-the-simulated-x-ray-source">MARX
+	documentation of the spectrum format</HREF>
 	for further information on how to use this routine.
       </PARA>
 
@@ -39,7 +41,7 @@
       </PARA>
 
 <VERBATIM>
-from sherpa_contrib.chart import *
+from sherpa_contrib.marx import *
 </VERBATIM>
 
       <TABLE>
@@ -89,7 +91,7 @@ from sherpa_contrib.chart import *
 	  <DATA>
 	    A scaling factor to allow you to easily change the overall flux
 	    of the model. A value of None is equivalent to a factor
-	    of 1; a value of 10 would create a ChaRT spectral model ten times
+	    of 1; a value of 10 would create a MARX spectral model ten times
 	    brighter than the input model.
 	  </DATA>
 	</ROW>
@@ -101,13 +103,13 @@ from sherpa_contrib.chart import *
     <QEXAMPLELIST>
       <QEXAMPLE>
         <SYNTAX>
-          <LINE>&pr; (xlo, xhi, ,y) = get_chart_spectrum()</LINE>
+          <LINE>&pr; (xhi, ,y) = get_marx_spectrum()</LINE>
 	</SYNTAX>
 	<DESC>
 
           <PARA>
 	    Get the model values for the default dataset using the units
-	    expected by &chart2;.
+	    expected by &marx;.
 	  </PARA>
 
         </DESC>
@@ -115,7 +117,7 @@ from sherpa_contrib.chart import *
 
       <QEXAMPLE>
         <SYNTAX>
-          <LINE>&pr; (xlo, xhi, y) = get_chart_spectrum(elow=1, ehigh=8)</LINE>
+          <LINE>&pr; (xhi, y) = get_marx_spectrum(elow=1, ehigh=8)</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
@@ -129,15 +131,6 @@ from sherpa_contrib.chart import *
 
     </QEXAMPLELIST>
 
-    <ADESC title="Changes in the scripts 4.8.2 (January 2016) release">
-      <PARA>
-	The routine has been updated to work with
-	version 2 of ChART, so that the return value now
-	contains three values rather than two.
-      </PARA>
-    </ADESC>
-
-
     <BUGS>
       <PARA>
         See the
@@ -146,6 +139,6 @@ from sherpa_contrib.chart import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>September 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.10/contrib/share/doc/xml/plot_marx_spectrum.xml
+++ b/ciao-4.10/contrib/share/doc/xml/plot_marx_spectrum.xml
@@ -2,36 +2,27 @@
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
   <!ENTITY pr  'sherpa>'>
 
-  <!ENTITY chart2 '<HREF link="http://cxc.harvard.edu/ciao/PSFs/chart2">ChaRT2</HREF>'>
+  <!ENTITY marx '<HREF link="http://space.mit.edu/cxc/marx/index.html">MARX</HREF>'>
 
 ]>
 <cxchelptopics>
-  <ENTRY key="get_chart_spectrum" context="contrib" pkg="sherpa"
-	 refkeywords="get access read chart spectrum spectra file psf simulate simulation"
-	 seealsogroups="sh.get sh.chart">
+  <ENTRY key="plot_marx_spectrum" context="contrib" pkg="sherpa"
+	 refkeywords="plot draw marx spectrum spectra file psf simulate simulation"
+	 seealsogroups="sh.plot sh.marx">
 
     <SYNOPSIS>
-      Return the model spectrum in the form required by ChaRT2
+      Plot up the model spectrum in the form required by MARX
     </SYNOPSIS>
 
     <SYNTAX>
-      <LINE>(xlo, xhi, y) = get_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None, norm=None)</LINE>
+      <LINE>plot_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None, norm=None)</LINE>
     </SYNTAX>
 
     <DESC>
       <PARA>
-	The get_chart_spectrum() command turns the current model
-	values into the form expected by &chart2;
+	The plot_marx_spectrum() command creates a plot of the current model
+	values in the form expected by &marx;
 	(the Chandra Ray Tracer).
-	The x values are the low and high edges of each bin, and are in keV;
-	the y values are the model flux in units of photon/cm^2/s
-	(they give the integrated flux for each bin, rather than
-	the flux density as displayed by the plot_source command).
-      </PARA>
-      <PARA>
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/threads/prep_chart/">ChaRT preparation thread</HREF>
-	for further information on how to use this routine.
       </PARA>
 
       <PARA title="Loading the routine">
@@ -39,7 +30,7 @@
       </PARA>
 
 <VERBATIM>
-from sherpa_contrib.chart import *
+from sherpa_contrib.marx import *
 </VERBATIM>
 
       <TABLE>
@@ -71,7 +62,7 @@ from sherpa_contrib.chart import *
 	    The maximum energy at which to evaluate the model; this parameter
 	    controls the upper edge of the highest-energy bin, and is in keV.
 	    A value of None means to use the highest energy bin from the
-	    ARF grid. This value should not be larger than 10 keV.
+	    ARF grid. This valus should not be larger than 10 keV.
 	  </DATA>
 	</ROW>
 	<ROW>
@@ -89,7 +80,7 @@ from sherpa_contrib.chart import *
 	  <DATA>
 	    A scaling factor to allow you to easily change the overall flux
 	    of the model. A value of None is equivalent to a factor
-	    of 1; a value of 10 would create a ChaRT spectral model ten times
+	    of 1; a value of 10 would create a MARX spectral model ten times
 	    brighter than the input model.
 	  </DATA>
 	</ROW>
@@ -101,13 +92,13 @@ from sherpa_contrib.chart import *
     <QEXAMPLELIST>
       <QEXAMPLE>
         <SYNTAX>
-          <LINE>&pr; (xlo, xhi, ,y) = get_chart_spectrum()</LINE>
+          <LINE>&pr; plot_marx_spectrum()</LINE>
 	</SYNTAX>
 	<DESC>
 
           <PARA>
-	    Get the model values for the default dataset using the units
-	    expected by &chart2;.
+	    Create a plot of the model for the default dataset using the units
+	    expected by &marx;.
 	  </PARA>
 
         </DESC>
@@ -115,11 +106,11 @@ from sherpa_contrib.chart import *
 
       <QEXAMPLE>
         <SYNTAX>
-          <LINE>&pr; (xlo, xhi, y) = get_chart_spectrum(elow=1, ehigh=8)</LINE>
+          <LINE>&pr; plot_marx_spectrum(elow=1, ehigh=8)</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
-	    In this example the returned values are restricted to the range 1 to 8 keV, using the default
+	    In this example the plot  is restricted to the range 1 to 8 keV, using the default
 	    binning given by the ARF grid. Note that this energy range need not overlap the
 	    range used to fit the data (or even the energy ranges of the ARF and RMF files).
 	    It should however remain within the range 0.2 to 10 keV.
@@ -131,12 +122,9 @@ from sherpa_contrib.chart import *
 
     <ADESC title="Changes in the scripts 4.8.2 (January 2016) release">
       <PARA>
-	The routine has been updated to work with
-	version 2 of ChART, so that the return value now
-	contains three values rather than two.
+	The plot style is now a histogram rather than a curve.
       </PARA>
     </ADESC>
-
 
     <BUGS>
       <PARA>
@@ -146,6 +134,6 @@ from sherpa_contrib.chart import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>September 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.10/contrib/share/doc/xml/save_marx_spectrum.xml
+++ b/ciao-4.10/contrib/share/doc/xml/save_marx_spectrum.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
+  <!ENTITY pr  'sherpa>'>
+
+  <!ENTITY marx '<HREF link="http://space.mit.edu/cxc/marx/index.html">MARX</HREF>'>
+
+]>
+<cxchelptopics>
+  <ENTRY key="save_marx_spectrum" context="contrib" pkg="sherpa"
+	 refkeywords="write_marx_spectrum save write create marx spectrum spectra file psf simulate simulation"
+	 seealsogroups="sh.save sh.marx">
+
+    <SYNOPSIS>
+      Write out the model spectrum in the form required by MARX
+    </SYNOPSIS>
+
+    <SYNTAX>
+      <LINE>save_marx_spectrum(outfile, clobber=True, verbose=True, id=None, elow=None, ehigh=None, ewidth=None, norm=None)</LINE>
+    </SYNTAX>
+
+    <DESC>
+      <PARA>
+	The save_marx_spectrum() command writes out the current model
+	values in the form expected by &marx;
+	(the Chandra Ray Tracer).
+	Please see the
+	<HREF
+	    link="http://space.mit.edu/cxc/marx/indetail/models.html#spectrum-of-the-simulated-x-ray-source">MARX
+	documentation of the spectrum format</HREF>
+	for further information on how to use this routine.
+      </PARA>
+
+      <PARA title="Loading the routine">
+        The routine can be loaded into Sherpa by saying:
+      </PARA>
+
+<VERBATIM>
+from sherpa_contrib.marx import *
+</VERBATIM>
+
+      <TABLE>
+	<CAPTION>Arguments</CAPTION>
+	<ROW>
+	  <DATA>Name</DATA><DATA>Default value</DATA><DATA>Description</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>outfile</DATA>
+	  <DATA></DATA>
+	  <DATA>The name of the file to create.
+	  </DATA>
+	</ROW>
+	<ROW>
+	  <DATA>clobber</DATA>
+	  <DATA>True</DATA>
+	  <DATA>Determines the behavior if the output file already
+	    exists: a value of True (the default) means that the
+	    file will be overwritten, otherwise an error will be
+	    raised.</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>verbose</DATA>
+	  <DATA>True</DATA>
+	  <DATA>If verbose is True then a message will be printed to the
+	  standard output when the file has been created.</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>id</DATA>
+	  <DATA>None</DATA>
+	  <DATA>Which dataset to use: if None then the value returned
+	  by get_default_id() will be used.</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>elow</DATA>
+	  <DATA>None</DATA>
+	  <DATA>
+	    The minimum energy at which to evaluate the model; this parameter
+	    controls the lower edge of the lowest-energy bin, and is in keV.
+	    A value of None means to use the lowest energy bin from the
+	    ARF grid. This value should not be smaller than 0.2 keV.
+	  </DATA>
+	</ROW>
+	<ROW>
+	  <DATA>ehigh</DATA>
+	  <DATA>None</DATA>
+	  <DATA>
+	    The maximum energy at which to evaluate the model; this parameter
+	    controls the upper edge of the highest-energy bin, and is in keV.
+	    A value of None means to use the highest energy bin from the
+	    ARF grid. This valus should not be larger than 10 keV.
+	  </DATA>
+	</ROW>
+	<ROW>
+	  <DATA>ewidth</DATA>
+	  <DATA>None</DATA>
+	  <DATA>
+	    The bin width to use, in keV.
+	    A value of None means to use the bin width from the
+	    ARF grid.
+	  </DATA>
+	</ROW>
+	<ROW>
+	  <DATA>norm</DATA>
+	  <DATA>None</DATA>
+	  <DATA>
+	    A scaling factor to allow you to easily change the overall flux
+	    of the model. A value of None is equivalent to a factor
+	    of 1; a value of 10 would create a MARX spectral model ten times
+	    brighter than the input model.
+	  </DATA>
+	</ROW>
+
+      </TABLE>
+
+    </DESC>
+
+    <QEXAMPLELIST>
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>&pr; load_pha("3c273.pi")</LINE>
+	  <LINE>&pr; subtract()</LINE>
+	  <LINE>&pr; notice(0.1, 6)</LINE>
+          <LINE>&pr; set_source(xsphabs.abs1 * powlaw1d.p1)</LINE>
+          <LINE>&pr; abs1.nh = 0.07</LINE>
+          <LINE>&pr; freeze(abs1)</LINE>
+          <LINE>&pr; guess(p1)</LINE>
+          <LINE>&pr; fit()</LINE>
+          <LINE>...</LINE>
+          <LINE>&pr; save_marx_spectrum("marx.dat")</LINE>
+	</SYNTAX>
+	<DESC>
+
+          <PARA>
+	    Here we load in a source spectrum from the file 3c273.pi, along
+	    with the associated files (e.g. ARF, RMF, and background) that are indicated
+	    in its header.
+	    The background is subtracted, the analysis restricted to the 0.1 to 6 keV
+	    range, a model is created - consisting of an absorbed power law - and then
+	    parameter values are set before the fit is made.
+	  </PARA>
+	  <PARA>
+	    After the fit has been made the save_marx_spectrum() routine is used to
+	    write out the best-fit model - in a format usable by
+	    &marx; - 
+	    to the text file "marx.dat".
+	  </PARA>
+
+        </DESC>
+      </QEXAMPLE>
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>&pr; save_marx_spectrum("marx.dat", elow=1, ehigh=8)</LINE>
+	</SYNTAX>
+	<DESC>
+          <PARA>
+	    In this example the output is restricted to the range 1 to 8 keV, using the default
+	    binning given by the ARF grid. Note that this energy range need not overlap the
+	    range used to fit the data (or even the energy ranges of the ARF and RMF files).
+	    It should however remain within the range 0.2 to 10 keV.
+	  </PARA>
+        </DESC>
+      </QEXAMPLE>
+
+    </QEXAMPLELIST>
+
+    <BUGS>
+      <PARA>
+        See the
+        <HREF link="http://cxc.harvard.edu/sherpa/bugs/">bugs pages
+        on the Sherpa website</HREF> for an up-to-date listing of known bugs.
+      </PARA>
+    </BUGS>
+
+    <LASTMODIFIED>September 2018</LASTMODIFIED>
+  </ENTRY>
+</cxchelptopics>

--- a/ciao-4.10/contrib/share/doc/xml/sherpa_marx.xml
+++ b/ciao-4.10/contrib/share/doc/xml/sherpa_marx.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
+  <!ENTITY pr  'sherpa>'>
+
+  <!ENTITY marx '<HREF link="http://space.mit.edu/cxc/marx/index.html">MARX</HREF>'>
+
+]>
+<cxchelptopics>
+  <ENTRY key="sherpa_marx" context="contrib" pkg="sherpa"
+	 refkeywords="sherpa_contrib.marx marx ray ray-trace sherpa contrib contributed ciao script package module extra python py"
+	 seealsogroups="sh.marx">
+
+    <SYNOPSIS>
+      Create and view spectral files for MARX (CIAO contributed package).
+    </SYNOPSIS>
+
+    <SYNTAX>
+      <LINE>from sherpa_contrib.marx import *</LINE>
+    </SYNTAX>
+
+    <DESC>
+      <PARA>
+	The sherpa_contrib.marx
+	module provides routines for creating and viewing the input spectral files
+	for users of
+	&marx;
+	and is provided as part of the
+	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO contributed
+	scripts</HREF> package.
+      </PARA>
+
+      <PARA title="Loading the routines">
+        The module can be loaded into Sherpa by saying either of:
+      </PARA>
+
+<VERBATIM>
+from sherpa_contrib.marx import *
+from sherpa_contrib.all import *
+</VERBATIM>
+
+      <PARA>
+	where the second form loads in all the Sherpa contributed routines,
+	not just the marx module.
+      </PARA>
+
+      <PARA title="Contents">
+	The marx module currenly provides the following routines:
+      </PARA>
+
+      <TABLE>
+	<ROW>
+	  <DATA>Function name</DATA>
+	  <DATA>Description</DATA>
+	</ROW>
+        <ROW>
+	  <DATA>save_marx_spectum</DATA>
+	  <DATA>Writes out the model spectrum in the units used by by MARX</DATA>
+	</ROW>
+        <ROW>
+	  <DATA>plot_marx_spectum</DATA>
+	  <DATA>Plot the model spectrum in the units used by MARX</DATA>
+	</ROW>
+        <ROW>
+	  <DATA>get_marx_spectum</DATA>
+	  <DATA>Get the model spectrum in the units used by MARX</DATA>
+	</ROW>
+      </TABLE>
+
+      <PARA>
+	See the ahelp file for the routine and the
+	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">contributed
+	scripts</HREF> page for further information.
+      </PARA>
+
+    </DESC>
+
+    <BUGS>
+      <PARA>
+        See the
+        <HREF link="http://cxc.harvard.edu/sherpa/bugs/">bugs pages</HREF>
+	for an up-to-date listing of known bugs.
+      </PARA>
+    </BUGS>
+
+    <LASTMODIFIED>September 2018</LASTMODIFIED>
+  </ENTRY>
+</cxchelptopics>


### PR DESCRIPTION
The is very much analogous to getting/plotting/exporting spectra
for ChaRT. Most of the code is copied verbatim from the ChaRT routines.

I have not tested any of this because I try to avoid the setting up a new CIAO version for this with my
own contrib package. If I happen to write more contributions to contrib in the future, I will do that, but in
this case I would like to ask @DougBurke to try it out and let me know.
The test would obviously be to generate a spectrum and run marx.

In particular, (i) please have a look at the XML format to check that I did not screwed that up and (ii) the plot_marx_spectrum, which does not really do anything, but is there for symmetry with ChaRT.