### PR TITLE
Update non-radial-profile sherpa plots to support matplotlib (fix #224)

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -1,3 +1,17 @@
+## 4.11.4 - 2019 ##
+
+This release updates the Sherpa plotting functionality to use Matplotlib
+rather than ChIPS when the plot_pkg setting is pylab in your ~/.sherpa.rc
+file. The updated routines are
+
+  sherpa_contrib.chart.plot_chart_spectrum
+  sherpa_contrib.marx.plot_marx_spectrum
+  sherpa_contrib.utils.plot_instmap_weights
+
+The plots may have changed slightly in this update (for instance, the
+labelling is slightly different in some of the plots), and support for
+the overplot and clearwindow arguments has been added where necessary.
+
 ## 4.11.3 - May 2019 ##
 
 This update includes an imporant bugfix to srcflux, which had been

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/chart.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/chart.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010, 2015, 2016
+# Copyright (C) 2009, 2010, 2015, 2016, 2019
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -78,8 +78,6 @@ def _get_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
             # b) Assume this means the dataset is not derived from the
             #    PHA class
             arf = None
-        except:
-            raise
 
         if arf is None:
             emsg = "No ARF found for dataset {} ".format(repr(id)) + \
@@ -234,7 +232,7 @@ def save_chart_spectrum(outfile, clobber=True, verbose=True,
                   format=format, clobber=clobber)
 
     if verbose:
-        print ("Created: {}".format(outfile))
+        print("Created: {}".format(outfile))
 
 
 def plot_chart_spectrum(**kwargs):
@@ -270,7 +268,7 @@ def plot_chart_spectrum(**kwargs):
                     "Dataset: {}".format(repr(vals["id"])),
                     ["halign", 1])
 
-    except:
+    except Exception:
         c.discard_undo_buffer()
         raise
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/chart.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/chart.py
@@ -131,9 +131,10 @@ def get_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
         dataset must have a grid and source model defined.
     elow, ehigh, ewidth : number or None
         Only used if all three are given, otherwise the grid
-        of the data set is used. The elo value is the start
-        of the low-energy bin, ehigh is the end of the high-energy
-        bin, and ewidth the bin width, all in keV.
+        of the data set is used. The elo value gives the start
+        of the grid (the left edge of the first bin) and ehi
+        is the end of the grid (the right edge of the last bin),
+        and ewidth the bin width, all in keV.
     norm : number or None
         Multiply the flux values by this value, if set.
 
@@ -206,9 +207,10 @@ def save_chart_spectrum(outfile, clobber=True, verbose=True,
         dataset must have a grid and source model defined.
     elow, ehigh, ewidth : number or None
         Only used if all three are given, otherwise the grid
-        of the data set is used. The elo value is the start
-        of the low-energy bin, ehigh is the end of the high-energy
-        bin, and ewidth the bin width, all in keV.
+        of the data set is used. The elo value gives the start
+        of the grid (the left edge of the first bin) and ehi
+        is the end of the grid (the right edge of the last bin),
+        and ewidth the bin width, all in keV.
     norm : number or None
         Multiply the flux values by this value, if set.
 
@@ -256,9 +258,10 @@ def plot_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
         dataset must have a grid and source model defined.
     elow, ehigh, ewidth : number or None
         Only used if all three are given, otherwise the grid
-        of the data set is used. The elo value is the start
-        of the low-energy bin, ehigh is the end of the high-energy
-        bin, and ewidth the bin width, all in keV.
+        of the data set is used. The elo value gives the start
+        of the grid (the left edge of the first bin) and ehi
+        is the end of the grid (the right edge of the last bin),
+        and ewidth the bin width, all in keV.
     norm : number or None
         Multiply the flux values by this value, if set.
     overplot : bool, optional

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/chart.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/chart.py
@@ -39,9 +39,8 @@ Examples
 
 import sherpa.astro.ui as s
 
+from sherpa.plot import HistogramPlot, backend
 from sherpa.utils.err import IdentifierErr, ArgumentErr
-
-import pychips.all as c
 
 import numpy as np
 
@@ -142,7 +141,7 @@ def get_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     -------
     (energy_lo, energ_hi, flux_bins)
        The energies are in keV and fluxes in photons/cm^2/s.
-       This has changed from ChART versino 1, which used
+       This has changed from ChART version 1, which used
        the mid point rather than low and high edges.
 
     Notes
@@ -183,11 +182,10 @@ def get_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
 
 
 def save_chart_spectrum(outfile, clobber=True, verbose=True,
-                        format='text', **kwargs):
+                        format='text',
+                        id=None, elow=None, ehigh=None, ewidth=None,
+                        norm=None):
     """Create a spectrum file in the format used by ChART2.
-
-    See `get_chart_spectrum` for information on the other
-    arguments supported by this function.
 
     Parameters
     ----------
@@ -203,6 +201,16 @@ def save_chart_spectrum(outfile, clobber=True, verbose=True,
         Should a message be displayed indicating that the file
         has been created? This is only used when outfile is not
         ``None``.
+    id : int or string or None
+        If id is None then the default Sherpa id is used. This
+        dataset must have a grid and source model defined.
+    elow, ehigh, ewidth : number or None
+        Only used if all three are given, otherwise the grid
+        of the data set is used. The elo value is the start
+        of the low-energy bin, ehigh is the end of the high-energy
+        bin, and ewidth the bin width, all in keV.
+    norm : number or None
+        Multiply the flux values by this value, if set.
 
     Notes
     -----
@@ -226,7 +234,9 @@ def save_chart_spectrum(outfile, clobber=True, verbose=True,
     #  - 3 columns (energ_lo, energ_hi, spectrum)
     #  - can accept ascii or FITS format
     #
-    (elo, ehi, flux) = get_chart_spectrum(**kwargs)
+    (elo, ehi, flux) = get_chart_spectrum(id=id, elow=elow,
+                                          ehigh=ehigh, ewidth=ewidth,
+                                          norm=norm)
     colnames = ['elo', 'ehi', 'spectrum']
     write_columns(outfile, elo, ehi, flux, colnames=colnames,
                   format=format, clobber=clobber)
@@ -235,41 +245,63 @@ def save_chart_spectrum(outfile, clobber=True, verbose=True,
         print("Created: {}".format(outfile))
 
 
-def plot_chart_spectrum(**kwargs):
+def plot_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
+                        norm=None, overplot=False, clearwindow=True):
     """Plots the spectrum as used by ChART2.
 
