### PR TITLE
Replace outdated link with generic statement (fix #183)

### DIFF
--- a/ciao-4.11/contrib/share/doc/xml/acis_bkgrnd_lookup.xml
+++ b/ciao-4.11/contrib/share/doc/xml/acis_bkgrnd_lookup.xml
@@ -259,10 +259,7 @@
 	This script is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF>
-	for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
 
       <PARA title="Downloading the CALDB background files">
@@ -282,7 +279,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2016</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/acis_clear_status_bits.xml
+++ b/ciao-4.11/contrib/share/doc/xml/acis_clear_status_bits.xml
@@ -96,9 +96,7 @@ CLSTBITS= '11111111011000000011111111000001' / 0 means clear STATUS bit
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
     <BUGS>
@@ -110,6 +108,6 @@ CLSTBITS= '11111111011000000011111111000001' / 0 means clear STATUS bit
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>September 2014</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/acis_fef_lookup.xml
+++ b/ciao-4.11/contrib/share/doc/xml/acis_fef_lookup.xml
@@ -326,9 +326,7 @@
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
     <BUGS>
@@ -340,6 +338,6 @@
 	listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/acis_set_ardlib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/acis_set_ardlib.xml
@@ -195,9 +195,7 @@ Updated ardlib parameter file: /home/ciaouser/cxcds_param4/ardlib.par
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
     <BUGS>
@@ -209,6 +207,6 @@ Updated ardlib parameter file: /home/ciaouser/cxcds_param4/ardlib.par
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/blanksky_image.xml
+++ b/ciao-4.11/contrib/share/doc/xml/blanksky_image.xml
@@ -175,8 +175,7 @@
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see this page for installation instructions - such as how to
-        ensure that the parameter file is available.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -190,6 +189,6 @@
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>Sepetember 2016</LASTMODIFIED>
+    <LASTMODIFIED>September 2016</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
+++ b/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
@@ -1009,9 +1009,7 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -1041,6 +1039,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2018</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/check_ciao_caldb.xml
+++ b/ciao-4.11/contrib/share/doc/xml/check_ciao_caldb.xml
@@ -150,9 +150,7 @@ ERROR: The latest available CALDB version is &lt;latest version&gt;
         This tool is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-	instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -163,7 +161,7 @@ ERROR: The latest available CALDB version is &lt;latest version&gt;
 	on the CIAO website for an up-to-date listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/check_ciao_version.xml
+++ b/ciao-4.11/contrib/share/doc/xml/check_ciao_version.xml
@@ -135,9 +135,7 @@ to update your CIAO installation.
         This tool is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-	instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -149,7 +147,7 @@ to update your CIAO installation.
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/combine_grating_spectra.xml
+++ b/ciao-4.11/contrib/share/doc/xml/combine_grating_spectra.xml
@@ -759,8 +759,7 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -772,9 +771,7 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
       </PARA>
     </BUGS>
 
-   
-    <LASTMODIFIED>September 2018</LASTMODIFIED>
-
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/combine_spectra.xml
+++ b/ciao-4.11/contrib/share/doc/xml/combine_spectra.xml
@@ -487,8 +487,7 @@ combined background counts in any channel is 0.
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -499,10 +498,8 @@ combined background counts in any channel is 0.
         page for this script</HREF> on the CIAO website for an up-to-date listing of known bugs. 
       </PARA>
     </BUGS>
-
    
-    <LASTMODIFIED>September 2018</LASTMODIFIED>
-
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/correct_periscope_drift.xml
+++ b/ciao-4.11/contrib/share/doc/xml/correct_periscope_drift.xml
@@ -195,14 +195,11 @@ corr_data_zag.png
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>September 2016</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
-
-    </ENTRY>    
+  </ENTRY>    
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/deflare.xml
+++ b/ciao-4.11/contrib/share/doc/xml/deflare.xml
@@ -643,9 +643,7 @@
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -658,7 +656,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>October 2018</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/detilt.xml
+++ b/ciao-4.11/contrib/share/doc/xml/detilt.xml
@@ -106,9 +106,7 @@
         This tool is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-	instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -120,7 +118,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>September 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/dewiggle.xml
+++ b/ciao-4.11/contrib/share/doc/xml/dewiggle.xml
@@ -108,9 +108,7 @@
         This tool is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-	instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -122,7 +120,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2016</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/download_chandra_obsid.xml
+++ b/ciao-4.11/contrib/share/doc/xml/download_chandra_obsid.xml
@@ -300,9 +300,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 	This script is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-	instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -315,6 +313,6 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/download_obsid_caldb.xml
+++ b/ciao-4.11/contrib/share/doc/xml/download_obsid_caldb.xml
@@ -394,9 +394,7 @@ they are skipped and only the background files are actually retrieved.
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
     
@@ -411,7 +409,7 @@ they are skipped and only the background files are actually retrieved.
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>September 2018</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>
 

--- a/ciao-4.11/contrib/share/doc/xml/hrc_bkgrnd_lookup.xml
+++ b/ciao-4.11/contrib/share/doc/xml/hrc_bkgrnd_lookup.xml
@@ -203,10 +203,7 @@
 	This script is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF>
-	for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
 
       <PARA title="Downloading the CALDB background files">
@@ -227,7 +224,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/install_marx.xml
+++ b/ciao-4.11/contrib/share/doc/xml/install_marx.xml
@@ -185,13 +185,9 @@ bash: source /soft/marx/setup_marx.sh
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
-    
-    
 
     <BUGS>
 
@@ -203,8 +199,8 @@ bash: source /soft/marx/setup_marx.sh
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>April 2018</LASTMODIFIED>
-</ENTRY>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
+  </ENTRY>
 </cxchelptopics>
 
     

--- a/ciao-4.11/contrib/share/doc/xml/lc_clean.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lc_clean.xml
@@ -341,9 +341,7 @@ unix% dmcopy "evt2.fits[@clean.gti]" evt2_filt.fits
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -356,7 +354,7 @@ unix% dmcopy "evt2.fits[@clean.gti]" evt2_filt.fits
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/lc_sigma_clip.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lc_sigma_clip.xml
@@ -348,9 +348,7 @@ unix% dmcopy "evt2.fits[@clip.gti]" evt2_filt.fits
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -363,7 +361,7 @@ unix% dmcopy "evt2.fits[@clip.gti]" evt2_filt.fits
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>May 2017</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/lightcurves.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lightcurves.xml
@@ -156,9 +156,7 @@ from lightcurves import *
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -171,7 +169,7 @@ from lightcurves import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>October 2011</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/make_instmap_weights.xml
+++ b/ciao-4.11/contrib/share/doc/xml/make_instmap_weights.xml
@@ -174,9 +174,7 @@
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -189,8 +187,7 @@
       </PARA>
     </BUGS>
 
-    <VERSION>02 June 2010</VERSION>
-    <LASTMODIFIED>June 2010</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/make_psf_asymmetry_region.xml
+++ b/ciao-4.11/contrib/share/doc/xml/make_psf_asymmetry_region.xml
@@ -253,9 +253,7 @@
        This script is not an official part of the CIAO release but is
        made available as "contributed" software via the
        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-       Please see the
-       <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-       instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
      </PARA>
    </ADESC>
 
@@ -268,6 +266,6 @@
      </PARA>
    </BUGS>
    
-   <LASTMODIFIED>March 2018</LASTMODIFIED>
+   <LASTMODIFIED>December 2018</LASTMODIFIED>
  </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/mkbgreg.xml
+++ b/ciao-4.11/contrib/share/doc/xml/mkbgreg.xml
@@ -64,9 +64,7 @@ Output filename: bkg.reg
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.	
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -79,8 +77,7 @@ Output filename: bkg.reg
       </PARA>
     </BUGS>
 
-    <VERSION>mkBgReg.pl v1.1 (CIAO 3.1 or higher)</VERSION>
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>
 

--- a/ciao-4.11/contrib/share/doc/xml/mksubbgreg.xml
+++ b/ciao-4.11/contrib/share/doc/xml/mksubbgreg.xml
@@ -73,9 +73,7 @@ ellipse(4098.84,3656.79,13.02,7.07,51.12)-ellipse(4098.84,3656.79,6.51,3.53,51.1
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.	
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -88,8 +86,7 @@ ellipse(4098.84,3656.79,13.02,7.07,51.12)-ellipse(4098.84,3656.79,6.51,3.53,51.1
       </PARA>
     </BUGS>
 
-    <VERSION>mkSubBgReg.pl v1.1 (CIAO 3.1 or higher)</VERSION>
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>
 

--- a/ciao-4.11/contrib/share/doc/xml/readout_bkg.xml
+++ b/ciao-4.11/contrib/share/doc/xml/readout_bkg.xml
@@ -247,9 +247,7 @@ sherpa&gt; plot_bkg()
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -262,6 +260,6 @@ sherpa&gt; plot_bkg()
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>July 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/simulate_psf.xml
+++ b/ciao-4.11/contrib/share/doc/xml/simulate_psf.xml
@@ -989,9 +989,7 @@
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -1005,11 +1003,7 @@
       </PARA>
     </BUGS>
 
-
-
-
-   <LASTMODIFIED>September 2018</LASTMODIFIED>
-
+   <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/splitroi.xml
+++ b/ciao-4.11/contrib/share/doc/xml/splitroi.xml
@@ -111,9 +111,7 @@
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -128,6 +126,6 @@
     </BUGS>
     -->
 
-    <LASTMODIFIED>November 2012</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/symmetrize.xml
+++ b/ciao-4.11/contrib/share/doc/xml/symmetrize.xml
@@ -111,9 +111,7 @@
         This tool is not an official part of the CIAO release but is
 	made available as "contributed" software via the
 	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-	Please see the
-	<HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-	instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -125,7 +123,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>September 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/tg_bkg.xml
+++ b/ciao-4.11/contrib/share/doc/xml/tg_bkg.xml
@@ -80,9 +80,7 @@
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
 
@@ -95,7 +93,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>
 

--- a/ciao-4.11/contrib/share/doc/xml/tgsplit.xml
+++ b/ciao-4.11/contrib/share/doc/xml/tgsplit.xml
@@ -413,9 +413,7 @@ Created background spectrum: tgcat_obs7435_heg_p1_bkg.pha
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
         <HREF link="http://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
-        Please see the
-        <HREF link="http://cxc.harvard.edu/ciao/download/scripts/instructions.html">installation
-          instructions page</HREF> for help on installing the package.
+        Please see this page for installation instructions.
       </PARA>
     </ADESC>
     
@@ -429,8 +427,7 @@ Created background spectrum: tgcat_obs7435_heg_p1_bkg.pha
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>September 2018</LASTMODIFIED>
+    <LASTMODIFIED>December 2018</LASTMODIFIED>
 
-
-    </ENTRY>    
+  </ENTRY>    
 </cxchelptopics>


### PR DESCRIPTION
The scripts/instructions.html page no-longer exists, so replace with
a generic statement to "look at the contrib page" for installation
instructions.

This fixes all but fullgarf.xml, which is currently being changed in
another PR so let's avoid a rebase/merge.