### PR TITLE
chandra_repro: do not write out a second HISTORY block (fix #175)

### DIFF
--- a/ciao-4.11/contrib/bin/chandra_repro
+++ b/ciao-4.11/contrib/bin/chandra_repro
@@ -1009,7 +1009,7 @@ def reset_acis_status(params):
     v5("Filename for reset event file: " + reset_file)
 
     v1("Resetting afterglow status bits in evt1.fits file...")
-    cdw.clear_acis_status_bits(reset_file, "chandra_repro")
+    cdw.clear_acis_status_bits(reset_file)
 
     v2('Created intermediate evt1 with afterglow status reset:\n'+reset_file)
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cxcdm_wrapper.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cxcdm_wrapper.py
@@ -1,8 +1,5 @@
-
-# Python35Support
-
 #
-#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016
+#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -36,8 +33,6 @@ The API is not guaranteed to remain stable, so use at your own risk.
 import os
 import sys
 import time
-
-import six
 
 from collections import namedtuple
 
@@ -158,7 +153,7 @@ def get_block_info(bl):
     # seen some issues with the NumPy string type when sending empty
     # values to parallel processes using multiprocessing.
     #
-    keyinfo = { "HDUNAME": Record("HDUNAME", blname, None, None) }
+    keyinfo = {"HDUNAME": Record("HDUNAME", blname, None, None)}
     for key in blockGetKeyList(bl):
         keyname = getName(key)
         keyval = getData(key)
@@ -604,14 +599,15 @@ def _clear_status_column(dd, nrows):
         setData(dd, ndata, i)
 
 
-def clear_acis_status_bits(fname, toolname):
+def clear_acis_status_bits(fname, toolname=None):
     """Clear bits 1-5, 14-20, and 23 of the STATUS
     column of fname. The edits are made in place.
 
-    toolname is the name of the tool written to the HISTORY header,
-    and the CLSTBITS keyword will be added/modified to indicate
+    The CLSTBITS keyword will be added/modified to indicate
     the bit-mask used.
 
+    toolname, if not None, is the name of the tool written to the
+    HISTORY header,
     """
 
     timeVal = time.strftime("%Y-%m-%dT%H:%M:%S")
@@ -625,14 +621,20 @@ def clear_acis_status_bits(fname, toolname):
     nrows = tableGetNoRows(bl)
     _clear_status_column(col, nrows)
 
+    # should perhaps just use str(_cbits_str)
+    keyWrite(bl, "CLSTBITS", "{}".format(_cbits_str),
+             desc="0 means clear STATUS bit")
+
     # Add a note to the history records; we do not try to replicate
     # the CXCDM history block as we have no parameter file.
     #
-    keyWrite(bl, "CLSTBITS", "{0}".format(_cbits_str),
-             desc="0 means clear STATUS bit")
-    blockWriteComment(bl, "HISTORY", "TOOL: {0} at {1}".format(toolname,
-                                                               timeVal))
-    blockWriteComment(bl, "HISTORY", "  infile={0}".format(fname))
+    # This could be updated to use the CIAO-4.11 history functionality,
+    # but that is more Crates than cxcdm based.
+    #
+    if toolname is not None:
+        blockWriteComment(bl, "HISTORY", "TOOL: {} at {}".format(toolname,
+                                                                 timeVal))
+        blockWriteComment(bl, "HISTORY", "  infile={}".format(fname))
 
     tableClose(bl)
 


### PR DESCRIPTION
The clear acis status bits functionality - called by chandra_repro - added
a HISTORY record in non-standard format, which was causing some confusion.
The change is to make this header addition optional, and for chandra_repro
not to make the change.

One option would be for chandra_repro to call clear_acis_status_bits
with toolname set to 'acis_clear_status_bits', but that is a bit risky
(when/if the script gets removed or renamed).

Note: I did not add any documentation about this change to chandra_repro, as I don't think it's worth it.