-    See `get_chart_spectrum` for information on the
-    arguments supported by this function.
+    Parameters
+    ----------
+    id : int or string or None
+        If id is None then the default Sherpa id is used. This
+        dataset must have a grid and source model defined.
+    elow, ehigh, ewidth : number or None
+        Only used if all three are given, otherwise the grid
+        of the data set is used. The elo value is the start
+        of the low-energy bin, ehigh is the end of the high-energy
+        bin, and ewidth the bin width, all in keV.
+    norm : number or None
+        Multiply the flux values by this value, if set.
+    overplot : bool, optional
+        If ``True`` then the data is added to the current plot,
+        otherwise a new plot is created.
+    clearwindow: bool, optional
+        If ``True`` then clear out the current plot area of all
+        existing plots. This is not used if ``overplot`` is set.
 
     Notes
     -----
     A histogram plot is now used, instead of the curve plot
     used for ChART version 1.
+
+    Labels used to be added to the top-left and -right corners to
+    indicate the model and dataset identifier. The plot title
+    now contains the model name and the dataset identifier has been
+    removed.
     """
 
-    vals = _get_chart_spectrum(**kwargs)
-    c.open_undo_buffer()
-    try:
-        if c.info() is None:
-            c.add_window(["id", "chart"])
-        else:
-            c.erase()
+    vals = _get_chart_spectrum(id=id, elow=elow,
+                               ehigh=ehigh, ewidth=ewidth,
+                               norm=norm)
 
-        c.add_histogram(vals["xlo"], vals["xhi"], vals["y"])
-        c.set_plot_xlabel("Energy (keV)")
-        c.set_plot_ylabel("Flux (photon cm^{-2} s^{-1})")
-        c.set_plot_title("ChaRT Source Spectrum")
+    # In sherpa_contrib.utils.plot_instmap_weights it was found useful
+    # to convert the Y values to float32 from float64 to avoid
+    # precision issues confusing the plot (i.e. showing structure that
+    # isn't meaningful to the user). Is this going to be needed
+    # here too?
+    #
+    hplot = HistogramPlot()
+    hplot.xlo = vals['xlo']
+    hplot.xhi = vals['xhi']
+    hplot.y = vals['y']  # .astype(np.float32)
+    hplot.xlabel = 'Energy (keV)'
+    hplot.title = 'ChaRT Spectrum: {}'.format(vals['model'])
 
-        id = c.ChipsId()
-        id.coord_sys = c.FRAME_NORM
-        c.add_label(id, 0.05, 0.97,
-                    "Model: {}".format(vals["model"]))
-        c.add_label(id, 0.95, 0.97,
-                    "Dataset: {}".format(repr(vals["id"])),
-                    ["halign", 1])
+    # LaTeX support depends on the backend
+    if backend.name == 'pylab':
+        hplot.ylabel = 'Flux (photon cm$^{-2}$ s$^{-1}$)'
+    elif backend.name == 'chips':
+        hplot.ylabel = 'Flux (photon cm^{-2} s^{-1})'
+    else:
+        hplot.ylabel = 'Flux (photon cm^-2 s^-1)'
 
-    except Exception:
-        c.discard_undo_buffer()
-        raise
-
-    c.close_undo_buffer()
+    hplot.plot(overplot=overplot, clearwindow=clearwindow)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
@@ -37,11 +37,11 @@ Examples
 
 """
 
