### PR TITLE
Try and support CERTIFICATE_VERIFY_FAILED errors

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -1,4 +1,3 @@
-
 ## 4.11.2 - March 2019 ##
 
 Updated scripts
@@ -8,6 +7,11 @@ Updated scripts
     Updates to support level-2 event files with no exposure time: the
     FOV file will be created using the time ranges from the asol1 file
     or files.
+
+  find_chandra_obsid
+
+    Work around CERTIFICATE_VERIFY_FAILED errors seen on some macOS/openSSL
+    systems, falling through to curl or wget to download the data.
 
   install_marx
 

--- a/ciao-4.11/contrib/bin/find_chandra_obsid
+++ b/ciao-4.11/contrib/bin/find_chandra_obsid
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018
+#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -76,16 +76,11 @@ ftp://anonymous:foo@bar.org@cda.cfa.harvard.edu/pub/.
 """
 
 toolname = "find_chandra_obsid"
-version = "06 Nov 2018"
+version = "08 Feb 2019"
 
 import sys
 import os
 import math
-
-from six.moves import urllib
-import six
-
-import socket
 
 import paramio as pio
 
@@ -113,6 +108,8 @@ from ciao_contrib.param_wrapper import open_param_file
 
 from ciao_contrib.cda import search
 from ciao_contrib.cda import data
+
+from ciao_contrib.downloadutils import retrieve_url
 
 import coords.format as coords
 from coords import resolver
@@ -336,7 +333,7 @@ def ask_download(nobsid):
 
     print("")
     while True:
-        resp = six.moves.input(prompt)
+        resp = input(prompt)
         ans = resp.strip().lower()
         if ans == "":
             continue
@@ -515,33 +512,8 @@ def find_obsid_position(obsid):
     # assuming no need to protect or sanitize the input
     url = 'https://cda.harvard.edu/srservices/ocatDetails.do?obsid={}&format=text'.format(obsid)
 
-    # error handling based on ciao_contrib.caldb.get_caldb_releases()
-    try:
-        v3("Trying to identify obsid={}".format(obsid))
-        v4(" using URL={}".format(url))
-        ans = urllib.request.urlopen(url)
-
-    except urllib.error.URLError as ue:
-        # There used to be a lot of code trying to provide a
-        # "nice" error message, but it was not well tested,
-        # so simplify
-        #
-        v3("Error opening URL: {}".format(ue))
-
-        if hasattr(ue, 'reason'):
-            v3("error.reason = {}".format(ue.reason))
-
-            if ue.reason == 'unknown url type: https':
-                ans = search._manual_download(url)
-            else:
-                raise
-        else:
-            raise
-
-    # Ugly code; what is the better way to do this
-    ans = ans.read()
-    if not isinstance(ans, six.string_types):
-        ans = ans.decode('utf8')
+    v3("Trying to identify obsid={}".format(obsid))
+    ans = retrieve_url(url).read().decode('utf8')
 
     v3("==> Response from CDA query for ObsId={} is:".format(obsid))
     v3(ans)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/search.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/search.py
@@ -40,27 +40,16 @@ Although the SIA protocol is general, this module is only
 designed to work with the Chandra service and may not work
 with other access points.
 
-Since the footprint server is - as of the middle of 2018 - now
-accessed via https, the ability to download data depends on
-if Python includes SSL support, which is unfortunately not the
-case for all builds of CIAO 4.10 (primarily OS-X but it may also
-affect Linux users using an OS different from CentOS or Ubuntu).
-In the latter case a fall through to using the command-line
-tools curl or wget is attempted.
-
 Example
 -------
 
-    from ciao_contrib.utils import write_columns
-    sr = search_chandra_archive(8.815, -43.566, size=0.3)
-    obsinfo = get_chandra_obs(sr)
-    print(obsinfo['obsid'])
-    write_columns('search.dat', obsinfo, kernel='simple')
+>>> from ciao_contrib.utils import write_columns
+>>> sr = search_chandra_archive(8.815, -43.566, size=0.3)
+>>> obsinfo = get_chandra_obs(sr)
+>>> print(obsinfo['obsid'])
+>>> write_columns('search.dat', obsinfo, kernel='simple')
 
 """
-
-from six.moves import urllib
-import six
 
 import numpy as np
 
@@ -69,6 +58,8 @@ from collections import OrderedDict
 
 import coords.format as coords
 import coords.utils as cutils
+
+from ciao_contrib.downloadutils import retrieve_url
 
 import ciao_contrib.logger_wrapper as lw
 
