### PR TITLE
Dax sherpa scripts

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -23,6 +23,14 @@ Updated scripts
     ardlib qualifiers to the calls to mkgarf. This is useful for handling
     spectra simulated with MARX.
 
+  dax
+  
+    Clarified error messages to indicate that users must have regions
+    selected to perform spectral or spatial fits.  Additional
+    internal changes to use python scripts to perform sherpa fits
+    rather than using sherpa IPython wrapper.  
+
+
 Updated Python modules
 
   ciao_contrib.runtool

--- a/ciao-4.11/contrib/share/doc/xml/dax.xml
+++ b/ciao-4.11/contrib/share/doc/xml/dax.xml
@@ -132,6 +132,16 @@ source $ASCDS_INSTALL/contrib/config/chips_startup.tk
    </ADESC>
 
 
+<ADESC title="Changes in the 4.11.1 (December 2018) release">
+  <PARA>
+    Clarified error messages to indicate that users must have regions
+    selected to perform spectral or spatial fits.  Additional
+    internal changes to use python scripts to perform sherpa fits
+    rather than using sherpa IPython wrapper.    
+  </PARA>
+</ADESC>
+
+
 <ADESC title="Changes in the 4.10.3 (October 2018) release">
 <PARA>
       Updated to ensure that on systems where ds9 autoloads 
@@ -182,6 +192,6 @@ clear which task is being run.
       </PARA>
    </BUGS>
 
-   <LASTMODIFIED>September 2018</LASTMODIFIED>
+   <LASTMODIFIED>November 2018</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #182 .

The dax scripts now create and run python scripts rather than using the sherpa ipython wrapper.

I also updated error messages to be clear that regions have to be **selected** for fitting to be performed.  
The code was always intending for this to happen, but the earlier versions of ds9 didn't recognize the old syntax error which was corrected in 4.10.3.