-import pychips.all as c
+from sherpa.plot import HistogramPlot, backend
 
 from crates_contrib.utils import write_columns
 
-from .chart import _get_chart_spectrum, plot_chart_spectrum
+from .chart import _get_chart_spectrum
 
 __all__ = ("get_marx_spectrum",
            "save_marx_spectrum",
@@ -68,7 +68,7 @@ def get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     Returns
     -------
     (energ_hi, flux_bins)
-       The energies are in keV and fluxes in photons/cm^2/s.
+       The energies are in keV and fluxes in photons/cm^2/s/keV.
 
     Notes
     -----
@@ -102,7 +102,7 @@ def get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     >>> gal.nh = 0.09
     >>> pl.gamma = 1.25
     >>> pl.ampl = 8.432e-5
-    >>> (xlo, xhi, y) = get_chart_spectrum()
+    >>> (xhi, y) = get_marx_spectrum()
 
     """
 
@@ -111,11 +111,9 @@ def get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
 
 
 def save_marx_spectrum(outfile, clobber=True, verbose=True,
-                       **kwargs):
+                       id=None, elow=None, ehigh=None, ewidth=None,
+                       norm=None):
     """Create a spectrum file in the format used by MARX.
-
-    See `get_marx_spectrum` for information on the other
-    arguments supported by this function.
 
     Parameters
     ----------
@@ -129,6 +127,16 @@ def save_marx_spectrum(outfile, clobber=True, verbose=True,
         Should a message be displayed indicating that the file
         has been created? This is only used when outfile is not
         ``None``.
+    id : int or string or None
+        If id is None then the default Sherpa id is used. This
+        dataset must have a grid and source model defined.
+    elow, ehigh, ewidth : number or None
+        Only used if all three are given, otherwise the grid
+        of the data set is used. The elo value is the start
+        of the low-energy bin, ehigh is the end of the high-energy
+        bin, and ewidth the bin width, all in keV.
+    norm : number or None
+        Multiply the flux values by this value, if set.
 
     Notes
     -----
@@ -139,7 +147,9 @@ def save_marx_spectrum(outfile, clobber=True, verbose=True,
     if outfile is None:
         raise ValueError("The outfile argument must be specified")
 
-    (ehi, flux) = get_marx_spectrum(**kwargs)
+    (ehi, flux) = get_marx_spectrum(id=id, elow=elow,
+                                    ehigh=ehigh, ewidth=ewidth,
+                                    norm=norm)
     write_columns(outfile, ehi, flux,
                   format='raw', clobber=clobber)
 
@@ -147,13 +157,54 @@ def save_marx_spectrum(outfile, clobber=True, verbose=True,
         print("Created: {}".format(outfile))
 
 
-def plot_marx_spectrum(**kwargs):
+def plot_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
+                       norm=None, overplot=False, clearwindow=True):
     """Plots the spectrum as used by MARX.
 
-    See `get_marx_spectrum` for information on the
-    arguments supported by this function.
+    Parameters
+    ----------
+    id : int or string or None
+        If id is None then the default Sherpa id is used. This
+        dataset must have a grid and source model defined.
+    elow, ehigh, ewidth : number or None
+        Only used if all three are given, otherwise the grid
+        of the data set is used. The elo value is the start
+        of the low-energy bin, ehigh is the end of the high-energy
+        bin, and ewidth the bin width, all in keV.
+    norm : number or None
+        Multiply the flux values by this value, if set.
+    overplot : bool, optional
+        If ``True`` then the data is added to the current plot,
+        otherwise a new plot is created.
+    clearwindow: bool, optional
+        If ``True`` then clear out the current plot area of all
+        existing plots. This is not used if ``overplot`` is set.
+
     """
-    plot_chart_spectrum(**kwargs)
-    c.open_undo_buffer()
-    c.set_plot_title("MARX Source Spectrum")
-    c.close_undo_buffer()
+
+    vals = _get_chart_spectrum(id=id, elow=elow,
+                               ehigh=ehigh, ewidth=ewidth,
+                               norm=norm)
+
+    # In sherpa_contrib.utils.plot_instmap_weights it was found useful
+    # to convert the Y values to float32 from float64 to avoid
+    # precision issues confusing the plot (i.e. showing structure that
+    # isn't meaningful to the user). Is this going to be needed
+    # here too?
+    #
+    hplot = HistogramPlot()
+    hplot.xlo = vals['xlo']
+    hplot.xhi = vals['xhi']
+    hplot.y = vals['y'] / (vals['xhi'] - vals['xlo'])
+    hplot.xlabel = 'Energy (keV)'
+    hplot.title = 'MARX Spectrum: {}'.format(vals['model'])
+
+    # LaTeX support depends on the backend
+    if backend.name == 'pylab':
+        hplot.ylabel = 'Flux (photon cm$^{-2}$ s$^{-1}$ keV$^{-1}$)'
+    elif backend.name == 'chips':
+        hplot.ylabel = 'Flux (photon cm^{-2} s^{-1} keV^{-1})'
+    else:
+        hplot.ylabel = 'Flux (photon cm^-2 s^-1)'
+
+    hplot.plot(overplot=overplot, clearwindow=clearwindow)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018
+# Copyright (C) 2018, 2019
 #           Massachusetts Institute of Technology
 #
 #
@@ -144,7 +144,7 @@ def save_marx_spectrum(outfile, clobber=True, verbose=True,
                   format='raw', clobber=clobber)
 
     if verbose:
-        print ("Created: {}".format(outfile))
+        print("Created: {}".format(outfile))
 
 
 def plot_marx_spectrum(**kwargs):

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/marx.py
@@ -59,9 +59,10 @@ def get_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
         dataset must have a grid and source model defined.
     elow, ehigh, ewidth : number or None
         Only used if all three are given, otherwise the grid
-        of the data set is used. The elo value is the start
-        of the low-energy bin, ehigh is the end of the high-energy
-        bin, and ewidth the bin width, all in keV.
+        of the data set is used. The elo value gives the start
+        of the grid (the left edge of the first bin) and ehi
+        is the end of the grid (the right edge of the last bin),
+        and ewidth the bin width, all in keV.
     norm : number or None
         Multiply the flux values by this value, if set.
 
@@ -132,9 +133,10 @@ def save_marx_spectrum(outfile, clobber=True, verbose=True,
         dataset must have a grid and source model defined.
     elow, ehigh, ewidth : number or None
         Only used if all three are given, otherwise the grid
-        of the data set is used. The elo value is the start
-        of the low-energy bin, ehigh is the end of the high-energy
-        bin, and ewidth the bin width, all in keV.
+        of the data set is used. The elo value gives the start
+        of the grid (the left edge of the first bin) and ehi
+        is the end of the grid (the right edge of the last bin),
+        and ewidth the bin width, all in keV.
     norm : number or None
         Multiply the flux values by this value, if set.
 
@@ -168,9 +170,10 @@ def plot_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
         dataset must have a grid and source model defined.
     elow, ehigh, ewidth : number or None
         Only used if all three are given, otherwise the grid
-        of the data set is used. The elo value is the start
-        of the low-energy bin, ehigh is the end of the high-energy
-        bin, and ewidth the bin width, all in keV.
+        of the data set is used. The elo value gives the start
+        of the grid (the left edge of the first bin) and ehi
+        is the end of the grid (the right edge of the last bin),
+        and ewidth the bin width, all in keV.
     norm : number or None
         Multiply the flux values by this value, if set.
     overplot : bool, optional

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2010, 2011, 2012, 2014, 2015, 2016
+#  Copyright (C) 2009, 2010, 2011, 2012, 2014, 2015, 2016, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -66,10 +66,7 @@ from sherpa.models.parameter import Parameter
 import pychips.all as pyc
 import pycrates
 
-# from crates_contrib.utils import make_table_crate
-
-__all__ = ["renorm"
-           , "get_instmap_weights", "save_instmap_weights",
+__all__ = ["renorm", "get_instmap_weights", "save_instmap_weights",
            "plot_instmap_weights", "estimate_weighted_expmap",
            "InstMapWeights", "InstMapWeights1DInt",
            "InstMapWeightsPHA"
@@ -355,7 +352,7 @@ class InstMapWeights:
                 if axis > 0:
                     pyc.log_scale(axis)
 
-        except:
+        except Exception:
             pyc.discard_undo_buffer()
             raise
 
@@ -812,7 +809,7 @@ def plot_instmap_weights(id=None, overplot=False, fluxtype="photon"):
 def estimate_weighted_expmap(id=None, arf=None, elo=None, ehi=None,
                              specresp=None, fluxtype="photon",
                              par=None, pvals=None):
-    """Estimate the weighted exposure map value for an ARF.
+    r"""Estimate the weighted exposure map value for an ARF.
 
     Parameters
     ----------

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
@@ -48,8 +48,6 @@ import os
 import logging
 import time
 
-import six
-
 import numpy as np
 
 from sherpa.astro import ui
@@ -121,7 +119,7 @@ class InstMapWeights:
         names = ["id", "modelexpr", "xlo", "xhi", "xmid", "weight",
                  "fluxtype"]
         vals  = [getattr(self, n) for n in names]
-        return print_fields(names, dict(six.moves.zip(names, vals)))
+        return print_fields(names, dict(zip(names, vals)))
 
     def __init__(self, id=None, fluxtype="photon"):
         "If id is None the default id will be used."
@@ -723,7 +721,7 @@ def save_instmap_weights(*args, **kwargs):
         user["id"]       = args[0]
         user["filename"] = args[1]
 
-    for (n, v) in six.iteritems(kwargs):
+    for (n, v) in kwargs.items():
         if n not in argnames:
             emsg = "{}() got an unexpected ".format(fname) + \
                 "keyword argument '{}'".format(n)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
@@ -60,8 +60,8 @@ from sherpa.utils.err import ArgumentErr, ParameterErr
 from sherpa.data import Data1DInt
 from sherpa.astro.data import DataPHA
 from sherpa.models.parameter import Parameter
+from sherpa.plot import HistogramPlot
 
-import pychips.all as pyc
 import pycrates
 
 __all__ = ["renorm", "get_instmap_weights", "save_instmap_weights",
@@ -281,15 +281,18 @@ class InstMapWeights:
 
         info("Created: {}".format(filename))
 
-    def plot(self, overplot=False):
+    def plot(self, overplot=False, clearwindow=True):
         """Plot the weights values.
 
         Parameters
         ----------
         overplot : bool, optional
-            If ``True`` then the data is added to the current
-            plot, otherwise a ChIPS `erase()` call is made
-            at the start of plotting.
+            If ``True`` then the data is added to the current plot,
+            otherwise a new plot is created.
+        clearwindow: bool, optional
+            If ``True`` then clear out the current plot area of
+            all existing plots. This is not used if ``overplot`` is
+            set.
 
         Notes
         -----
@@ -299,62 +302,45 @@ class InstMapWeights:
 
             ``xlog``
             ``ylog``
-            ``linethickness``
-            ``linecolor``
-
-        The ``linestyle`` is always set to ``chips_solid``.
+            ``linethickness``  (ChIPS only)
+            ``linecolor``      (ChIPS only)
         """
 
-        prefs = ui.get_data_plot_prefs()
+        # Create a Sherpa histogram plot. Unlike other plot
+        # classes there is no prepare method, which means
+        # that we do not have to create a temporary data object,
+        # but do have to set the attributes manually.
+        #
+        # This assumes that it is okay to use a histogram-style
+        # plot, since pre CIAO 4.2 there were numeric problems with
+        # bin edges that made these plots look ugly, so a "curve"
+        # was used.
+        #
+        # To avoid issues with numeric accuracy (I have seen a
+        # case where the variation in the weight values was ~2e-16
+        # and matplotlib showed this structure), convert the weights
+        # to 32-bit before plotting. This is a lot simpler than
+        # dealing with some sort of run-length-encoding scheme to
+        # group bins that are "close enough" numerically.
+        #
+        hplot = HistogramPlot()
+        hplot.xlo = self.xlo
+        hplot.xhi = self.xhi
+        hplot.y = self.weight.astype(np.float32)
+        hplot.xlabel = 'Energy (keV)'
+        hplot.ylabel = 'Weights'
+        hplot.title = 'Weights for {}: '.format(self.id) + \
+                      ' {}'.format(self.modelexpr)
 
         # There is no validation of the preference values
         #
-        hprefs = pyc.ChipsHistogram()
-        hprefs.symbol.style = pyc.chips_none
-        if prefs.get("linethickness", None) is not None:
-            hprefs.line.thickness = prefs["linethickness"]
-        if prefs.get("linecolor", None) is not None:
-            hprefs.line.color = prefs["linecolor"]
-        # if prefs.get("linestyle", None) is not None:
-        #     hprefs.line.style = prefs["linestyle"]
-        hprefs.line.style = pyc.chips_solid
+        prefs = ui.get_data_plot_prefs()
+        for name in ['xlog', 'ylog', 'linethickness', 'linecolor']:
+            value = prefs.get(name, None)
+            if value is not None:
+                hplot.histo_prefs[name] = value
 
-        # We rely on XY_AXIS == X_AXIS | Y_AXIS
-        #
-        xlog = prefs.get("xlog", False)
-        ylog = prefs.get("ylog", False)
-        axis = 0
-        if xlog: axis |= pyc.X_AXIS
-        if ylog: axis |= pyc.Y_AXIS
-
-        pyc.open_undo_buffer()
-        try:
-
-            if not overplot:
-                pyc.erase()
-
-            # I would like to use self.xlo/self.xhi here but this can
-            # lead to ugly plots for certain datasets created by
-            # dataspace1d.  So we use xmid for now. This may no-longer
-            # be an issue (CIAO 4.2), but left as-is for now.
-            #
-            pyc.add_histogram(self.xmid, self.weight, hprefs)
-
-            if not overplot:
-                pyc.set_plot_xlabel("Energy (keV)")
-                pyc.set_plot_ylabel("Weights")
-                title = "Weights for {}: ".format(self.id) + \
-                    " {}".format(self.modelexpr)
-                pyc.set_plot_title(title)
-
-                if axis > 0:
-                    pyc.log_scale(axis)
-
-        except Exception:
-            pyc.discard_undo_buffer()
-            raise
-
-        pyc.close_undo_buffer()
+        hplot.plot(overplot=overplot, clearwindow=clearwindow)
 
     def _estimate_expmap(self, *args):
         """Estimate the exposure map given an ARF.
@@ -732,7 +718,8 @@ def save_instmap_weights(*args, **kwargs):
     wgts.save(user["filename"], clobber=user["clobber"])
 
 
-def plot_instmap_weights(id=None, overplot=False, fluxtype="photon"):
+def plot_instmap_weights(id=None, fluxtype="photon",
+                         overplot=False, clearwindow=True):
     """Plot the weights values.
 
     Parameters
@@ -740,13 +727,15 @@ def plot_instmap_weights(id=None, overplot=False, fluxtype="photon"):
     id : int, string, or None
         The Sherpa dataset to use. If ``None`` then the default
         dataset is used.
-    overplot : bool, optional
-        If ``True`` then the data is added to the current
-        plot, otherwise a ChIPS `erase()` call is made
-        at the start of plotting.
     fluxtype : 'photon' or 'erg'
         The units of the instrument map are
         cm^2 count / ``fluxtype``. The default is ``photon``.
+    overplot : bool, optional
+        If ``True`` then the data is added to the current plot,
+        otherwise a new plot is created.
+    clearwindow: bool, optional
+        If ``True`` then clear out the current plot area of all
+        existing plots. This is not used if ``overplot`` is set.
 
     See Also
     --------
@@ -762,10 +751,8 @@ def plot_instmap_weights(id=None, overplot=False, fluxtype="photon"):
 
         ``xlog``
         ``ylog``
-        ``linethickness``
-        ``linecolor``
-
-    The ``linestyle`` is always set to ``chips_solid``.
+        ``linethickness``  (ChIPS only)
+        ``linecolor``      (ChIPS only)
 
     Examples
     --------
@@ -777,7 +764,6 @@ def plot_instmap_weights(id=None, overplot=False, fluxtype="photon"):
     >>> gal.nh = 0.12
     >>> pl.phoindex = 1.7
     >>> plot_instmap_weights()
-    >>> log_scale()
 
     Change the model to an absorbed APEC model and overplot it
     (in orange).
@@ -792,8 +778,6 @@ def plot_instmap_weights(id=None, overplot=False, fluxtype="photon"):
 
     >>> plot_instmap_weights()
     >>> plot_instmap_weights(fluxtype='erg')
-    >>> set_histogram(['*.color', 'orange'])
-    >>> log_scale()
 
     """
 
@@ -801,13 +785,13 @@ def plot_instmap_weights(id=None, overplot=False, fluxtype="photon"):
         id = ui.get_default_id()
 
     wgts = get_instmap_weights(id, fluxtype=fluxtype)
-    wgts.plot(overplot=overplot)
+    wgts.plot(overplot=overplot, clearwindow=clearwindow)
 
 
 def estimate_weighted_expmap(id=None, arf=None, elo=None, ehi=None,
                              specresp=None, fluxtype="photon",
                              par=None, pvals=None):
-    r"""Estimate the weighted exposure map value for an ARF.
+    """Estimate the weighted exposure map value for an ARF.
 
     Parameters
     ----------
@@ -865,9 +849,6 @@ def estimate_weighted_expmap(id=None, arf=None, elo=None, ehi=None,
     >>> gvals = np.arange(0.5,5,0.1)
     >>> evals = estimate_weighted_expmap(arf="arf.fits", par=pl.gamma,
                                          pvals=gvals)
-    >>> add_curve(gvals, evals, ['symbol.style', 'none'])
-    >>> set_plot_xlabel(r'\Gamma')
-    >>> set_plot_ylabel('Exposure map (cm^2 count / photon')
 
     """
 

--- a/ciao-4.11/contrib/share/doc/xml/estimate_weighted_expmap.xml
+++ b/ciao-4.11/contrib/share/doc/xml/estimate_weighted_expmap.xml
@@ -135,11 +135,11 @@ from sherpa_contrib.utils import *
 <VERBATIM>
 gamma_vals = np.arange(0.1,5,0.1)
 expmap_vals = estimate_weighted_expmap(par=pl.gamma, pvals=gamma_vals)
-add_curve(gamma_vals, expmap_vals)
 </VERBATIM>
 
       <PARA>
-	The plot shows how the conversion factor (i.e. weighted exposure map)
+	The curve gamma_vals, expmap_vals shows how the
+	conversion factor (i.e. weighted exposure map)
 	value varies as gamma changes from 0.1 to 4.9.
       </PARA>
     </DESC>
@@ -266,7 +266,6 @@ add_curve(gamma_vals, expmap_vals)
         <SYNTAX>
           <LINE>&pr; kts = 10**np.linspace(-1,1,11)</LINE>
           <LINE>&pr; evals = estimate_weighted_expmap(2, elo=x1, ehi=x2, specresp=arf, par=clus.kt, parvals=kts)</LINE>
-          <LINE>&pr; add_curve(evals, kts, ["symbol.style", "none"])</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -292,6 +291,6 @@ add_curve(gamma_vals, expmap_vals)
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/plot_chart_spectrum.xml
+++ b/ciao-4.11/contrib/share/doc/xml/plot_chart_spectrum.xml
@@ -87,6 +87,22 @@ from sherpa_contrib.chart import *
 	    brighter than the input model.
 	  </DATA>
 	</ROW>
+	<ROW>
+	  <DATA>overplot</DATA>
+	  <DATA>False</DATA>
+	  <DATA>
+	    If True then the data is added to the current plot,
+            otherwise a new plot is created.
+	  </DATA>
+	</ROW>
+	<ROW>
+	  <DATA>clearwindow</DATA>
+	  <DATA>True</DATA>
+	  <DATA>
+            If True then clear out the current plot area of all
+            existing plots. This is not used if overplot is set.
+	  </DATA>
+	</ROW>
 
       </TABLE>
 
@@ -123,6 +139,22 @@ from sherpa_contrib.chart import *
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The plot_chart_spectrum() routine now uses the
+	Sherpa plot backend (controlled by the plot_pkg setting in
+	a user's ~/.sherpa.rc file), rather than always using ChIPS.
+	As part of this update the extra labelling in the plot - that
+	gave the model name and dataset identifier - have been
+	removed (although the model name is now included in the plot
+	title). 
+      </PARA>
+      <PARA title="Optional arguments">
+	The overplot and clearwindow optional arguments have been added
+	to plot_chart_spectrum.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.8.2 (January 2016) release">
       <PARA>
 	The plot style is now a histogram rather than a curve.
@@ -137,6 +169,6 @@ from sherpa_contrib.chart import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/plot_instmap_weights.xml
+++ b/ciao-4.11/contrib/share/doc/xml/plot_instmap_weights.xml
@@ -49,6 +49,22 @@ from sherpa_contrib.utils import *
 	  valid options for this argument are "photon" (the default) or "erg".
 	  </DATA>
 	</ROW>
+	<ROW>
+	  <DATA>overplot</DATA>
+	  <DATA>False</DATA>
+	  <DATA>
+	    If True then the data is added to the current plot,
+            otherwise a new plot is created.
+	  </DATA>
+	</ROW>
+	<ROW>
+	  <DATA>clearwindow</DATA>
+	  <DATA>True</DATA>
+	  <DATA>
+            If True then clear out the current plot area of all
+            existing plots. This is not used if overplot is set.
+	  </DATA>
+	</ROW>
       </TABLE>
 
     </DESC>
@@ -57,34 +73,41 @@ from sherpa_contrib.utils import *
       <QEXAMPLE>
         <SYNTAX>
           <LINE>&pr; plot_instmap_weights()</LINE>
-          <LINE>&pr; log_scale()</LINE>
 	</SYNTAX>
 	<DESC>
-
           <PARA>
-	    Create a plot of the model weights for the default dataset and then change to
-	    a logarithmic scale for both axes.
+	    Create a plot of the model weights for the default dataset.
 	  </PARA>
-
         </DESC>
       </QEXAMPLE>
 
       <QEXAMPLE>
         <SYNTAX>
           <LINE>&pr; plot_instmap_weights(fluxtype="erg")</LINE>
-          <LINE>&pr; log_scale(Y_AXIS)</LINE>
 	</SYNTAX>
 	<DESC>
 
           <PARA>
 	    Here the weights are for use in creating an instrument map in units
-	    of cm^2 count / erg rather than the defaulf of cm^2 count / photon.
+	    of cm^2 count / erg rather than the default of cm^2 count / photon.
 	  </PARA>
 
         </DESC>
       </QEXAMPLE>
 
     </QEXAMPLELIST>
+
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The plot_instmap_weights() routine now uses the
+	Sherpa plot backend (controlled by the plot_pkg setting in
+	a user's ~/.sherpa.rc file), rather than always using ChIPS.
+      </PARA>
+      <PARA title="Optional argument">
+	The clearwindow optional arguments has been added
+	to plot_instmap_weights.
+      </PARA>
+    </ADESC>
 
     <BUGS>
       <PARA>
@@ -94,6 +117,6 @@ from sherpa_contrib.utils import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>April 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/plot_marx_spectrum.xml
+++ b/ciao-4.11/contrib/share/doc/xml/plot_marx_spectrum.xml
@@ -84,6 +84,22 @@ from sherpa_contrib.marx import *
 	    brighter than the input model.
 	  </DATA>
 	</ROW>
+	<ROW>
+	  <DATA>overplot</DATA>
+	  <DATA>False</DATA>
+	  <DATA>
+	    If True then the data is added to the current plot,
+            otherwise a new plot is created.
+	  </DATA>
+	</ROW>
+	<ROW>
+	  <DATA>clearwindow</DATA>
+	  <DATA>True</DATA>
+	  <DATA>
+            If True then clear out the current plot area of all
+            existing plots. This is not used if overplot is set.
+	  </DATA>
+	</ROW>
 
       </TABLE>
 
@@ -120,6 +136,24 @@ from sherpa_contrib.marx import *
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The plot_marx_spectrum() routine now uses the
+	Sherpa plot backend (controlled by the plot_pkg setting in
+	a user's ~/.sherpa.rc file), rather than always using ChIPS.
+	The Y axis now displays the units required by MARX - namely
+	photon/cm^2/s/keV - rather than photon/cm^2/s.
+	As part of this update the extra labelling in the plot - that
+	gave the model name and dataset identifier - have been
+	removed (although the model name is now included in the plot
+	title). 
+      </PARA>
+      <PARA title="Optional arguments">
+	The overplot and clearwindow optional arguments have been added
+	to plot_marx_spectrum.
+      </PARA>
+    </ADESC>
+
     <BUGS>
       <PARA>
         See the
@@ -128,6 +162,6 @@ from sherpa_contrib.marx import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>September 2018</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_chart.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_chart.xml
@@ -74,6 +74,18 @@ from sherpa_contrib.all import *
 
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The plot_chart_spectrum() routine now uses the
+	Sherpa plot backend (controlled by the plot_pkg setting in
+	a user's ~/.sherpa.rc file), rather than always using ChIPS.
+	As part of this change the extra labelling in the plot - that
+	gave the model name and dataset identifier - have been
+	removed (although the model name is now included in the plot
+	title).
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.8.2 (January 2016) release">
       <PARA>
 	The routines have been updated to work with
@@ -89,6 +101,6 @@ from sherpa_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
@@ -80,6 +80,19 @@ import sherpa_contrib.all
     
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The plots created by sherpa_contrib.utils.plot_instmap_weights(),
+	sherpa_contrib.chart.plot_chart_spectrum(), and
+	sherpa_contrib.marx.plot_marx_spectrum() now use the
+	Sherpa plot backend (controlled by the plot_pkg setting in
+	a user's ~/.sherpa.rc file), rather than always using ChIPS.
+	As part of this change the extra labelling of the plot_xxx_spectrum
+	routines has been removed, so the plots may look slightly
+	different.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA title="Fixes to save_marx_spectrum">
 	The sherpa_contrib.marx.save_marx_spectrum() function now
@@ -141,6 +154,6 @@ import sherpa_contrib.all
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>April 2019</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_marx.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_marx.xml
@@ -74,6 +74,20 @@ from sherpa_contrib.all import *
 
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The plot_marx_spectrum() routine now uses the
+	Sherpa plot backend (controlled by the plot_pkg setting in
+	a user's ~/.sherpa.rc file), rather than always using ChIPS.
+	The Y axis now displays the units required by MARX - namely
+	photon/cm^2/s/keV - rather than photon/cm^2/s.
+	As part of this update the extra labelling in the plot - that
+	gave the model name and dataset identifier - have been
+	removed (although the model name is now included in the plot
+	title). 
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA title="Fixes to save_marx_spectrum">
 	The sherpa_contrib.marx.save_marx_spectrum() function now
@@ -97,6 +111,6 @@ from sherpa_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>April 2019</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_utils.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_utils.xml
@@ -77,6 +77,14 @@ from sherpa_contrib.all import *
 
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The plot_instmap_weights() routine now uses the
+	Sherpa plot backend (controlled by the plot_pkg setting in
+	a user's ~/.sherpa.rc file), rather than always using ChIPS.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.8.2 (January 2016) release">
       <PARA title="New routine">
 	The renorm() function was added.
@@ -102,6 +110,6 @@ from sherpa_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Fix the plotting in `sherpa_contrib` - for the `utils`, `chart`, and `marx` modules - so that it uses the Sherpa plotting objects (so is backend agnostic).

 - [x] `sherpa_contrib.utils.plot_instmap_weights`
    - adds the `clearwindow` argument
    - now plots the weights after downcasting to `float32` as there was "noise" when using `float64`
      which matplotlib was displaying
 - [x] `sherpa_contrib.chart.plot_chart_spectrum`
   - adds the `overplot` and `clearwindow` arguments
   - moves the model name to the plot title and drops the dataset label
 - [x] `sherpa_contrib.marx.plot_marx_spectrum`
   - adds the `overplot` and `clearwindow` arguments
   - moves the model name to the plot title and drops the dataset label
   - plots the Y axis in units of `photon/cm^2/s/keV` to match the data needed by MARX
 - [X] update the ahelp documentation
 - [X] add the changelog entry

# Note

This does not make all Sherpa plots use matplotlib, as the `sherpa_contrib.profiles.prof_XXX` routines still need to be updated, but that's for another PR.