@@ -115,13 +106,13 @@ def _get_child(parent, name, attr=None):
             resource = name
         else:
             (aname, avalue) = attr
-            resource = "{0}[{1}={2}]".format(name, aname, avalue)
+            resource = "{}[{}={}]".format(name, aname, avalue)
 
         if nout == 0:
-            raise ValueError("No child called {0} of {1}".format(resource, parent.tag))
+            raise ValueError("No child called {} of {}".format(resource, parent.tag))
 
         else:
-            raise ValueError("Expected 1 {0} child of {1} but found {2}".format(resource, parent.tag, nout))
+            raise ValueError("Expected 1 {} child of {} but found {}".format(resource, parent.tag, nout))
 
 
 def _get_children(parent, name, attr=None):
@@ -207,7 +198,7 @@ def _valconv(val, fmt):
         cfunc = float
 
     else:
-        raise ValueError("Unrecognized data type: {0}".format(datatype))
+        raise ValueError("Unrecognized data type: {}".format(datatype))
 
     if arraysize is None:
         return cfunc(val)
@@ -216,7 +207,7 @@ def _valconv(val, fmt):
         return [cfunc(v) for v in val.split(',')]
 
     else:
-        raise ValueError("Unsupported arraysize value of {0}".format(arraysize))
+        raise ValueError("Unsupported arraysize value of {}".format(arraysize))
 
 
 def read_chandra_siap_table(fname):
@@ -247,14 +238,14 @@ def read_chandra_siap_table(fname):
 
     root = vot.getroot()
     if root.tag != _mkl('VOTABLE'):
-        raise IOError("Expected VOTABLE but found {0} as the root element".format(root.tag))
+        raise IOError("Expected VOTABLE but found {} as the root element".format(root.tag))
 
     res = _get_child(vot, 'RESOURCE', attr=('type', 'results'))
 
     # Check download status
     st = _get_child(res, 'INFO', attr=('name', 'QUERY_STATUS'))
     if st.get('value') != 'OK':
-        raise ValueError("Query failed: {0}".format(st.text))
+        raise ValueError("Query failed: {}".format(st.text))
 
     # Coordnate mapping
     coosys = res.findall('COOSYS')
@@ -276,13 +267,13 @@ def read_chandra_siap_table(fname):
     # to NumPy types. Not the most memory efficient but it is assumed
     # that the number of rows is small.
     #
-    coldata = { c['name']: [] for c in cols }
+    coldata = {c['name']: [] for c in cols}
     rowctr = 0
     for row in tbl.findall(_combl('DATA', 'TABLEDATA', 'TR')):
         rowctr += 1
         tds = _get_children(row, 'TD')
         if len(tds) != ncols:
