### PR TITLE
ciao_stacklib ahelp tweaks (fix #213)

### DIFF
--- a/ciao-4.11/contrib/share/doc/xml/ciao_stacklib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/ciao_stacklib.xml
@@ -121,7 +121,7 @@ src2/b.fits
 
       <PARA>
 	you can use the stkname variable as input to a tool that accepts
-	a stack. Onceyou have finished with the stack you can call
+	a stack. Once you have finished with the stack you can call
       </PARA>
       <PARA>
 	<SYNTAX><LINE>stk.close()</LINE></SYNTAX>
@@ -151,7 +151,7 @@ src2/b.fits
 	  <LINE>import stk</LINE>
 	  <LINE>means = paramio.pget("dmstat", "out_mean")</LINE>
 	  <LINE>means = stk.build(means)</LINE>
-	  <LINE>means = map(float, means)</LINE>
+	  <LINE>mvals = [float(m) for m in means]</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -159,22 +159,8 @@ src2/b.fits
 	    contain multiple values as a stack, and use the build routine from
 	    the stk module to
 	    convert it into an array of strings.
-	    The final line uses the Python map command to apply the float
-	    routine to each element of means, converting the string into
-	    a floating-point value.
-	  </PARA>
-	  <PARA>
-	    We could have instead used
-	  </PARA>
-	  <PARA>
-	    <SYNTAX>
-	      <LINE>import ciao_contrib.stacklib as stacklib</LINE>
-	      <LINE>means = stacklib.expand_stack(means)</LINE>
-	    </SYNTAX>
-	  </PARA>
-	  <PARA>
-	    but this approach is deprecated, as of CIAO 4.5, in favor
-	    if stk.build().
+	    The final line uses a list comprehension to convert each
+	    string element in the means array to a floating-point value.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -237,6 +223,6 @@ src2/b.fits
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2012</LASTMODIFIED>
+    <LASTMODIFIED>May 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Replaces a map call by a list comprehension. Removes some old text
related to the long-deprecated functionality. Fix a typo.