### PR TITLE
fix csc search curl-fallover logic

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -1,4 +1,12 @@
 
+## 4.11.2 - March 2019 ##
+
+  obsid_search_csc, search_csc
+  
+    Corrects logic error when an invalid user query (ie invalid column
+    names) triggers an unhelpful error message.
+
+
 ## 4.11.1 - December 2018 ##
 
 Updated scripts

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
@@ -385,15 +385,18 @@ def make_URL_request( resource, vals ):
     try:
         response = urllib.request.urlopen( request )
         page = response.read()
+
+        verb5( "URL Code: {0}".format( response.getcode() ))
+        if response.getcode() != 200:
+            # If we get a redirect, 30x, then fall through to curl too
+            raise Exception( page )
+            
     except:
-        make_CURL_request( resource, vals )
+        page = make_CURL_request( resource, vals )
     
     if len(page) == 0:
         raise Exception("Problem accessing resource {0}".format(resource))
     
-    verb5( "URL Code: {0}".format( response.getcode() ))
-    if response.getcode() != 200:
-        raise Exception( page )
     
     return page
 

--- a/ciao-4.11/contrib/share/doc/xml/obsid_search_csc.xml
+++ b/ciao-4.11/contrib/share/doc/xml/obsid_search_csc.xml
@@ -431,6 +431,15 @@ unix% search_csc ... columns="SOS,a.match_type,o.livetime" ...
     
     </PARAMLIST>
 
+    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+      <PARA>
+        Corrects logic introduced to fall back to using curl if CXC 
+        websites redirect to secure sites.  User errors such as 
+        incorrect column names would not have been reported correctly.
+      </PARA>
+    </ADESC>
+
+
 
     <ADESC title="Changes in the scripts 4.6.6 (September 2014) release">
       <PARA>

--- a/ciao-4.11/contrib/share/doc/xml/search_csc.xml
+++ b/ciao-4.11/contrib/share/doc/xml/search_csc.xml
@@ -599,6 +599,14 @@ unix% search_csc ... columns="SOS,a.match_type,o.livetime" ...
     
     </PARAMLIST>
 
+    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+      <PARA>
+        Corrects logic introduced to fall back to using curl if CXC 
+        websites redirect to secure sites.  User errors such as 
+        incorrect column names would not have been reported correctly.
+      </PARA>
+    </ADESC>
+
 
     <ADESC title="Changes in the scripts 4.6.6 (September 2014) release">
       <PARA>


### PR DESCRIPTION
This fixes #191 .

With the ssl changes coming, the `curl` logic path will probably be obsolete before it is needed -- maybe.