### PR TITLE
remove chips import from dax specfit script

### DIFF
--- a/ciao-4.11/contrib/bin/ds9_specfit.sh
+++ b/ciao-4.11/contrib/bin/ds9_specfit.sh
@@ -241,7 +241,6 @@ echo " (4/4) Fitting spectrum"
 cat <<EOF > $cmd
 
 import sherpa.astro.ui as sherpa
-import pychips
 
 sherpa.load_data("$spi")
 


### PR DESCRIPTION
While I removed `chips` plotting from the script, I missed the initial `import`.  

This does not affect ciao-4.11 since `chips` is still in the system; but does affect ciaox.

