### PR TITLE
Update release notes for 4.11.2

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -1,4 +1,4 @@
-## 4.11.2 - March 2019 ##
+## 4.11.2 - April 2019 ##
 
 Updated scripts
 
@@ -7,6 +7,13 @@ Updated scripts
     Updates to support level-2 event files with no exposure time: the
     FOV file will be created using the time ranges from the asol1 file
     or files.
+
+  deflare
+
+    The deflare script has been updated to use matplotlib rather than
+    ChIPS for its plotting. The output is similar but will not match
+    exactly. This change should improve support for running the script
+    remotely or on a system with no X display.
 
   find_chandra_obsid
 

--- a/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
+++ b/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
@@ -751,7 +751,7 @@ acisf084244478N003_2_bias0.fits.gz
     </PARAMLIST>
 
 
-<ADESC title="Changes in scripts 4.11.2 (March 2019) release">
+<ADESC title="Changes in scripts 4.11.2 (April 2019) release">
   <PARA>
     Changes to allow observations where the Level 2 ONTIME
     is 0 to be fully processed. Previously the script would 
@@ -1050,6 +1050,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>February 2019</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/deflare.xml
+++ b/ciao-4.11/contrib/share/doc/xml/deflare.xml
@@ -614,6 +614,14 @@
     </ADESC>
     -->
 
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
+      <PARA title="Switched to matplotlib">
+	The plot is now generated with matplotlib rather than ChIPS,
+	which should allow the script to be run remotely or on systems
+	with no X display.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
       <PARA>
         The ahelp file - the SYNTAX and PARAMETERS sections - has been
@@ -658,7 +666,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/find_chandra_obsid.xml
+++ b/ciao-4.11/contrib/share/doc/xml/find_chandra_obsid.xml
@@ -795,7 +795,7 @@ Download [y, n, q, a, h]: y
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA>
 	Support running on some macOS/openSSL systems by catching
 	CERTIFICATE_VERIFY_FAILED errors and falling through to curl
@@ -878,6 +878,6 @@ Download [y, n, q, a, h]: y
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>February 2019</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/install_marx.xml
+++ b/ciao-4.11/contrib/share/doc/xml/install_marx.xml
@@ -142,7 +142,7 @@ bash: source /soft/marx/setup_marx.sh
       </PARAM>
     </PARAMLIST>
 
-    <ADESC title="Change in scripts CIAO 4.11.2 (March 2019) release">
+    <ADESC title="Change in scripts CIAO 4.11.2 (April 2019) release">
       <PARA>
         Run make clean after successful installation.
       </PARA>
@@ -206,7 +206,7 @@ bash: source /soft/marx/setup_marx.sh
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>February 2019</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>
 

--- a/ciao-4.11/contrib/share/doc/xml/obsid_search_csc.xml
+++ b/ciao-4.11/contrib/share/doc/xml/obsid_search_csc.xml
@@ -431,7 +431,7 @@ unix% search_csc ... columns="SOS,a.match_type,o.livetime" ...
     
     </PARAMLIST>
 
-    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA>
         Corrects logic introduced to fall back to using curl if CXC 
         websites redirect to secure sites.  User errors such as 
@@ -463,9 +463,7 @@ unix% search_csc ... columns="SOS,a.match_type,o.livetime" ...
         on the CIAO website for an up-to-date listing of known bugs.
       </PARA>
     </BUGS>
-<LASTMODIFIED>September 2014</LASTMODIFIED>
-
-
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
 
 
   </ENTRY>

--- a/ciao-4.11/contrib/share/doc/xml/save_marx_spectrum.xml
+++ b/ciao-4.11/contrib/share/doc/xml/save_marx_spectrum.xml
@@ -163,7 +163,7 @@ from sherpa_contrib.marx import *
 
     </QEXAMPLELIST>
 
-    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA title="Fixes to save_marx_spectrum">
 	The sherpa_contrib.marx.save_marx_spectrum() function now
 	normalizes the output by the bin width, as expected by MARX.
@@ -178,6 +178,6 @@ from sherpa_contrib.marx import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>March 2019</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/search_csc.xml
+++ b/ciao-4.11/contrib/share/doc/xml/search_csc.xml
@@ -599,7 +599,7 @@ unix% search_csc ... columns="SOS,a.match_type,o.livetime" ...
     
     </PARAMLIST>
 
-    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA>
         Corrects logic introduced to fall back to using curl if CXC 
         websites redirect to secure sites.  User errors such as 
@@ -631,7 +631,7 @@ unix% search_csc ... columns="SOS,a.match_type,o.livetime" ...
       </PARA>
     </BUGS>
 
-  <LASTMODIFIED>September 2014</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
 
   </ENTRY>
 

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
@@ -80,7 +80,7 @@ import sherpa_contrib.all
     
     </DESC>
 
-    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA title="Fixes to save_marx_spectrum">
 	The sherpa_contrib.marx.save_marx_spectrum() function now
 	normalizes the output by the bin width, as expected by MARX.
@@ -141,6 +141,6 @@ import sherpa_contrib.all
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>March 2019</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_marx.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_marx.xml
@@ -74,7 +74,7 @@ from sherpa_contrib.all import *
 
     </DESC>
 
-    <ADESC title="Changes in the scripts 4.11.2 (March 2019) release">
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA title="Fixes to save_marx_spectrum">
 	The sherpa_contrib.marx.save_marx_spectrum() function now
 	normalizes the output by the bin width, as expected by MARX.
@@ -97,6 +97,6 @@ from sherpa_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>March 2019</LASTMODIFIED>
+    <LASTMODIFIED>April 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Mainly updating from March to April 2019 but also adds information about
the deflare change.