### PR TITLE
use PNT keywords for aimpoint chip

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -1,3 +1,13 @@
+## 4.11.3 - May 2019 ##
+
+Updated scripts
+
+  blanksky
+
+    The aimpoint chip of the observation is now calculated using the
+    RA_PNT and DEC_PNT keywords rather than the RA_NOM and DEC_NOM ones.
+    This is to better support reprojected data sets.
+
 ## 4.11.2 - April 2019 ##
 
 Updated scripts

--- a/ciao-4.11/contrib/bin/blanksky
+++ b/ciao-4.11/contrib/bin/blanksky
@@ -20,7 +20,7 @@
 
 __version__ = "CIAO 4.11"
 toolname = "blanksky"
-__revision__  = "23 April 2019"
+__revision__  = "01 May 2019"
 
 import os, sys, paramio, tempfile, shutil, stat
 import pycrates as pcr
@@ -490,16 +490,17 @@ def blanksky(infile,filters,asols,tmpdir,keywords,verbose,clobber):
             ccds.remove(9)
 
         if [0 in ccds, set([4,5,6,7,8,9]).isdisjoint(set(ccds))] == [True,False]:
-            # check location of aimpoint with dmcoords using the nominal (optical-axis) coordinates
-            ra_nom = keywords["RA_NOM"]
-            dec_nom = keywords["DEC_NOM"]
+            # check location of aimpoint with dmcoords using the 
+            # time-averaged optical-axis coordinates
+            ra_pnt = keywords["RA_PNT"]
+            dec_pnt = keywords["DEC_PNT"]
 
             dmcoords.punlearn()
 
             dmcoords.infile = infile
             dmcoords.asol = asols
-            dmcoords.ra = ra_nom
-            dmcoords.dec = dec_nom
+            dmcoords.ra = ra_pnt
+            dmcoords.dec = dec_pnt
             dmcoords.opt = "cel"
             dmcoords.celfmt = "deg"
             dmcoords.verbose = "0"

--- a/ciao-4.11/contrib/share/doc/xml/blanksky.xml
+++ b/ciao-4.11/contrib/share/doc/xml/blanksky.xml
@@ -284,6 +284,14 @@
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.11.3 (May 2019) release">
+      <PARA>
+	The aimpoint chip is now calculated using the RA_PNT and DEC_PNT
+	keywords, rather than the RA_NOM and DEC_NOM, to better support
+	reprojected datasets.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA>
 	The script no-longer copies over the RA_PNT, DEC_PNT, ROLL_PNT,
@@ -313,6 +321,6 @@
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>April 2019</LASTMODIFIED>
+    <LASTMODIFIED>May 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
instead of using the *_NOM keywords to identify the aimpoint chip, use the time-averaged optical-axis *_PNT coordinates, since if used with a reprojected file with a wildly far off tangent point, the aimpoint chip could be misidentified using the nominal aimpoint, as noted in #214 