### PR TITLE
correct_periscope_drift now uses Sherpa to create plots (support matplotlib, fix #202)

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -20,6 +20,16 @@ The plots may have changed slightly in this update (for instance, the
 labelling is slightly different in some of the plots), and support for
 the overplot and clearwindow arguments has been added where necessary.
 
+Updated scripts
+
+  correct_periscope_drift
+
+    The script now uses the same plotting backend (ChIPS or Matplotlib)
+    as Sherpa does. Switching to Matplotlib will allow the script to
+    work when there is no X Display, is run over a remote connection, or
+    when run on recent macOS systems.
+
+
 ## 4.11.3 - May 2019 ##
 
 This update includes an imporant bugfix to srcflux, which had been

--- a/ciao-4.11/contrib/bin/correct_periscope_drift
+++ b/ciao-4.11/contrib/bin/correct_periscope_drift
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010, 2016  Smithsonian Astrophysical Observatory
+# Copyright (C) 2010, 2016, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -24,35 +24,25 @@
 
 """
 
-TOOLNAME = "correct_periscope_drift"
-VERSION = "0.2"
-
-# import standard python modules as required
 import os
 import sys
 import logging
 import numpy as np
 
-
-# Import the CIAO contributed modules.
-# 
-# Here I explicitly name what is imported for documentation
-# purposes. You can use the 'from foo import *' syntax but
-# in general it is better to either be explicit or load
-# into a separate namespace, so that you can find out
-# where a routine or symbol is defined
-#
-
-
-from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
+from ciao_contrib.logger_wrapper import initialize_logger, \
+    make_verbose_level, set_verbosity, handle_ciao_errors
 from ciao_contrib.param_wrapper import open_param_file
 from ciao_contrib.runtool import add_tool_history
 from ciao_contrib._tools.fileio import outfile_clobber_checks
 import pycrates
-from pychips import (add_curve, print_window, set_plot_xlabel, set_plot_ylabel, clear_plot,
-                     add_window, set_plot_title, limits, Y_AXIS)
-from sherpa import ui
 import paramio as pio
+
+from sherpa import ui
+from sherpa import plot
+
+
+TOOLNAME = "correct_periscope_drift"
+VERSION = "0.3"
 
 # Set up the logging/verbose code
 initialize_logger(TOOLNAME)
@@ -332,6 +322,143 @@ def write_key(crate, name, value, comment, units=""):
     crate.add_key(kw)
 
 
+def make_fit_plot(evt_times, fit_data, mp, ax):
+    """Create the plot of the binned data and fit."""
+
+    bin_centers, bin_mean, bin_std = time_bins(evt_times, fit_data)
+    dx = (bin_centers - evt_times[0]) / 1000.
+
+    # set minimum limit on fit plot in arcsecs and set this explicitly
+    # as a symmetric limit
+    fit_ymax = max(0.3,
+                   np.max(np.abs(bin_mean - bin_std)),
+                   np.max(np.abs(bin_mean + bin_std)))
+
+    # Rather than create a data object to pass to .prepare, set the
+    # attributes manually.
+    #
+    dplot = plot.DataPlot()
+    dplot.x = dx
+    dplot.y = bin_mean
+    dplot.yerr = bin_std
+    dplot.xlabel = 'Observation elapsed/delta time (ks)'
+    dplot.ylabel = 'Position offset from mean, {} (arcsec)'.format(ax)
+    dplot.title = 'Fit of {} data (with time-binned event offsets)'.format(ax)
+
+    # Backend-specific customization
+    #
+    if 'errstyle' in dplot.plot_prefs:
+        dplot.plot_prefs['errstyle'] = 'cap'
+
+    if 'capsize' in dplot.plot_prefs:
+        dplot.plot_prefs['capsize'] = 5
+
+    mplot = plot.ModelPlot()
+    mplot.x = mp.x / 1000
+    mplot.y = mp.y
+
+    try:
+        plot.begin()
+        dplot.plot()
+        mplot.plot(overplot=True)
+        ylimits(-1 * fit_ymax, fit_ymax)
+    except Exception:
+        plot.exceptions()
+        raise
+    else:
+        plot.end()
+
+
+def make_data_plot(data_id, fit_data, ax):
+
+    # set minimum limit on data plot in arcsecs and set this explicitly
+    # as a symmetric limit
+    data_ymax = max(2.0, np.max(np.abs(fit_data)) + .2)
+
+    # Adjust the default look of the plot
+    fplot = ui.get_fit_plot(data_id)
+    dplot = fplot.dataplot
+    dplot.plot_prefs['yerrorbars'] = False
+    dplot.xlabel = 'Observation elapsed/delta time (s)'
+    dplot.ylabel = 'Position offset from mean, {} (arcsec)'.format(ax)
+    dplot.title = 'Raw data and fit in {}'.format(ax)
+
+    try:
+        plot.begin()
+        fplot.plot()
+        ylimits(-1 * data_ymax, data_ymax)
+    except Exception:
+        plot.exceptions()
+        raise
+    else:
+        plot.end()
+
+
+def ylimits(ymin, ymax):
+    """Force the Y axis to cover the given range.
+
+    Parameters
+    ----------
+    ymin, ymax : number
+
+    Notes
+    -----
+    Sherpa doesn't provide a back-end agnostic interface for this
+    functionality.
+    """
+
+    if plot.backend.name == 'pylab':
+        from matplotlib import pyplot as plt
+        plt.ylim(ymin, ymax)
+
+    elif plot.backend.name == 'chips':
+        import pychips
+        pychips.limits(pychips.Y_AXIS, ymin, ymax)
+
+    else:
+        # unlike hardcoopy, we do not tell the user if the backend
+        # is unknown, as this is a cosmetic change.
+        #
+        pass
+
+
+def hardcopy(filename):
+    """Save the current plot to filename.
+
+    The output file is overwritten if it already exists. It is assumed
+    that any "clobber" checks have already been made, which does mean
+    there is a potential for a "race condition" (the file to be created
+    by an external process between teh check and this call), but live
+    with that possibility.
+
+    Parameters
+    ----------
+    filename : str
+        The file to create, including any suffix.
+
+    Notes
+    -----
+    Sherpa doesn't provide a back-end agnostic interface for this
+    functionality.
+    """
+
+    if plot.backend.name == 'pylab':
+        from matplotlib import pyplot as plt
+        plt.savefig(filename)
+
+    elif plot.backend.name == 'chips':
+        import pychips
+        pychips.print_window(filename, ['clobber', True])
+
+    else:
+        # could check if this has already been created, but if this
+        # does happen we want the user to know, so a repeated message
+        # is not a bad thing.
+        #
+        print('WARNING: No hardcopy - unrecognized Sherpa setting: ' +
+              'plot_pkg={}'.format(plot.backend.name))
+
+
 # The '@handle_ciao_errors' decorator will catch any error thrown and
 # display it in a format like that of a CIAO tool, then exit with a
 # non-zero status. So, if at any point in your code you need to exit just
@@ -403,38 +530,17 @@ def main(opt):
         fit_data = ax_data[ax] - np.mean(ax_data[ax])
         mp, model = _fit_poly(fit_data, evt_times, opt['corr_poly_degree'], data_id=data_id)
 
-        bin_centers, bin_mean, bin_std = time_bins(evt_times, fit_data)
+        make_fit_plot(evt_times, fit_data, mp, ax)
 
-        add_window(6, 4, "inches")
-        add_curve((bin_centers - evt_times[0]) / 1000., bin_mean, [bin_std, +bin_std],
-                  ["line.style", "none", "symbol.style", "none", "err.style", "cap"])
-        add_curve(mp.x / 1000., mp.y, ["symbol.style", "none"])
-        # set minimum limit on fit plot in arcsecs and set this explicitly as a symmetric limit
-        fit_ymax = max(0.3, np.max(np.abs(bin_mean - bin_std)), np.max(np.abs(bin_mean + bin_std)))
-        limits(Y_AXIS, -1 * fit_ymax, fit_ymax)
-        set_plot_xlabel("Observation elapsed/delta time (ks)")
-        set_plot_ylabel("Position offset from mean, {} (arcsec)".format(ax))
-        set_plot_title("Fit of {} data (with time-binned event offsets)".format(ax))
         fit_plot = "{}_fit_{}.png".format(opt['corr_plot_root'], ax)
-        if os.path.exists(fit_plot) and opt['clobber'] == 'yes':
-            os.unlink(fit_plot)
+        hardcopy(fit_plot)
         plot_list.append(fit_plot)
-        print_window(fit_plot)
 
-        add_window(6, 4, "inches")
+        make_data_plot(data_id, fit_data, ax)
+
         data_plot = "{}_data_{}.png".format(opt['corr_plot_root'], ax)
-        ui.get_data_plot_prefs()['yerrorbars'] = False
-        ui.plot_fit(data_id)
-        if os.path.exists(data_plot) and opt['clobber'] == 'yes':
-            os.unlink(data_plot)
-        # set minimum limit on data plot in arcsecs and set this explicitly as a symmetric limit
-        data_ymax = max(2.0, np.max(np.abs(fit_data)) + .2)
-        limits(Y_AXIS, -1 * data_ymax, data_ymax)
-        set_plot_xlabel("Observation elapsed/delta time (s)")
-        set_plot_ylabel("Position offset from mean, {} (arcsec)".format(ax))
-        set_plot_title("Raw data and fit in {}".format(ax))
+        hardcopy(data_plot)
         plot_list.append(data_plot)
-        print_window(data_plot)
 
         asol_corr = np.interp(asol_times, mp.x + evt_times[0], mp.y)
         asol_col_to_fix = asol.get_column(ax_map[ax])
@@ -475,15 +581,18 @@ def main(opt):
         v2("\t{}".format(c))
     v2("-" * 60)
     v2("Writing out corrected aspect solution file to {}".format(opt['outfile']))
-    v2("\tTo review fit see correction plots in:")
+    v2("\nYou *must* review the following plots before using this correction:")
     for p in plot_list:
-        v2("\t\t{}".format(p))
+        v2("\t{}".format(p))
+
+    v2("")
 
     # Actually write out the new aspect solution file
     asol.write(opt['outfile'], clobber=opt['clobber'])
 
     # Add history
-    add_tool_history(opt['outfile'], TOOLNAME, params=opt, toolversion=VERSION)
+    add_tool_history(opt['outfile'], TOOLNAME, params=opt,
+                     toolversion=VERSION)
 
 
 if __name__ == "__main__":

--- a/ciao-4.11/contrib/share/doc/xml/correct_periscope_drift.xml
+++ b/ciao-4.11/contrib/share/doc/xml/correct_periscope_drift.xml
@@ -2,39 +2,50 @@
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
 <cxchelptopics>
   <ENTRY key="correct_periscope_drift" context="tools"
-         refkeywords="aspect solution motion source coordinates astrometry alignment
-         correction temporal drift sub-arcsec sub-pixel subarcsec subpixel thermal
-         periscope alignment psf"
+         refkeywords="aspect solution motion source coordinates astrometry
+		      alignment correct correction temporal drift sub-arcsec
+		      sub-pixel subarcsec subpixel thermal aimpoint accurate
+		      accuracy periscope alignment psf"
          seealsogroups="" displayseealsogroups="pixtools asptools">
 
     <SYNOPSIS>
-        Correct a Chandra aspect solution for temporal drift calculated from a fit of the
-        drift in the sky positions of the events in a supplied circle region.
+        Correct a Chandra aspect solution for temporal drift
+        calculated from a fit of the drift in the sky positions of the
+        events in a supplied circle region.
     </SYNOPSIS>
 
     <DESC>
       <PARA>
-        Thermal cycling on the spacecraft can result in an apparent temporal drift of the sky
-        position of an X-ray source during an observation.  This appears as a drift of up to about
-        0.5 arcsec in X-ray event sky X, Y coordinates over time.  Because of the thermal
-        variation time scales, this effect is usually most prominent in long observations (more
-        than about 50 ksec).
+        Thermal cycling on the spacecraft can result in an apparent
+        temporal drift of the sky position of an X-ray source during
+        an observation.  This appears as a drift of up to about 0.5
+        arcsec in X-ray event sky X, Y coordinates over time.  Because
+        of the thermal variation time scales, this effect is usually
+        most prominent in long observations (more than about 50 ksec).
       </PARA>
       <PARA>
-        As of DS 8.4, a drift correction is applied to the aspect solution using the periscope
-        gradients telemetry.  However, temporal drifts have continued to increase with thermal
-        variation of the spacecraft.  Therefore the Aspect team suggests that to accomplish
-        science related to sub-arcsec source structure, users should follow this thread to correct
-        residual drift induced by the periscope.  This requires a relatively bright, on-axis
-        source (within
-        a few arcmin off-axis angle) to perform a "self-calibration" of the aspect solution.
+        As of DS 8.4, a drift correction is applied to the aspect
+        solution using the periscope gradients telemetry.  However,
+        temporal drifts have continued to increase with thermal
+        variation of the spacecraft.  Therefore the Aspect team
+        suggests that to accomplish science related to sub-arcsec
+        source structure, users should follow this thread to correct
+        residual drift induced by the periscope.  This requires a
+        relatively bright, on-axis source (within a few arcmin
+        off-axis angle) to perform a "self-calibration" of the aspect
+        solution.
       </PARA>
       <PARA>
-        This tool takes as input a source aspect solution and event files and returns a
-        new/corrected aspect solution that may be applied to the events to correct
-        residual temporal drift.
+        This tool takes as input a source aspect solution and event
+        files and returns a new/corrected aspect solution that may be
+        applied to the events to correct residual temporal drift.
       </PARA>
-
+      <PARA title="WARNING: do not apply without review">
+	The tool creates four plots as part of the output (they
+	end in _yag.png and _zag.png). These must be reviewed before
+	the correction is used, to ensure that the automatic fitting
+	process has not produced invalid results.
+      </PARA>
     </DESC>
 
     <QEXAMPLELIST>
@@ -42,25 +53,25 @@
          <SYNTAX>
            <LINE>
               % correct_periscope_drift 
-infile=pcadf537654279N001_asol1.fits.gz 
-evtfile=acisf16659N001_evt2.fits.gz 
+pcadf537654279N001_asol1.fits.gz 
+acisf16659N001_evt2.fits.gz 
+driftcorr_asol1.fits 
 x=4133.76 
 y=4078.74 
 radius=6 
-outfile=driftcorr_asol1.fits 
 verbose=2
            </LINE>
          </SYNTAX>
          <DESC>
 <VERBATIM>
 Running: correct_periscope_drift
-  version = 0.1
+  version = 0.3
 with parameters:
   infile=pcadf537654279N001_asol1.fits.gz
   evtfile=acisf16659N001_evt2.fits.gz
   outfile=driftcorr_asol1.fits
   verbose=2
-  and ASCDS_INSTALL is /soft/ciao-4.8
+  and ASCDS_INSTALL is /soft/ciao-4.11
 ------------------------------------------------------------
 Fitting a line to the data to get reduced stat errors
 Fitting a polynomial of degree 2 to the data
@@ -68,17 +79,23 @@ Fitting a line to the data to get reduced stat errors
 Fitting a polynomial of degree 2 to the data
 ------------------------------------------------------------
 Fit results
-Events show drift range of 0.24 arcsec in yag axis
-Max absolute correction of 0.14 arcsec for yag axis
-Events show drift range of 0.20 arcsec in zag axis
-Max absolute correction of 0.11 arcsec for zag axis
+        Events show drift range of 0.24 arcsec in yag axis
+        Max absolute correction of 0.14 arcsec for yag axis
+        Events show drift range of 0.20 arcsec in zag axis
+        Max absolute correction of 0.11 arcsec for zag axis
 ------------------------------------------------------------
 Writing out corrected aspect solution file to driftcorr_asol1.fits
-To review fit see correction plots in:
-corr_fit_yag.png
-corr_data_yag.png
-corr_fit_zag.png
-corr_data_zag.png
+
+You *must* review the following plots before using this correction:
+        corr_fit_yag.png
+        corr_data_yag.png
+        corr_fit_zag.png
+        corr_data_zag.png
+
+Adding HISTORY record for correct_periscope_drift (0.3)
+Adding history to driftcorr_asol1.fits
+Running tool dmhistory using:
+>>> dmhistory driftcorr_asol1.fits correct_periscope_drift action=put
 </VERBATIM>
 
          </DESC>
@@ -99,8 +116,9 @@ corr_data_zag.png
        </SYNOPSIS>
        <DESC>
           <PARA>
-            The event file should have been made with/processed with the aspect solution
-            supplied with infile (evtfile ASOLFILE header key value should match infile)
+            The event file should have been made with/processed with
+            the aspect solution supplied with infile (evtfile ASOLFILE
+            header key value should match infile)
           </PARA>
        </DESC>
      </PARAM>
@@ -117,42 +135,46 @@ corr_data_zag.png
        </SYNOPSIS>
        <DESC>
           <PARA>
-            The output prefix for fit and data plots.  The
-            output names will look like ${corr_plot_root}_fit_${axis}.png and
-            ${corr_plot_root}_data_${axis}.png where ${axis} will be 'yag' or 'zag'.
+            The output prefix for fit and data plots.  The output
+            names will look like ${corr_plot_root}_fit_${axis}.png and
+            ${corr_plot_root}_data_${axis}.png where ${axis} will be
+            'yag' or 'zag'.
           </PARA>
        </DESC>
      </PARAM>
 
      <PARAM name="x" type="float" min="1">
        <SYNOPSIS>
-         Sky X position of center of circle region used to extract events to fit correction.
+         Sky X position of center of circle region used to extract
+         events to fit correction.
        </SYNOPSIS>
      </PARAM>
 
      <PARAM name="y" type="float" min="1">
        <SYNOPSIS>
-         Sky Y position of center of circle region used to extract events to fit correction.
+         Sky Y position of center of circle region used to extract
+         events to fit correction.
        </SYNOPSIS>
      </PARAM>
 
      <PARAM name="radius" type="float" min="0">
        <SYNOPSIS>
-         Radius in pixels of circle region used to extract events to fit correction.
+         Radius in pixels of circle region used to extract events to
+         fit correction.
        </SYNOPSIS>
      </PARAM>
 
      <PARAM name="src_min_counts" type="float" min="0" def="250">
        <SYNOPSIS>
-         Minimum number of counts required in extracted source region (below which the
-         tool will complain and not fit).
+         Minimum number of counts required in extracted source region
+         (below which the tool will complain and not fit).
        </SYNOPSIS>
      </PARAM>
 
      <PARAM name="corr_poly_degree" type="integer" min="1" max="8" def="2">
        <SYNOPSIS>
-         Degree of polynomial used in the fit model to fit and correct drift in the two
-         Aspect Camera axes.
+         Degree of polynomial used in the fit model to fit and correct
+         drift in the two Aspect Camera axes.
        </SYNOPSIS>
      </PARAM>
 
@@ -171,24 +193,47 @@ corr_data_zag.png
    </PARAMLIST>
 
    <ADESC title="Caveats">
-        <PARA title="Bad fits">
-            This tool is provides output plots of the fits of the events.  The user
-            must evaluate those plots to determine if a correction is warranted and
-            if the output fit is reasonable.  This tool should not be blindly applied
-            to observations in aggregate.
-        </PARA>
-        <PARA title="Cannot be run headless or without ChIPS">
-            The output plots are not optional.
-        </PARA>
-        <PARA title="Counts needed for good fit">
-            The tool is not intended for short observations (less than 50ks) and
-            will not fit observations well without a bright point-like source.
-        </PARA>
-        <PARA title="Multiple aspect solutions files">
-            This tool is only intended for observations with single aspect solution files.
-        </PARA>
+     <PARA title="Bad fits">
+       This tool provides output plots of the fits of the
+       events. The user must evaluate those plots to determine
+       if a correction is warranted and if the output fit is
+       reasonable. This tool *should not* be blindly applied to
+       observations.
+     </PARA>
+     <PARA title="Counts needed for good fit">
+       The tool is not intended for short observations (less than
+       50ks) and will not work well for observations well without a
+       bright point-like source.
+     </PARA>
+     <PARA title="Multiple aspect solutions files">
+       This tool is only intended for observations with single
+       aspect solution files.
+     </PARA>
    </ADESC>
 
+   <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+     <PARA title="Matlotlib support">
+       The plots now use the chosen Sherpa plotting backend,
+       rather than always using ChIPS. To use Matplotlib,
+       change the plot_pkg line in your ~/.sherpa.rc file
+       so that it reads:
+     </PARA>
+     <PARA>
+       <SYNTAX>
+	 <LINE>plot_pkg : pylab</LINE>
+       </SYNTAX>
+     </PARA>
+     <PARA>
+       Note that making this change will also change
+       any new Sherpa sessions to use Matplotlib!
+     </PARA>
+     <PARA>
+       Using Matplotlib rather than ChIPS, will allow the script
+       to be run when there is no X Display, over a remote connection,
+       or on recent macOS releases. It also means that the plot windows
+       will no longer briefly appear on the screen when the script is run.
+     </PARA>
+   </ADESC>
 
     <ADESC title="About Contributed Software">
       <PARA>
@@ -199,7 +244,7 @@ corr_data_zag.png
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>    
 </cxchelptopics>


### PR DESCRIPTION
# Latest version

The code has been re-worked so that it uses the Sherpa plot routines for creating the plots (which means the plots are slightly different to the ones shown below). This means that the script will now use the `plot_pkg` setting in `~/.sherpa.rc` to determine whether to use ChIPS or Matplotlib.

I have also tweaked the screen output to be a bit-more emphatic about reviewing the output plots (since they will not appear briefly) when Matplotlib is in use.

## Question

We could keep the plotting changes but always force matplotlib.

# Original text

This should now allow users to run correct_periscope_drift when there
is no X display or over a remote connection (both problems with ChIPS),
and on recent macOS versions (where ChIPS is known to be problematic).

The plots are now larger, in color, and will not appear briefly as an
X window when the script is run. The plot files are now over-written
even if clobber is set.

The conversion to use matplotlib uses an "interesting" technique to
work around the use of Sherpa's plot_fit command. What I should have
done was to manually create the equivalent to plot_fit with direct
matplotlib calls, but I instead have decided to see if I can hack
Sherpa's ploting routines to ignore the user's plot_pkg setting and
always use the Sherpa matplotlib backend.

Here's example plots:

![corr_fit_zag](https://user-images.githubusercontent.com/224638/52242873-ddf44980-28a5-11e9-969c-3f8856a67e62.png)
![corr_data_zag](https://user-images.githubusercontent.com/224638/52242882-e2206700-28a5-11e9-89f8-c5c128006e44.png)
