### PR TITLE
splitroi update to restore point(0,0) behavior

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -30,6 +30,11 @@ Updated scripts
     internal changes to use python scripts to perform sherpa fits
     rather than using sherpa IPython wrapper.  
 
+  splitroi
+  
+    Updated to use "point(0,0)" when it finds a blank source
+    or background region.   This restores the behavior of the script
+    to what is was before changes that were made in CIAO 4.10.
 
 Updated Python modules
 

--- a/ciao-4.11/contrib/bin/splitroi
+++ b/ciao-4.11/contrib/bin/splitroi
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # 
-# Copyright (C) 2011, 2012  Smithsonian Astrophysical Observatory
+# Copyright (C) 2011, 2012, 2018  Smithsonian Astrophysical Observatory
 # 
 # 
 # 
@@ -36,7 +36,7 @@ gives the head/stem of the output files created:
 """
 
 toolname = "splitroi"
-version = "08 November 2012"
+version = "29 November 2018"
 
 import sys
 
@@ -52,7 +52,22 @@ def rparse(fname):
     """
 
     try:
-        return region.regParse("region({})".format(fname))
+        retval = region.regParse("region({})".format(fname))
+
+        # In CIAO 4.10, FITS regions with 0 rows are now returning
+        # a region with 0 shapes to which regRegionString() 
+        # returns a blank string.  stk_expand on blank lines
+        # are lost (multiple-stack separators are collapsed into 1)
+        # this may produce different number of regions in the src
+        # and bg outputs.
+        #
+        # This workaround restores the point(0,0) which was what
+        # the DM/regionlib did before CIAO 4.10. 
+        #
+        if region.regGetNoShapes(retval) == 0:
+            retval = region.regParse("point(0,0)")
+        
+        return retval
 
     except ValueError as ve:
         if str(ve) == "regParse() Could not parse region string":

--- a/ciao-4.11/contrib/share/doc/xml/splitroi.xml
+++ b/ciao-4.11/contrib/share/doc/xml/splitroi.xml
@@ -100,6 +100,18 @@
       </QEXAMPLE>
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in scripts 4.11.1 (December 2018) release">
+      <PARA>
+        Updated to restore the use of the region string "point(0,0)" for
+        empty regions.  In CIAO 4.10, the output would contain blank
+        lines for empty regions; blank lines are skipped when 
+        the files are processed as stacks which could cause 
+        a mismatch in source to background mapping.
+      </PARA>
+    
+    </ADESC>
+
+
     <ADESC title="Changes in the December 2012 Release">
       <PARA>
 	The script has been updated to work in CIAO 4.5.
@@ -115,16 +127,6 @@
       </PARA>
     </ADESC>
 
-    <!--
-    <BUGS>
-      <PARA>
-        See the
-        <HREF link="http://cxc.harvard.edu/ciao/bugs/acis_clear_status_bits.html">bugs page
-        for this script</HREF> on the CIAO website for an up-to-date
-	listing of known bugs.
-      </PARA>
-    </BUGS>
-    -->
 
     <LASTMODIFIED>December 2018</LASTMODIFIED>
   </ENTRY>


### PR DESCRIPTION
In CIAO 4.10, FITS regions with 0 rows are now returning
a region with 0 shapes to which regRegionString() 
returns a blank string.  stk_expand on blank lines
are lost (multiple-stack separators are collapsed into 1)
this may produce different number of regions in the src
and bg outputs.

This workaround restores the point(0,0) which was what
he DM/regionlib did before CIAO 4.10. 

Ref: CXC Helpdesk ticket 21625 where user running `srcflux` (which runs `splitroi`) ran into this very problem : a mismatch between number of src and background regions.

