### PR TITLE
Fix bug in save_marx_spectrum

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -18,6 +18,13 @@ Updated scripts
     Corrects logic error when an invalid user query (ie invalid column
     names) triggers an unhelpful error message.
 
+Updated Python modules
+
+  sherpa_contrib.marx
+
+    The save_marx_spectrum function now normalizes the output by the bin
+    width, as expected by MARX.
+
 ## 4.11.1 - December 2018 ##
 
 Updated scripts

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
@@ -107,7 +107,7 @@ def get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     """
 
     vals = _get_chart_spectrum(id, elow, ehigh, ewidth, norm)
-    return (vals["xhi"], vals["y"])
+    return (vals["xhi"], vals["y"] / (vals['xhi'] - vals['xlo']))
 
 
 def save_marx_spectrum(outfile, clobber=True, verbose=True,

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_chart.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_chart.py
@@ -167,9 +167,8 @@ class TestSimple(unittest.TestCase):
         self.assertTrue(np.all(res['y'] > 0))
 
     def test_spec_flat(self):
-        elo, ehi, de = self.grid['arf1']
-        res = chart.get_chart_spectrum(elow=elo, ehigh=ehi,
-                                       ewidth=de, id='no-arf-flat')
+        res = chart.get_chart_spectrum(elow=2, ehigh=6,
+                                       ewidth=1, id='no-arf-flat')
         self.assertTrue(np.all(res[2] == 1))
 
 if __name__ == "__main__":

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_chart.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_chart.py
@@ -69,6 +69,7 @@ class TestSimple(unittest.TestCase):
         ui.set_source('no-arf', pl1)
         ui.set_source('arf1', pltst)
         ui.set_source('flatarf', pltst)
+        ui.set_source('no-arf-flat', ui.const1d.c1)
 
         pl1.gamma = 0.0
         pl1.ampl = 1.2
@@ -165,9 +166,11 @@ class TestSimple(unittest.TestCase):
         # self.assertGreater(res['y'].sum(), 0.0)
         self.assertTrue(np.all(res['y'] > 0))
 
-    # NOTE:
-    # currently no absolute checks on the calculated values (the
-    # "model flux").
+    def test_spec_flat(self):
+        elo, ehi, de = self.grid['arf1']
+        res = chart.get_chart_spectrum(elow=elo, ehigh=ehi,
+                                       ewidth=de, id='no-arf-flat')
+        self.assertTrue(np.all(res[2] == 1))
 
 if __name__ == "__main__":
     unittest.main()

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_marx.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_marx.py
@@ -1,0 +1,62 @@
+#
+#  Copyright (C) 2016
+#            Smithsonian Astrophysical Observatory
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+
+"""
+Test routines for the ChART code in
+sherpa_contrib.chart.
+"""
+
+import unittest
+
+import numpy as np
+
+from sherpa.astro import ui
+
+from sherpa_contrib import marx
+
+import sys
+sys.tracebacklimit = 4
+
+
+class TestSimple(unittest.TestCase):
+    """Basic tests"""
+
+    def setUp(self):
+        ui.set_source('no-arf-flat', ui.const1d.c1)
+
+    def tearDown(self):
+        # there's an issue in CIAO 4.8 with delete_model and
+        # delete_model_component, so just call clean
+        ui.clean()
+
+    def test_spec_flat(self):
+        res = marx.get_marx_spectrum(elow=1., ehigh=4.,
+                                     ewidth=1., id='no-arf-flat')
+        self.assertTrue(np.all(res[1] == 1))
+
+        # Different bin width
+        res = marx.get_marx_spectrum(elow=1., ehigh=4.,
+                                     ewidth=.5, id='no-arf-flat')
+        self.assertTrue(np.all(res[1] == 2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_marx.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/tests/test_marx.py
@@ -55,7 +55,7 @@ class TestSimple(unittest.TestCase):
         # Different bin width
         res = marx.get_marx_spectrum(elow=1., ehigh=4.,
                                      ewidth=.5, id='no-arf-flat')
-        self.assertTrue(np.all(res[1] == 2))
+        self.assertTrue(np.all(res[1] == 1))
 
 
 if __name__ == "__main__":

--- a/ciao-4.11/contrib/share/doc/xml/save_marx_spectrum.xml
+++ b/ciao-4.11/contrib/share/doc/xml/save_marx_spectrum.xml
@@ -163,6 +163,13 @@ from sherpa_contrib.marx import *
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+      <PARA title="Fixes to save_marx_spectrum">
+	The sherpa_contrib.marx.save_marx_spectrum() function now
+	normalizes the output by the bin width, as expected by MARX.
+      </PARA>
+    </ADESC>
+
     <BUGS>
       <PARA>
         See the
@@ -171,6 +178,6 @@ from sherpa_contrib.marx import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>September 2018</LASTMODIFIED>
+    <LASTMODIFIED>March 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
@@ -58,6 +58,11 @@ import sherpa_contrib.all
 	  <DATA>Routines for creating and visualizing the
 	  data files used by the Chandra Ray Tracer (ChaRT).</DATA>
 	</ROW>
+        <ROW>
+	  <DATA>sherpa_contrib.marx</DATA>
+	  <DATA>Routines for creating the spectrum file used by
+	  MARX.</DATA>
+	</ROW>
       </TABLE>
 
       <PARA>
@@ -74,6 +79,13 @@ import sherpa_contrib.all
       </PARA>
     
     </DESC>
+
+    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+      <PARA title="Fixes to save_marx_spectrum">
+	The sherpa_contrib.marx.save_marx_spectrum() function now
+	normalizes the output by the bin width, as expected by MARX.
+      </PARA>
+    </ADESC>
 
     <ADESC title="Changes in the scripts 4.8.2 (January 2016) release">
       <PARA title="New routine">
@@ -129,6 +141,6 @@ import sherpa_contrib.all
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>March 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_marx.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_marx.xml
@@ -74,6 +74,13 @@ from sherpa_contrib.all import *
 
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+      <PARA title="Fixes to save_marx_spectrum">
+	The sherpa_contrib.marx.save_marx_spectrum() function now
+	normalizes the output by the bin width, as expected by MARX.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
       <PARA>
         The sherpa_contrib.marx module - which provides the
@@ -90,6 +97,6 @@ from sherpa_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>September 2018</LASTMODIFIED>
+    <LASTMODIFIED>March 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
MARX expects the flux in per bin width (i.e. per keV), contrary to
ChaRT. Thus, data calculated with the ChaRT routines internally must
be divided by the bin width.

Tests have been added for a very simple model to at least verify this
behaviour.

Please try out the tests and verify that is passes, I simply don't know how
them best. (I can probably figure it out, but if it's easy for you, please try.)

fixes #194