### PR TITLE
Use https for cda query

### DIFF
--- a/ciao-4.10/contrib/bin/find_chandra_obsid
+++ b/ciao-4.10/contrib/bin/find_chandra_obsid
@@ -76,7 +76,7 @@ ftp://anonymous:foo@bar.org@cda.cfa.harvard.edu/pub/.
 """
 
 toolname = "find_chandra_obsid"
-version = "29 Oct 2018"
+version = "06 Nov 2018"
 
 import sys
 import os
@@ -505,7 +505,7 @@ def find_obsid_position(obsid):
     no obsid is be found.
 
     Relies on the CDA interface
-      http://cda.harvard.edu/srservices/ocatDetails.do?obsid=<obsid>&format=text
+      https://cda.harvard.edu/srservices/ocatDetails.do?obsid=<obsid>&format=text
     and assumes that obsid is a valid obsid (i.e. no protection against URL
     injection attects).
 
@@ -513,7 +513,7 @@ def find_obsid_position(obsid):
     """
 
     # assuming no need to protect or sanitize the input
-    url = 'http://cda.harvard.edu/srservices/ocatDetails.do?obsid={}&format=text'.format(obsid)
+    url = 'https://cda.harvard.edu/srservices/ocatDetails.do?obsid={}&format=text'.format(obsid)
 
     # error handling based on ciao_contrib.caldb.get_caldb_releases()
     try:

--- a/ciao-4.10/contrib/share/doc/xml/find_chandra_obsid.xml
+++ b/ciao-4.10/contrib/share/doc/xml/find_chandra_obsid.xml
@@ -795,7 +795,7 @@ Download [y, n, q, a, h]: y
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
+    <ADESC title="Changes in the scripts 4.10.3 (November 2018) release">
       <PARA>
 	Fall through to curl or wget for https access to the
 	Chandra Data Archive.
@@ -870,6 +870,6 @@ Download [y, n, q, a, h]: y
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>October 2018</LASTMODIFIED>
+    <LASTMODIFIED>November 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
In testing, it looks like the fall-through-to-curl/wget wasn't working
if using the http URL (because the curl/wget calls were not being told
to follow referrals). A simple solution is just to use the https
endpoint directly.