-            raise ValueError("Expected {0} columns in row #{1} but found {2}".format(ncols, rowctr, len(tds)))
+            raise ValueError("Expected {} columns in row #{} but found {}".format(ncols, rowctr, len(tds)))
 
         for (col, colinfo) in zip(tds, cols):
             coldata[colinfo['name']].append(_valconv(col.text,
@@ -294,7 +285,7 @@ def read_chandra_siap_table(fname):
         out[cname] = np.asarray(coldata[cname])
         nr = out[cname].shape[0]
         if nr != nrows:
-            raise ValueError("Expected {0} rows in column {1} but found {2}".format(nrows, cname, nr))
+            raise ValueError("Expected {} rows in column {} but found {}".format(nrows, cname, nr))
 
     # We could return the ordered dict, or store it in a dictionary along
     # with some meta data. Instead, let's try using a structured array.
@@ -308,9 +299,9 @@ def read_chandra_siap_table(fname):
         else:
             return (k, v.dtype, v.shape[1:])
 
-    dtypes = [mkdtype(k, v) for (k, v) in six.iteritems(out)]
+    dtypes = [mkdtype(k, v) for (k, v) in out.items()]
     sout = np.zeros(nrows, dtype=dtypes)
-    for (k, v) in six.iteritems(out):
+    for (k, v) in out.items():
         sout[k] = v
 
     return sout
@@ -365,8 +356,8 @@ def construct_query(ra, dec, size,
 
     """
 
-    url ="https://cxcfps.cfa.harvard.edu/"
-    url +="cgi-bin/cda/footprint/get_vo_table.pl"
+    url = "https://cxcfps.cfa.harvard.edu/"
+    url += "cgi-bin/cda/footprint/get_vo_table.pl"
     url += "?strict=1&POS={},{}&SIZE={}".format(ra, dec, size)
 
     if instrument is not None:
@@ -375,66 +366,6 @@ def construct_query(ra, dec, size,
                          for i in set(instrument)])
 
     return url
-
-
-def _manual_download(url):
-    """Try curl then wget to query the URL.
-
-    Parameters
-    ----------
-    url : str
-        The URL for the query; see construct_query
-
-    Returns
-    -------
-    ans : ?
-
-    """
-
-    from subprocess import check_output
-    from six.moves import StringIO
-    import six
-
-    v3("Fall back to curl or wget to download the data")
-
-    # Should package this up nicely, but hardcode for the moment.
-    #
-    # Python 2.7 throws OSError ("no such file or directory")
-    # and    3.5        FileNotFoundError (a subclass of OSError
-    #                   which has a similar, but not the same,
-    #                   message)
-    #
-    # It is not clear if this is sufficient to catch "no curl"
-    # while allowing errors like "no access to the internet"
-    # to not cause too much pointless work.
-    #
-    args = ['curl', '--silent', '-L', url]
-    v4("About to execute: {}".format(args))
-
-    try:
-        rsp = check_output(args)
-
-    except OSError as exc1:
-        v3("Unable to call curl: {}".format(exc1))
-        args = ['wget', '--quiet', '-O-', url]
-        v4("About to execute: {}".format(args))
-
-        try:
-            rsp = check_output(args)
-
-        except OSError as exc2:
-            v3("Unable to call wget: {}".format(exc2))
-            emsg = "Unable to access the CXC footprint server. " + \
-                   "Please install curl or wget (if you continue " + \
-                   "to see this message, contact the CXC " + \
-                   "HelpDesk)."
-            raise RuntimeError(emsg)
-
-    # Ugly; should do better
-    if six.PY2:
-        return StringIO(rsp)
-    else:
-        return StringIO(rsp.decode("utf-8"))
 
 
 def _make_query(url):
@@ -451,36 +382,9 @@ def _make_query(url):
         The response, as a NumPy structured array, if there are
         any rows, otherwise None.
 
-    Notes
-    -----
-    This is complicated by the fact that not all versions of CIAO 4.10
-    support using SSL. For these, a fall back to curl and wget
-    command-line tools is attempted.
-
     """
 
-    try:
-        v3("URL: {0}".format(url))
-        rsp = urllib.request.urlopen(url)
-
-    except urllib.error.URLError as ue:
-        v3("Error opening URL: {0}".format(ue))
-        v3("error.reason = {0}".format(ue.reason))
-
-        # Assume this is the error message indicating "no SSL support"
-        if ue.reason == 'unknown url type: https':
-            rsp = _manual_download(url)
-
-        else:
-            # There used to be a check on the reason for the error,
-            # converting it into a "user-friendly" message, but this
-            # was error prone (the check itself was faulty) and
-            # potentially hid useful error information. So just
-            # re-raise the error here after logging it: is it really
-            # worth logging this error condition?
-            #
-            raise
-
+    rsp = retrieve_url(url)
     return read_chandra_siap_table(rsp)
 
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/search.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/search.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2018
+#  Copyright (C) 2011, 2015, 2016, 2018, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -234,7 +234,10 @@ def read_chandra_siap_table(fname):
     Metadata from the table is currently not returned.
     """
 
-    vot = ElementTree.parse(fname)
+    try:
+        vot = ElementTree.parse(fname)
+    except ElementTree.ParseError as exc:
+        raise OSError("Input is not an XML file.\n{}".format(exc))
 
     root = vot.getroot()
     if root.tag != _mkl('VOTABLE'):
@@ -385,7 +388,13 @@ def _make_query(url):
     """
 
     rsp = retrieve_url(url)
-    return read_chandra_siap_table(rsp)
+    try:
+        ans = read_chandra_siap_table(rsp)
+    except OSError as exc:
+        raise OSError("There may be a problem with the CXC " +
+                      "footprint service.\n{}".format(exc))
+
+    return ans
 
 
 def search_chandra_archive(ra, dec, size=0.1,

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/downloadutils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/downloadutils.py
@@ -1,0 +1,147 @@
+#
+#  Copyright (C) 2018
+#            Smithsonian Astrophysical Observatory
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Support downloading data from URLs in CIAO.
+
+CIAO 4.11 does not include any SSL support, instead relying on the OS.
+This can cause problems on certain platforms. So try with Python and
+then fall through to curl or wget.
+
+This is an internal module, and so the API it provides is not
+considered stable (e.g. we may remove this module at any time). Use
+at your own risk.
+
+"""
+
+
+from io import StringIO
+from subprocess import check_output
+import urllib
+import urllib.request
+import urllib.error
+
+import ciao_contrib.logger_wrapper as lw
+
+logger = lw.initialize_module_logger("downloadutils")
+
+v3 = logger.verbose3
+v4 = logger.verbose4
+
+
+def manual_download(url):
+    """Try curl then wget to query the URL.
+
+    Parameters
+    ----------
+    url : str
+        The URL for the query; see construct_query
+
+    Returns
+    -------
+    ans : StringIO instance
+        The response
+
+    """
+
+    v3("Fall back to curl or wget to download: {}".format(url))
+
+    # Should package this up nicely, but hardcode for the moment.
+    #
+    # It is not clear if this is sufficient to catch "no curl"
+    # while allowing errors like "no access to the internet"
+    # to not cause too much pointless work.
+    #
+    args = ['curl', '--silent', '-L', url]
+    v4("About to execute: {}".format(args))
+
+    try:
+        rsp = check_output(args)
+
+    except FileNotFoundError as exc1:
+        v3("Unable to call curl: {}".format(exc1))
+        args = ['wget', '--quiet', '-O-', url]
+        v4("About to execute: {}".format(args))
+
+        try:
+            rsp = check_output(args)
+
+        except FileNotFoundError as exc2:
+            v3("Unable to call wget: {}".format(exc2))
+            emsg = "Unable to access the URL {}.\n".format(url) + \
+                   "Please install curl or wget (and if you " + \
+                   "continue to see this message, contact the " + \
+                   "CXC HelpDesk)."
+            raise RuntimeError(emsg)
+
+    return StringIO(rsp.decode("utf-8"))
+
+
+def retrieve_url(url, timeout=None):
+    """Handle possible problems retrieving the URL contents.
+
+    Using URLs with the https scheme causes problems for certain OS
+    set ups because CIAO 4.11 does not provide SSL support, but relies
+    on the system libraries to work. This is "supported" by falling
+    over from Python to external tools (curl or wget).
+
+    Parameters
+    ----------
+    url : str
+        The URL to retrieve.
+    timeout : optional
+        The timeout parameter for the urlopen call; if not
+        None then the value is in seconds.
+
+    Returns
+    -------
+    response : StringIO instance
+        The response
+
+    """
+
+    try:
+        v3("Retrieving URL: {} timeout={}".format(url, timeout))
+        if timeout is None:
+            return urllib.request.urlopen(url)
+        else:
+            return urllib.request.urlopen(url, timeout=timeout)
+
+    except urllib.error.URLError as ue:
+        v3("Error opening URL: {}".format(ue))
+        v3("error.reason = {}".format(ue.reason))
+
+        # Assume this is the error message indicating "no SSL support"
+        # There is a new (in CIAO 4.11) message
+        # "urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:719)"
+        #
+        # It appears that the reason attribute can be an object, so
+        # for now explicitly convert to a string:
+        reason = str(ue.reason)
+        if reason.find('unknown url type: https') != -1 or \
+           reason.find('CERTIFICATE_VERIFY_FAILED') != -1:
+            return manual_download(url)
+
+        # There used to be a check on the reason for the error,
+        # converting it into a "user-friendly" message, but this
+        # was error prone (the check itself was faulty) and
+        # potentially hid useful error information. So just
+        # re-raise the error here after logging it.
+        #
+        raise

--- a/ciao-4.11/contrib/share/doc/xml/find_chandra_obsid.xml
+++ b/ciao-4.11/contrib/share/doc/xml/find_chandra_obsid.xml
@@ -795,6 +795,14 @@ Download [y, n, q, a, h]: y
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+      <PARA>
+	Support running on some macOS/openSSL systems by catching
+	CERTIFICATE_VERIFY_FAILED errors and falling through to curl
+	or wget in these cases.
+      </PARA>
+    </ADESC>
+    
     <ADESC title="Changes in the scripts 4.10.3 (November 2018) release">
       <PARA>
 	Fall through to curl or wget for https access to the
@@ -870,6 +878,6 @@ Download [y, n, q, a, h]: y
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2018</LASTMODIFIED>
+    <LASTMODIFIED>February 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
It is not clear why we are getting these messages, so try and fall
through to curl/wget if we do get them. Seems to be a macOS issue
at present.

Should the csccli routines be updated to use this "downloadutils"
module? Note that at the moment the csccli access doesn't need
https support I believe.