### PR TITLE
Remove blanksky_sample from the changelog

### DIFF
--- a/ciao-4.10/contrib/Changes.CIAO_scripts
+++ b/ciao-4.10/contrib/Changes.CIAO_scripts
@@ -1,14 +1,11 @@
 
 ## 4.10.3 - November 2018 ##
 
-  New and Updated scripts
+  Updated scripts
 
-    blanksky, blanksky_sample
+    blanksky
 
       The blanksky script has been updated to support sub-array data.
-      The blanksky_sample script is new in this release, and allows
-      users to create scaled background event files based on the
-      blank sky data sets.
       
     dax
       
@@ -33,8 +30,8 @@
 
       Updated the URL used for the name resolver provided by the
       CADC to avoid problems with certain name searches. Support
-      fall over to curl or wget for when the Chandra Data Archive
-      moves to https.
+      fall over to curl or wget as the Chandra Data Archive has
+      moved to using https.
 
     mktgresp
 
@@ -52,7 +49,7 @@
       Recognizes when outroot is a directory and adjusts file names
       so they no longer begin with an underscore or period.
     
-  New and Updated Python modules
+  New Python modules
 
     sherpa_contrib.marx (new)
 
@@ -60,11 +57,6 @@
       and get_marx_spectrum which are used when using Sherpa to
       generate model spectra for MARX. They are similar to the
       routines provided by sherpa_contrib.chart.
-
-    ciao_contrib.runtool
-
-      This has been updated to add support for the new blanksky_sample
-      script.
 
 ## 4.10.2 - May 2018 ##
 


### PR DESCRIPTION
The blanksky_sample script is being included in the release but
not being advertised as it is still somewhat experimental.