### PR TITLE
Change ardlibqual to hidden and fix a typo

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -3,11 +3,6 @@
 
 Updated scripts
 
-  fullgarf
-
-    The script has a new parameter tat allows to pass ardlib qualifiers
-    to the calls to mkgarf.
-
   chandra_repro
   
     The script has been updated for HRC to keep all the standard 
@@ -21,6 +16,12 @@ Updated scripts
     default). This parameter is also supported by flux_obs and merge_obs,
     which also add the psfmerge parameter for chosing how the
     per-observation PSF maps are combined.
+
+  fullgarf
+
+    The script has a new parameter, ardlibqual, that allows users to pass
+    ardlib qualifiers to the calls to mkgarf. This is useful for handling
+    spectra simulated with MARX.
 
 Updated Python modules
 

--- a/ciao-4.11/contrib/param/fullgarf.par
+++ b/ciao-4.11/contrib/param/fullgarf.par
@@ -9,7 +9,7 @@ rootname,s,a,"",,,"Output rootname"
 dafile,s,h,"CALDB",,,"NONE, CALDB, or name of ACIS dead-area calibration file"
 osipfile,s,h,"CALDB",,,"NONE or Name of fits file with order sorting info"
 maskfile,s,a,"",,,"NONE, or name of ACIS window mask file"
-ardlibqual,s,a,"",,,"Additional ardlib qualifiers"
+ardlibqual,s,h,"",,,"Additional ardlib qualifiers"
 #
 clobber,b,h,no,,,"Clobber existing output files? This is passed to ALL child processes."
 verbose,i,h,0,0,5,"Control the level of diagnostic output. 0=>least."


### PR DESCRIPTION
This was originally a fix for a small typo in the readme, but then I noticed that the new `ardlibqual` parameter to `fullgarf` was listed as automatic (`a`) rather than hidden (`h`).