### PR TITLE
Add an ardlibqual argument to fullgarf

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -3,6 +3,11 @@
 
 Update scripts
 
+  fullgarf
+
+    The script has a new parameter tat allows to pass ardlib qualifiers
+    to the calls to mkgarf.
+
   chandra_repro
   
     The script has been updated for HRC to keep all the standard 

--- a/ciao-4.11/contrib/bin/fullgarf
+++ b/ciao-4.11/contrib/bin/fullgarf
@@ -30,6 +30,7 @@
 # the version of the script
 #
 # Changes:
+#   (4.11)       Add parameter to set ARDLIB qualifyers
 #   (4.5)        Support HRC-I
 #   (4.1.4)      If bad pixel file is not supplied, use the one from the CALDB
 #   (4.1.3)      Replaced use of tail command with CIAO "dmkeypar" tool
@@ -453,6 +454,7 @@ runMkgarf ()
    osip=`pquery $pacc osipfile`
    mask=`pquery $pacc maskfile`
    evtfile=`pquery $pacc evtfile`
+   ardlibqual=`pquery $pacc ardlibqual`
 
 ### We're now ready to run mkgarf . . .
 #
@@ -469,7 +471,7 @@ runMkgarf ()
 
      if [ ! -f ${out} -a ! -f ${out}.gz ]; then
 
-       echo mkgarf detsubsys=$mydet \
+       echo mkgarf detsubsys=$mydet$ardlibqual \
                    order=$ord \
                    grating_arm=$garm \
 		   outfile=$out \
@@ -486,7 +488,7 @@ runMkgarf ()
 		   mode="hl" \
 		   verb=0
 
-       mkgarf detsubsys="$mydet" \
+       mkgarf detsubsys="$mydet$ardlibqual" \
                    order=$ord \
 		   grating_arm="$garm" \
                    outfile="$out" \
@@ -508,7 +510,7 @@ runMkgarf ()
         if [ $clob -eq 1 ]; then
           echo "$out exists . . . will clobber "
 
-          echo mkgarf detsubsys=$mydet \
+          echo mkgarf detsubsys=$mydet$ardlibqual \
 	           order=$ord \
                    grating_arm=$garm \
 		   outfile=$out \
@@ -526,7 +528,7 @@ runMkgarf ()
 		   verb=0 \
 		   clobber=$clobber 
 
-          mkgarf detsubsys="$mydet" \
+          mkgarf detsubsys="$mydet$ardlibqual" \
 	           order=$ord \
 		   grating_arm="$garm" \
                    outfile="$out" \

--- a/ciao-4.11/contrib/param/fullgarf.par
+++ b/ciao-4.11/contrib/param/fullgarf.par
@@ -9,6 +9,7 @@ rootname,s,a,"",,,"Output rootname"
 dafile,s,h,"CALDB",,,"NONE, CALDB, or name of ACIS dead-area calibration file"
 osipfile,s,h,"CALDB",,,"NONE or Name of fits file with order sorting info"
 maskfile,s,a,"",,,"NONE, or name of ACIS window mask file"
+ardlibqual,s,a,"",,,"Additional ardlib qualifiers"
 #
 clobber,b,h,no,,,"Clobber existing output files? This is passed to ALL child processes."
 verbose,i,h,0,0,5,"Control the level of diagnostic output. 0=>least."

--- a/ciao-4.11/contrib/share/doc/xml/fullgarf.xml
+++ b/ciao-4.11/contrib/share/doc/xml/fullgarf.xml
@@ -537,10 +537,7 @@ ROW    TG_M TG_PART
 
     <BUGS>
       <PARA>
-        See the
-        <HREF link="http://cxc.harvard.edu/ciao/bugs/fullgarf.html">bugs page
-        for this script</HREF> on the CIAO website for an up-to-date
-        listing of known bugs. 
+        See this page for installation instructions.
       </PARA>
     </BUGS>
 

--- a/ciao-4.11/contrib/share/doc/xml/fullgarf.xml
+++ b/ciao-4.11/contrib/share/doc/xml/fullgarf.xml
@@ -174,6 +174,29 @@ ROW    TG_M TG_PART
 </DESC>
 
 </QEXAMPLE>
+<QEXAMPLE>
+<SYNTAX>
+<LINE>
+            fullgarf phafile=acisf00007_005N001_pha2.fits pharow=10
+           evtfile=acisf00007N001_evt2.fits.gz
+           asol=pcadf085492801N001_asol1.fits
+           engrid=&quot;grid(acis_meg_1.rmf[cols ENERG_LO,ENERG_HI])&quot;
+           maskfile=""
+           dafile=NONE ardlibqual=";UNIFORM;bpmask=0"
+</LINE>
+</SYNTAX>
+<DESC>
+<PARA>
+  This will create an ACIS-S, MEG ARF for the first order with no dead area
+  correction, no dead pixel mask and assuming a uniform quantum efficiency of
+  the detector. This setting would be appropriate to process spectra simulated
+  with MARX.
+</PARA>
+
+</DESC>
+
+</QEXAMPLE>
+
 </QEXAMPLELIST>
 <PARAMLIST>
 <PARAM name="phafile"  type="file"  reqd="yes"  stacks="no"  >
@@ -444,6 +467,20 @@ ROW    TG_M TG_PART
 </DESC>
 </PARAM>
 
+<PARAM name="ardlibqual"  type="string"  def=""  >
+<DESC>
+<PARA>
+  This script processes several ACIS chips or HRC plates in a loop. This
+  parameters can specify additional ardlib qualifiers that will be used for
+  each chip; it will be attached to the detector specification when passed to
+  the mkgarf tool. Thus, this parameter has to be empty or start with a
+  semicolon (;).
+</PARA>
+</DESC>
+</PARAM>
+
+
+
 <PARAM name="clobber"  type="boolean"  def="no">
 <DESC>
 <PARA>
@@ -461,6 +498,13 @@ ROW    TG_M TG_PART
 
 </PARAM>
 </PARAMLIST>
+
+    <ADESC title="Changes in the scripts 4.11 (December 2018) release">
+      <PARA>
+      A parameters was added to specify ARDLIB qualifiers to be used for all
+      chips that are processed by this script.
+      </PARA>
+    </ADESC>
 
 
     <ADESC title="Changes in the scripts 4.10.1 (April 2018) release">
@@ -500,7 +544,7 @@ ROW    TG_M TG_PART
       </PARA>
     </BUGS>
 
-<LASTMODIFIED>January 2018</LASTMODIFIED>
+<LASTMODIFIED>December 2018</LASTMODIFIED>
 
 </ENTRY>
 


### PR DESCRIPTION
`fullgarf` runs a loop over all ACIS chips (or HRC plates for the HRC).
When it does, it dynamically constructs the `detsubsys` keyword for `mkgarf`.
Previously, there was no way to add ardlib qualifiers to this `detsubsys`
keyword, it would always use the bare e.g. "ACIS-5".

Unfortunately, that means that fullgarf is incompatible with MARX
simulations, see Chandra-MARX/marx#34 .
This change adds a way to add ardlib qualifiers.