### PR TITLE
Change the URL of the CADC name resolver (fix #144)

### DIFF
--- a/ciao-4.10/contrib/Changes.CIAO_scripts
+++ b/ciao-4.10/contrib/Changes.CIAO_scripts
@@ -17,6 +17,11 @@
       those on the FTP site.  Partial files are automatically 
       retrieved again.
 
+    find_chandra_obsid, search_csc
+
+      Updated the URL used for the name resolver provided by the
+      CADC to avoid problems with certain name searches.
+
     mktgresp
     
       Fix problem in Python3 version that would skip creating 

--- a/ciao-4.10/contrib/lib/python3.5/site-packages/coords/resolver.py
+++ b/ciao-4.10/contrib/lib/python3.5/site-packages/coords/resolver.py
@@ -1,8 +1,5 @@
-
-# Python35Support
-
 #
-#  Copyright (C) 2011, 2013, 2015, 2016
+#  Copyright (C) 2011, 2013, 2015, 2016, 2018
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -36,9 +33,9 @@ following services
             http://vizier.hia.nrc.ca/viz-bin/VizieR
 
 This module provides a simple interface - the identify_name routine -
-to a name resolver (currently
+to a name resolver, which is currently
 the one provided by the CADC at
-http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/NameResolver/).
+http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver/
 """
 
 from six.moves import urllib
@@ -112,7 +109,7 @@ def identify_name(name):
     """
 
     tname = urllib.parse.quote_plus(name)
-    url = "http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/NameResolver/find?format=ascii&service=all&cached=true&target=" + tname
+    url = "http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver/find?format=ascii&service=all&cached=true&target=" + tname
 
     # We get a 425 response code when there's no match, so catch this to make
     # it somewhat readable.

--- a/ciao-4.10/contrib/share/doc/xml/identify_name.xml
+++ b/ciao-4.10/contrib/share/doc/xml/identify_name.xml
@@ -23,7 +23,7 @@
     <DESC>
       <PARA>
         The identify_name routine calls the Astronomical 
-        <HREF link="http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/NameResolver">name resolver</HREF>
+        <HREF link="http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver">name resolver</HREF>
         provided by the Canadian Astronomy Data Center (CADC).
         Given a name, it returns the Right Ascension, Declination,
         and coordinate system. If no position can be found then
@@ -71,6 +71,17 @@ from coords.resolver import identify_name
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
+      <PARA>
+        The routine now uses the service at 
+        http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver
+	rather than 
+        http://www1.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/NameResolver
+	because problems were seen with the automatic redirects
+	for some queries.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.5.4 (August 2013) release">
       <PARA>
         The routine now uses the service at 
@@ -80,7 +91,7 @@ from coords.resolver import identify_name
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>August 2013</LASTMODIFIED>
+    <LASTMODIFIED>October 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Although there is an automatic redirect in place, it can result in
invalid queries (it appears to be if the search term requires some
form of encoding, such as spaces or other "unusual" cahracters).
This should fix this by using the current URL of the name resolver.

# Notes

This does not update the search_csc ahelp file (even though it really
should have the same update as find_chandra_obsid) since I didn't
want to mess up #131