### PR TITLE
Fall through to curl/wget when the CDA moves to https (see #138)

### DIFF
--- a/ciao-4.10/contrib/Changes.CIAO_scripts
+++ b/ciao-4.10/contrib/Changes.CIAO_scripts
@@ -20,7 +20,9 @@
     find_chandra_obsid, search_csc
 
       Updated the URL used for the name resolver provided by the
-      CADC to avoid problems with certain name searches.
+      CADC to avoid problems with certain name searches. Support
+      fall over to curl or wget for when the Chandra Data Archive
+      moves to https.
 
     mktgresp
     
@@ -38,9 +40,6 @@
       Recognizes when outroot is a directory and adjusts file names
       so they no longer begin with an underscore or period.
     
-        
-    
-
 
 
 ## 4.10.2 - May 2018 ##

--- a/ciao-4.10/contrib/bin/find_chandra_obsid
+++ b/ciao-4.10/contrib/bin/find_chandra_obsid
@@ -76,7 +76,7 @@ ftp://anonymous:foo@bar.org@cda.cfa.harvard.edu/pub/.
 """
 
 toolname = "find_chandra_obsid"
-version = "09 May 2018"
+version = "29 Oct 2018"
 
 import sys
 import os
@@ -122,6 +122,7 @@ lw.initialize_logger(toolname)
 v1 = lw.make_verbose_level(toolname, 1)
 v2 = lw.make_verbose_level(toolname, 2)
 v3 = lw.make_verbose_level(toolname, 3)
+v4 = lw.make_verbose_level(toolname, 4)
 
 
 def protect_string(s):
@@ -516,25 +517,29 @@ def find_obsid_position(obsid):
 
     # error handling based on ciao_contrib.caldb.get_caldb_releases()
     try:
-        ans = urllib.request.urlopen(url).read()
+        v3("Trying to identify obsid={}".format(obsid))
+        v4(" using URL={}".format(url))
+        ans = urllib.request.urlopen(url)
+
     except urllib.error.URLError as ue:
-        if hasattr(ue, "reason"):
-            if hasattr(ue.reason, "errno") and ue.reason.errno == socket.EAI_NONAME:
-                raise IOError("Unable to reach the Chandra Data Archive - is the network down?")
-            else:
-                raise IOError("Unable to reach the Chandra Data Archive - {}".format(ue.reason))
+        # There used to be a lot of code trying to provide a
+        # "nice" error message, but it was not well tested,
+        # so simplify
+        #
+        v3("Error opening URL: {}".format(ue))
 
-        elif hasattr(ue, "getcode"):
-            cval = ue.getcode()
-            if cval == 404:
-                raise IOError("The Chandra Data Archive site appears to be unreachable.")
-            else:
-                raise IOError("The Chandra Data Archive site returned {}".format(ue))
+        if hasattr(ue, 'reason'):
+            v3("error.reason = {}".format(ue.reason))
 
+            if ue.reason == 'unknown url type: https':
+                ans = search._manual_download(url)
+            else:
+                raise
         else:
-            raise IOError("Unable to access the Chandra Data Archive site - {}".format(ue))
+            raise
 
     # Ugly code; what is the better way to do this
+    ans = ans.read()
     if not isinstance(ans, six.string_types):
         ans = ans.decode('utf8')
 

--- a/ciao-4.10/contrib/share/doc/xml/find_chandra_obsid.xml
+++ b/ciao-4.10/contrib/share/doc/xml/find_chandra_obsid.xml
@@ -795,6 +795,12 @@ Download [y, n, q, a, h]: y
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
+      <PARA>
+	Fall through to curl or wget for https access to the
+	Chandra Data Archive.
+      </PARA>
+    </ADESC>
 
     <ADESC title="Changes in the scripts 4.10.2 (May 2018) release">
       <PARA>
@@ -864,6 +870,6 @@ Download [y, n, q, a, h]: y
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>May 2018</LASTMODIFIED>
+    <LASTMODIFIED>October 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This is for find_chandra_obsid when called with an obsid, rather than a name or location.

(rebased to avoid multiple commits)