### PR TITLE
Update sherpa radial plots to use matplotlib

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -6,6 +6,14 @@ file. The updated routines are
 
   sherpa_contrib.chart.plot_chart_spectrum
   sherpa_contrib.marx.plot_marx_spectrum
+  sherpa_contrib.profiles.prof_data
+  sherpa_contrib.profiles.prof_delchi
+  sherpa_contrib.profiles.prof_fit
+  sherpa_contrib.profiles.prof_fit_delchi
+  sherpa_contrib.profiles.prof_fit_resid
+  sherpa_contrib.profiles.prof_model
+  sherpa_contrib.profiles.prof_resid
+  sherpa_contrib.profiles.prof_source
   sherpa_contrib.utils.plot_instmap_weights
 
 The plots may have changed slightly in this update (for instance, the

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -144,42 +144,51 @@ class RadialProfile(Histogram):
         Histogram.__init__(self)
 
     def __str__(self):
+        # Be safe and ensure the old print options are restored (e.g.
+        # in-case a user hits control-c)
+        #
+        oldopts = np.get_printoptions()
         np.set_printoptions(precision=4, threshold=6)
 
-        xlo = self.xlo
-        if self.xlo is not None:
-            xlo = np.array2string(self.xlo)
+        try:
+            xlo = self.xlo
+            if self.xlo is not None:
+                xlo = np.array2string(self.xlo)
 
-        xhi = self.xhi
-        if self.xhi is not None:
-            xhi = np.array2string(self.xhi)
+            xhi = self.xhi
+            if self.xhi is not None:
+                xhi = np.array2string(self.xhi)
 
-        y = self.y
-        if self.y is not None:
-            y = np.array2string(self.y)
+            y = self.y
+            if self.y is not None:
+                y = np.array2string(self.y)
 
-        yerr = self.yerr
-        if self.yerr is not None:
-            yerr = np.array2string(self.yerr)
+            yerr = self.yerr
+            if self.yerr is not None:
+                yerr = np.array2string(self.yerr)
 
-        return (('xlo    = {0}\n' +
-                 'xhi    = {1}\n' +
-                 'y      = {2}\n' +
-                 'yerr   = {3}\n' +
-                 'xlabel = {4}\n' +
-                 'ylabel = {5}\n' +
-                 'labels = {6}\n' +
-                 'title  = {7}\n' +
-                 'histo_prefs = {8}').format(
-                xlo,
-                xhi,
-                y,
-                yerr,
-                self.xlabel,
-                self.ylabel,
-                self.labels,
-                self.title,
-                self.histo_prefs))
+            out = ('xlo    = {}\n' +
+                   'xhi    = {}\n' +
+                   'y      = {}\n' +
+                   'yerr   = {}\n' +
+                   'xlabel = {}\n' +
+                   'ylabel = {}\n' +
+                   'labels = {}\n' +
+                   'title  = {}\n' +
+                   'histo_prefs = {}').format(
+                       xlo,
+                       xhi,
+                       y,
+                       yerr,
+                       self.xlabel,
+                       self.ylabel,
+                       self.labels,
+                       self.title,
+                       self.histo_prefs)
+        finally:
+            np.set_printoptions(**oldopts)
+
+        return out
 
     def prepare(self, xlo, xhi, y, yerr, title, xlabel, ylabel, labels=None):
         self.xlo = xlo

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -94,19 +94,37 @@ __all__ = (
 )
 
 
-# Set up plot defaults
+# Set up plot defaults: the *_defaults routines are not expected
+# to be called externally.
 #
 # Apparently the xxx.get_yyy_defaults() routines already return
 # a copy of the structure so no need to here.
 #
+# This has been adjusted to try and get similar plots for both
+# ChIPS and Matplotlib.
+#
 def get_data_prof_defaults():
     d = plot.backend.get_histo_defaults()
-    d["errstyle"] = "line"
-    d["linestyle"] = 0  # no line
-    d["symbolfill"] = False
-    d["symbolsize"] = 3
-    d["symbolstyle"] = 4  # chips circle
-    d["yerrorbars"] = True
+
+    d['yerrorbars'] = True
+
+    # Try to support backend-specific settings
+    #
+    if plot.backend.name == 'chips':
+        newopts = [('errstyle', 'line'),
+                   ('linestyle', 0),
+                   ('symbolfill', False),
+                   ('symbolsize', 3),
+                   ('symbolstyle', 4)]  # circle
+    elif plot.backend.name == 'pylab':
+        newopts = [('marker', 'o'),
+                   ('markerfacecolor', 'none'),
+                   ('markersize', 4),
+                   ('linestyle', '')]
+
+    for n, v in newopts:
+        d[n] = v
+
     # d['xlog'] = True
     # d['ylog'] = True
     return d
@@ -119,9 +137,14 @@ def get_model_prof_defaults():
 
 def get_resid_prof_defaults():
     d = plot.backend.get_resid_plot_defaults()
+
     # are these needed/are more needed?
-    d.pop("xerrorbars", True)
-    d.pop("ratioline", True)
+    d.pop('xerrorbars', True)
+    d.pop('ratioline', True)
+
+    if plot.backend.name == 'pylab':
+        d['markerfacecolor'] = 'none'
+
     return d
 
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -595,9 +595,16 @@ def get_data_prof(id=None, model=None,
                   xpos=None, ypos=None, ellip=None, theta=None,
                   group_counts=None, group_snr=None,
                   **kwargs):
-    """
-    Returns an object containing the data used to create the prof_data()
-    plot.
+    """Return the data used by prof_data.
+
+    See prof_data for a description of the arguments.
+
+    Returns
+    -------
+    data : a `sherpa_contrib.profiles.RadialProfile` instance
+       An object representing the data used to create the plot by
+       `prof_data`.
+
     """
     if utils.bool_cast(kwargs.pop('recalc', True)):
         _prepare_prof_data_plot(id=id, rmin=rmin, rmax=rmax, rstep=rstep,
@@ -612,9 +619,16 @@ def get_model_prof(id=None, model=None,
                    xpos=None, ypos=None, ellip=None, theta=None,
                    group_counts=None, group_snr=None,
                    **kwargs):
-    """
-    Returns an object containing the data used to create the prof_model()
-    plot.
+    """Return the data used by prof_model.
+
+    See prof_data for a description of the arguments.
+
+    Returns
+    -------
+    data : a `sherpa_contrib.profiles.ModelRadialProfile` instance
+       An object representing the data used to create the plot by
+       `prof_model`.
+
     """
     if utils.bool_cast(kwargs.pop('recalc', True)):
         _prepare_prof_model_plot(id=id, rmin=rmin, rmax=rmax,
@@ -631,9 +645,16 @@ def get_source_prof(id=None, model=None,
                     xpos=None, ypos=None, ellip=None, theta=None,
                     group_counts=None, group_snr=None,
                     **kwargs):
-    """
-    Returns an object containing the data used to create the prof_source()
-    plot.
+    """Return the data used by prof_source.
+
+    See prof_data for a description of the arguments.
+
+    Returns
+    -------
+    data : a `sherpa_contrib.profiles.ModelRadialProfile` instance
+       An object representing the data used to create the plot by
+       `prof_source`.
+
     """
     if utils.bool_cast(kwargs.pop('recalc', True)):
         _prepare_prof_source_plot(id=id, rmin=rmin, rmax=rmax,
@@ -650,9 +671,16 @@ def get_resid_prof(id=None, model=None,
                    xpos=None, ypos=None, ellip=None, theta=None,
                    group_counts=None, group_snr=None,
                    **kwargs):
-    """
-    Returns an object containing the data used to create the prof_resid()
-    plot.
+    """Return the data used by prof_resid.
+
+    See prof_data for a description of the arguments.
+
+    Returns
+    -------
+    data : a `sherpa_contrib.profiles.ResidRadialProfile` instance
+       An object representing the data used to create the plot by
+       `prof_resid`.
+
     """
     if utils.bool_cast(kwargs.pop('recalc', True)):
         _prepare_prof_resid_plot(id=id, rmin=rmin, rmax=rmax, rstep=rstep,
@@ -669,9 +697,16 @@ def get_delchi_prof(id=None, model=None,
                     xpos=None, ypos=None, ellip=None, theta=None,
                     group_counts=None, group_snr=None,
                     **kwargs):
-    """
-    Returns an object containing the data used to create the prof_delchi()
-    plot.
+    """Return the data used by prof_delchi.
+
+    See prof_data for a description of the arguments.
+
+    Returns
+    -------
+    data : a `sherpa_contrib.profiles.ResidRadialProfile` instance
+       An object representing the data used to create the plot by
+       `prof_delchi`.
+
     """
     if utils.bool_cast(kwargs.pop('recalc', True)):
         _prepare_prof_delchi_plot(id=id, rmin=rmin, rmax=rmax,
@@ -688,9 +723,16 @@ def get_fit_prof(id=None, model=None,
                  xpos=None, ypos=None, ellip=None, theta=None,
                  group_counts=None, group_snr=None,
                  **kwargs):
-    """
-    Returns an object containing the data used to create the prof_fit()
-    plot.
+    """Return the data used by prof_fit.
+
+    See prof_data for a description of the arguments.
+
+    Returns
+    -------
+    data : a `sherpa.plot.FitPlot` instance
+       An object representing the data used to create the plot by
+       `prof_fit`.
+
     """
     if utils.bool_cast(kwargs.pop('recalc', True)):
         _prepare_prof_fit_plot(id=id, rmin=rmin, rmax=rmax,
@@ -700,8 +742,6 @@ def get_fit_prof(id=None, model=None,
                                group_counts=group_counts, group_snr=group_snr)
     return _prof_fit_plot
 
-
-# do we need get_prof_fit_resid_plot()/... ?
 
 #
 # Plot routines
@@ -1102,22 +1142,120 @@ def prof_fit_delchi(id=None, model=None,
 # Plot preferences
 #
 def get_data_prof_prefs():
+    """Return the preferences for prof_data.
+
+    Returns
+    -------
+    prefs : dict
+       Changing the values of this dictionary will change any new
+       data plots. This dictionary will be empty if no plot
+       backend is available.
+
+    See Also
+    --------
+    prof_data, prof_fit, prof_fit_resid, prof_fit_delchi
+
+    Notes
+    -----
+    The meaning of the fields depend on the chosen plot backend.
+    A value of ``None`` means to use the default value for that
+    attribute, unless indicated otherwise.
+
+    """
     return _prof_data_plot.histo_prefs
 
 
 def get_resid_prof_prefs():
+    """Return the preferences for prof_resid.
+
+    Returns
+    -------
+    prefs : dict
+       Changing the values of this dictionary will change any new
+       residual plots. This dictionary will be empty if no plot
+       backend is available.
+
+    See Also
+    --------
+    prof_resid, prof_fit_resid
+
+    Notes
+    -----
+    The meaning of the fields depend on the chosen plot backend.
+    A value of ``None`` means to use the default value for that
+    attribute, unless indicated otherwise.
+
+    """
     return _prof_resid_plot.histo_prefs
 
 
 def get_delchi_prof_prefs():
+    """Return the preferences for prof_delchi.
+
+    Returns
+    -------
+    prefs : dict
+       Changing the values of this dictionary will change any new
+       delchi plots. This dictionary will be empty if no plot
+       backend is available.
+
+    See Also
+    --------
+    prof_delchi, prof_fit_delchi
+
+    Notes
+    -----
+    The meaning of the fields depend on the chosen plot backend.
+    A value of ``None`` means to use the default value for that
+    attribute, unless indicated otherwise.
+
+    """
     return _prof_delchi_plot.histo_prefs
 
 
 def get_model_prof_prefs():
+    """Return the preferences for prof_model.
+
+    Returns
+    -------
+    prefs : dict
+       Changing the values of this dictionary will change any new
+       model plots. This dictionary will be empty if no plot
+       backend is available.
+
+    See Also
+    --------
+    prof_model, prof_fit, prof_fit_resid, prof_fit_delchi
+
+    Notes
+    -----
+    The meaning of the fields depend on the chosen plot backend.
+    A value of ``None`` means to use the default value for that
+    attribute, unless indicated otherwise.
+
+    """
     return _prof_model_plot.histo_prefs
 
 
 def get_source_prof_prefs():
-    return _prof_source_plot.histo_prefs
+    """Return the preferences for prof_source.
 
-#
+    Returns
+    -------
+    prefs : dict
+       Changing the values of this dictionary will change any new
+       source plots. This dictionary will be empty if no plot
+       backend is available.
+
+    See Also
+    --------
+    prof_source
+
+    Notes
+    -----
+    The meaning of the fields depend on the chosen plot backend.
+    A value of ``None`` means to use the default value for that
+    attribute, unless indicated otherwise.
+
+    """
+    return _prof_source_plot.histo_prefs

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2010, 2015, 2016, 2018
+#  Copyright (C) 2009, 2010, 2015, 2016, 2018, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -135,8 +135,8 @@ class RadialProfile(Histogram):
     def __init__(self):
         self.xlo = None
         self.xhi = None
-        self.y  = None
-        self.yerr  = None
+        self.y = None
+        self.yerr = None
         self.xlabel = None
         self.ylabel = None
         self.labels = None
@@ -843,7 +843,7 @@ def prof_data(id=None, model=None,
     try:
         plot.begin()
         _prof_data_plot.plot(**kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:
@@ -875,7 +875,7 @@ def prof_model(id=None, model=None,
     try:
         plot.begin()
         _prof_model_plot.plot(**kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:
@@ -907,7 +907,7 @@ def prof_source(id=None, model=None,
     try:
         plot.begin()
         _prof_source_plot.plot(**kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:
@@ -939,7 +939,7 @@ def prof_resid(id=None, model=None,
     try:
         plot.begin()
         _prof_resid_plot.plot(**kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:
@@ -971,7 +971,7 @@ def prof_delchi(id=None, model=None,
     try:
         plot.begin()
         _prof_delchi_plot.plot(**kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:
@@ -1003,7 +1003,7 @@ def prof_fit(id=None, model=None,
     try:
         plot.begin()
         _prof_fit_plot.plot(**kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:
@@ -1042,7 +1042,7 @@ def prof_fit_resid(id=None, model=None,
         jp.reset()
         jp.plottop(fp, **kwargs)
         jp.plotbot(rp, **kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:
@@ -1081,7 +1081,7 @@ def prof_fit_delchi(id=None, model=None,
         jp.reset()
         jp.plottop(fp, **kwargs)
         jp.plotbot(rp, **kwargs)
-    except:
+    except Exception:
         plot.exceptions()
         raise
     else:

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -67,7 +67,6 @@ import numpy as np
 
 from . import calculate as c
 
-import pychips.all as chips
 from . import annotations
 
 
@@ -103,10 +102,10 @@ __all__ = (
 def get_data_prof_defaults():
     d = plot.backend.get_histo_defaults()
     d["errstyle"] = "line"
-    d["linestyle"] = chips.chips_noline
+    d["linestyle"] = 0  # no line
     d["symbolfill"] = False
     d["symbolsize"] = 3
-    d["symbolstyle"] = chips.chips_circle
+    d["symbolstyle"] = 4  # chips circle
     d["yerrorbars"] = True
     # d['xlog'] = True
     # d['ylog'] = True

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -208,14 +208,16 @@ class RadialProfile(Histogram):
         # the residual plots)
         #
         store = self.histo_prefs.copy()
-        self.histo_prefs.pop("xaxis", True)
-        self.histo_prefs.pop("ratioline", True)
-        self.histo_prefs.pop("xerrorbars", True)
-        Histogram.plot(self, self.xlo, self.xhi, self.y,
-                       yerr=self.yerr, title=self.title,
-                       xlabel=self.xlabel, ylabel=self.ylabel,
-                       overplot=overplot, clearwindow=clearwindow)
-        self.histo_prefs = store
+        try:
+            self.histo_prefs.pop("xaxis", True)
+            self.histo_prefs.pop("ratioline", True)
+            self.histo_prefs.pop("xerrorbars", True)
+            Histogram.plot(self, self.xlo, self.xhi, self.y,
+                           yerr=self.yerr, title=self.title,
+                           xlabel=self.xlabel, ylabel=self.ylabel,
+                           overplot=overplot, clearwindow=clearwindow)
+        finally:
+            self.histo_prefs = store
 
         if not overplot:
             if store.get("xaxis", False):

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -223,11 +223,8 @@ class RadialProfile(Histogram):
 
         if not overplot:
             if store.get("xaxis", False):
-                chips.add_hline(0, ["id", "zero"])
-                chips.shuffle_back(chips.chips_line)
-            # if store.get("ratioline", False):
-            #     chips.add_hline(1, ["id", "one"])
-            #     chips.shuffle_back(chips.chips_line)
+                annotations.add_hline(0)
+
             if self.labels is not None:
                 x0 = 0.95
                 y0 = 0.92

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -63,11 +63,13 @@ import sherpa.plot as plot
 from sherpa.plot import Histogram, FitPlot, JointPlot
 from sherpa.astro.plot import ModelHistogram
 
-import pychips.all as chips
-
 import numpy as np
 
 from . import calculate as c
+
+import pychips.all as chips
+from . import annotations
+
 
 __all__ = (
     # Classes
@@ -231,8 +233,7 @@ class RadialProfile(Histogram):
                 y0 = 0.92
                 dy = 0.05
                 for l in self.labels:
-                    chips.add_label(x0, y0, l,
-                                    ["coordsys", chips.PLOT_NORM, "halign", 1])
+                    annotations.add_rlabel(x0, y0, l)
                     y0 -= dy
 
 
@@ -275,8 +276,7 @@ class ModelRadialProfile(ModelHistogram):
             y0 = 0.92
             dy = 0.05
             for l in self.labels:
-                chips.add_label(x0, y0, l,
-                                ["coordsys", chips.PLOT_NORM, "halign", 1])
+                annotations.add_rlabel(x0, y0, l)
                 y0 -= dy
 
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/__init__.py
@@ -447,12 +447,13 @@ def _prepare_prof_delchi_plot(id=None, model=None,
     else:
         labels = None
 
-    title = "Sigma Residuals of {0} - Model".format(rprof["datafile"])
+    title = 'Sigma Residuals of {} - Model'.format(rprof["datafile"])
+    sigma = annotations.add_latex_symbol(r'\sigma')
     _prof_delchi_plot.prepare(rprof["rlo"], rprof["rhi"],
                               rprof["delchi"], np.ones(rprof["delchi"].size),
                               title=title,
                               xlabel=rprof["xlabel"],
-                              ylabel=r"Residual (\sigma)",
+                              ylabel='Residual ({})'.format(sigma),
                               labels=labels)
 
 
@@ -572,11 +573,13 @@ def _prepare_prof_fit_delchi_plot(id=None, model=None,
                       ylabel="Counts per {0} pixel".format(rprof["coord"]))
 
     fp.prepare(dataplot, modelplot)
+
+    sigma = annotations.add_latex_symbol(r'\sigma')
     rp.prepare(rprof["rlo"], rprof["rhi"],
                rprof["delchi"], np.ones(rprof["delchi"].size),
                title=rprof["datafile"],
                xlabel=rprof["xlabel"],
-               ylabel=r"Residual (\sigma)")
+               ylabel='Residual ({})'.format(sigma))
 
 
 #

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
@@ -1,0 +1,71 @@
+#
+#  Copyright (C) 2019
+#            Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Support adding lannotations to plots
+
+The radial profile plots add extra annotations compared to the normal Sherpa
+plots, which means we need some backend-specific code to support this.
+
+"""
+
+import importlib
+import logging
+import sys
+
+from sherpa import plot
+
+warning = logging.getLogger(__name__).warning
+
+backend = None
+try:
+    pkg = 'sherpa_contrib.profiles'
+    modname = '.annotations_{}'.format(plot.backend.name)
+    importlib.import_module(modname, package=pkg)
+    backend = sys.modules['{}{}'.format(pkg, modname)]
+except AttributeError:
+    warning('Unable to find plotting library used by Sherpa')
+except ImportError:
+    warning('No support for annotations with the ' +
+            '{} backend'.format(plot.backend.name))
+
+del pkg
+del modname
+
+
+def add_rlabel(x, y, lbl):
+    """Add right-justified text to the current plot.
+
+    Parameters
+    ----------
+    x, y : float
+        The location for the label, in "plot normalized" coordinates
+        (0,0 is the bottom left of the current plot area and 1,1 is the
+        top right). The label is right-justified, so x refers to the end
+        of the label text.
+    lbl : str
+        The label to plot (this includes any special syntax or codes
+        to identify latex support or color change or whatever the
+        backend supports).
+    """
+
+    if backend is None:
+        return
+
+    backend.add_rlabel(x, y, lbl)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
@@ -100,7 +100,39 @@ def add_hline(y):
         full plot.
     """
 
-    if backend is None:
-        return
-
     backend.add_hline(y)
+
+
+@ignore_attribute_error
+def add_subscript(term, subscript):
+    """Add a subscript to the term.
+
+    This is intended to support LaTeX-like (or other) control codes.
+
+    Parameters
+    ----------
+    term, subscript: str
+
+    Returns
+    -------
+    label: str
+    """
+
+    return backend.add_subscript(term, subscript)
+
+
+@ignore_attribute_error
+def add_latex_symbol(symbol):
+    r"""Add a LaTeX symbol.
+
+    Parameters
+    ----------
+    symbol: str
+        Examples include r'\epsilon' and r'\Sigma'.
+
+    Returns
+    -------
+    label: str
+    """
+
+    return backend.add_latex_symbol(symbol)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
@@ -29,6 +29,8 @@ import importlib
 import logging
 import sys
 
+from functools import wraps
+
 from sherpa import plot
 
 warning = logging.getLogger(__name__).warning
@@ -49,6 +51,25 @@ del pkg
 del modname
 
 
+def ignore_attribute_error(func):
+    """A decorator that ignores any AttributeError raised by the code.
+
+    The assumption is that the AttribteError can only come from
+    the backend not having the correct symbol, or backend is None,
+    but the decorator does not enforce this.
+    """
+
+    @wraps(func)
+    def newfunc(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except AttributeError:
+            return None
+
+    return newfunc
+
+
+@ignore_attribute_error
 def add_rlabel(x, y, lbl):
     """Add right-justified text to the current plot.
 
@@ -65,12 +86,10 @@ def add_rlabel(x, y, lbl):
         backend supports).
     """
 
-    if backend is None:
-        return
-
     backend.add_rlabel(x, y, lbl)
 
 
+@ignore_attribute_error
 def add_hline(y):
     """Add a horizontal line.
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations.py
@@ -69,3 +69,19 @@ def add_rlabel(x, y, lbl):
         return
 
     backend.add_rlabel(x, y, lbl)
+
+
+def add_hline(y):
+    """Add a horizontal line.
+
+    Parameters
+    ----------
+    y : float
+        The location for the line, in data coordinates. It covers the
+        full plot.
+    """
+
+    if backend is None:
+        return
+
+    backend.add_hline(y)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_chips.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_chips.py
@@ -36,3 +36,11 @@ def add_hline(y):
     # The following is not required, but as we can easily do it in
     # ChIPS do so.
     chips.shuffle_back(chips.chips_line)
+
+
+def add_subscript(term, subscript):
+    return "{}_{}".format(term, subscript)
+
+
+def add_latex_symbol(symbol):
+    return symbol

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_chips.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_chips.py
@@ -1,0 +1,31 @@
+#
+#  Copyright (C) 2019
+#            Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Add annotations to a plot using ChIPS.
+
+This is specific to the sherpa_contrib.profiles routines.
+"""
+
+import pychips.all as chips
+
+
+def add_rlabel(x, y, lbl):
+    chips.add_label(x, y, lbl,
+                    ['coordsys', chips.PLOT_NORM, 'halign', 1])

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_chips.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_chips.py
@@ -29,3 +29,10 @@ import pychips.all as chips
 def add_rlabel(x, y, lbl):
     chips.add_label(x, y, lbl,
                     ['coordsys', chips.PLOT_NORM, 'halign', 1])
+
+
+def add_hline(y):
+    chips.add_hline(y)
+    # The following is not required, but as we can easily do it in
+    # ChIPS do so.
+    chips.shuffle_back(chips.chips_line)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_pylab.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_pylab.py
@@ -29,3 +29,20 @@ from matplotlib import pyplot as plt
 def add_rlabel(x, y, lbl):
     ax = plt.gca()
     plt.text(x, y, lbl, horizontalalignment='right', transform=ax.transAxes)
+
+
+def add_hline(y):
+    ax = plt.gca()
+
+    # Try to match the axes; is there a better way to do this?
+    lw = 1.0
+    lc = 'k'
+
+    try:
+        spine = ax.spines['left']
+        lw = spine.get_linewidth()
+        lc = spine.get_edgecolor()
+    except (KeyError, AttributeError):
+        pass
+
+    ax.axhline(y, linewidth=lw, color=lc)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_pylab.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_pylab.py
@@ -46,3 +46,11 @@ def add_hline(y):
         pass
 
     ax.axhline(y, linewidth=lw, color=lc)
+
+
+def add_subscript(term, subscript):
+    return "{}$_{}$".format(term, subscript)
+
+
+def add_latex_symbol(symbol):
+    return '${}$'.format(symbol)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_pylab.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/annotations_pylab.py
@@ -1,0 +1,31 @@
+#
+#  Copyright (C) 2019
+#            Smithsonian Astrophysical Observatory
+#
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Add annotations to a plot using matplotlib.
+
+This is specific to the sherpa_contrib.profiles routines.
+"""
+
+from matplotlib import pyplot as plt
+
+
+def add_rlabel(x, y, lbl):
+    ax = plt.gca()
+    plt.text(x, y, lbl, horizontalalignment='right', transform=ax.transAxes)

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/calculate.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/calculate.py
@@ -37,6 +37,9 @@ import sherpa.astro.data
 
 import numpy as np
 
+from .annotations import add_latex_symbol, add_subscript
+
+
 __all__ = ("calc_profile", )
 
 
@@ -701,6 +704,47 @@ def _calc_radial_profile(data, model, dr2, bins_lo, bins_hi, pixarea,
     return out
 
 
+def _set_subscript(term, subscript, symval):
+    """Return a string showing the subscripted value setting.
+
+    Parameters
+    ----------
+    term, subscript: str
+        The value being subscripted and the subscript (assumed to need
+        no LaTeX for either).
+    symval : val
+        The symbol value: something that can be converted to a string.
+
+    Returns
+    -------
+    label : str
+        Returns 'symname = symval' in a form suitable for the plotting
+        backend (where symname is term + subscript).
+    """
+
+    return '{} = {}'.format(add_subscript(term, subscript), symval)
+
+
+def _set_symbol(symname, symval):
+    """Return a string showing the symbol setting.
+
+    Parameters
+    ----------
+    symname: str
+        The symbol name (e.g. '\theta')
+    symval : val
+        The symbol value: something that can be converted to a string.
+
+    Returns
+    -------
+    label : str
+        Returns 'symname = symval' in a form suitable for the plotting
+        backend.
+    """
+
+    return '{} = {}'.format(add_latex_symbol(symname), symval)
+
+
 def calc_profile(model_image_fn,
                  id=None,
                  rmin=None, rmax=None, rstep=None, rlo=None, rhi=None,
@@ -823,11 +867,13 @@ def calc_profile(model_image_fn,
 
     rprof["xpos"] = xpos
     rprof["ypos"] = ypos
-    rprof["labels"] = ["x_0 = {0}".format(xpos), "y_0 = {0}".format(ypos)]
+    rprof["labels"] = [_set_subscript('x', '0', xpos),
+                       _set_subscript('y', '0', ypos)]
+
     if ellipflag:
         rprof["ellip"] = ellip
         rprof["theta"] = theta
-        rprof["labels"].extend([r"\epsilon = {0}".format(ellip),
-                                r"\theta = {0}".format(theta)])
+        rprof['labels'].extend([_set_symbol(r'\epsilon', ellip),
+                                _set_symbol(r'\theta', theta)])
 
     return rprof

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/calculate.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/profiles/calculate.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2010, 2015
+#  Copyright (C) 2009, 2010, 2015, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -192,10 +192,14 @@ def _process_profile_details(id, xpos, ypos, ellip, theta, model):
 
         (xpos2, ypos2, ellip2, theta2) = _find_model_info(model)
 
-        if xpos is None: xpos = xpos2
-        if ypos is None: ypos = ypos2
-        if ellip is None: ellip = ellip2
-        if theta is None: theta = theta2
+        if xpos is None:
+            xpos = xpos2
+        if ypos is None:
+            ypos = ypos2
+        if ellip is None:
+            ellip = ellip2
+        if theta is None:
+            theta = theta2
 
         mname = model.name
         if xpos is None:
@@ -280,23 +284,6 @@ def _normalize_pixel(x, dx, flag):
         return dx * (xp + 1.0)
     else:
         return dx * xp * 1.0
-
-"""
-This is old code; not sure what it was doing so commented out of
-_normalize_pixel.
-
-    if dx < 1.0:
-        f = np.log10(dx)
-    else:
-        x1 = x * 1.0
-        dx1 = dx
-
-    xp = int (x * 1.0 / dx)
-    if flag:
-        return dx * (xp + 1.0)
-    else:
-        return dx * xp * 1.0
-"""
 
 
 def _process_rstep_array(rstep, rmin, rmax):
@@ -523,7 +510,7 @@ def _calculate_distances2(data, xpos, ypos, ellip=None, theta=None):
     else:
         ct = np.cos(theta)
         st = np.sin(theta)
-        x_new  = dx * ct + dy * st
+        x_new = dx * ct + dy * st
         y_new = -dx * st + dy * ct
         efact = (1.0 - ellip) * (1.0 - ellip)
         dr2 = (x_new * x_new * efact + y_new * y_new) / efact
@@ -624,18 +611,18 @@ def _calc_radial_profile(data, model, dr2, bins_lo, bins_hi, pixarea,
     # We add in a isfinite check to modify the data.mask file as a precaution
     # but it's not ideal.
     #
-    zdata  = data.y * 1.0
+    zdata = data.y * 1.0
     # good_idx = data.mask
     good_idx = data.mask & np.isfinite(data.y)
 
     if model is None:
-        dr2    = dr2[good_idx]
-        zdata  = zdata[good_idx]
+        dr2 = dr2[good_idx]
+        zdata = zdata[good_idx]
 
     else:
 
-        dr2    = dr2[good_idx]
-        zdata  = zdata[good_idx]
+        dr2 = dr2[good_idx]
+        zdata = zdata[good_idx]
         zmodel = (model.y * 1.0).flatten()[good_idx]
 
     good_idx = None
@@ -644,9 +631,9 @@ def _calc_radial_profile(data, model, dr2, bins_lo, bins_hi, pixarea,
     rhi2 = bins_hi * bins_hi
 
     nbins = bins_lo.size
-    hist_data  = np.zeros(nbins)
-    hist_area  = np.zeros(nbins)
-    flag       = np.zeros(nbins, dtype=bool)
+    hist_data = np.zeros(nbins)
+    hist_area = np.zeros(nbins)
+    flag = np.zeros(nbins, dtype=bool)
     if model is not None:
         hist_model = np.zeros(nbins)
 

--- a/ciao-4.11/contrib/share/doc/xml/get_data_prof.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_data_prof.xml
@@ -75,18 +75,11 @@ from sherpa_contrib.profiles import *
 	<SYNTAX>
           <LINE>&pr; d10 = get_data_prof(group_snr=10)</LINE>
           <LINE>&pr; d20 = get_data_prof(group_snr=20)</LINE>
-          <LINE>&pr; erase()</LINE>
-          <LINE>&pr; add_histogram(d10.xlo, d10.xhi, d10.y, d10.yerr)</LINE>
-          <LINE>&pr; add_histogram(d20.xlo, d20.xhi, d20.y, d20.yerr, ["line.color", "red"])</LINE>
-          <LINE>&pr; set_plot_xlabel(d10.xlabel)</LINE>
-          <LINE>&pr; set_plot_ylabel(d10.ylabel)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Two profiles of the same dataset are calculated; d10 uses a signal-to-noise
-	    ratio of 10 and d20 a value of 20. The return values are then used to plot
-	    up the profiles using ChIPS commands to compare the plots (the d20 results
-	    are shown in green).
+	    ratio of 10 and d20 a value of 20.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -97,13 +90,12 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; prof_data("src1", group_counts=100)</LINE>
 	  <LINE>&pr; da = get_data_prof(recalc=False)</LINE>
 	  <LINE>&pr; prof_data("src2", rlo=da.xlo, rhi=da.xhi, overplot=True)</LINE>
-          <LINE>&pr; set_histogram(["symbol.color", "orange"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    A profile is calculated and displayed for the dataset "src1". The bin
 	    edges from this are then used to create a profile for the dataset "src2",
-	    which is overlain on the first plot using orange symbols.
+	    which is overlain on the first plot.
 	    Note that recalc is set to False
 	    in the call to get_data_prof() to avoid unnescessary re-calculations.
 	  </PARA>
@@ -120,6 +112,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_data_prof_prefs.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_data_prof_prefs.xml
@@ -44,7 +44,10 @@ from sherpa_contrib.profiles import *
 
       <PARA title="Plot defaults">
 	The following table lists the allowed keys and values for
-	the object returned by get_data_prof_prefs().
+	the object returned by get_data_prof_prefs(), for when
+	the ChIPS backend is in use. The values returned
+	when Matplolib is used are similar in spirit, but use
+	the Matplotlib naming.
       </PARA>
       <TABLE>
 	<ROW><DATA>Key</DATA><DATA>Allowed values</DATA></ROW>
@@ -108,6 +111,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_delchi_prof.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_delchi_prof.xml
@@ -83,18 +83,11 @@ from sherpa_contrib.profiles import *
 	<SYNTAX>
           <LINE>&pr; d10 = get_delchi_prof(group_snr=10)</LINE>
           <LINE>&pr; d20 = get_delchi_prof(group_snr=20)</LINE>
-          <LINE>&pr; erase()</LINE>
-          <LINE>&pr; add_histogram(d10.xlo, d10.xhi, d10.y, d10.yerr)</LINE>
-          <LINE>&pr; add_histogram(d20.xlo, d20.xhi, d20.y, d20.yerr, ["line.color", "red"])</LINE>
-          <LINE>&pr; set_plot_xlabel(d10.xlabel)</LINE>
-          <LINE>&pr; set_plot_ylabel(d10.ylabel)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Two profiles of the same dataset are calculated; d10 uses a signal-to-noise
-	    ratio of 10 and d20 a value of 20. The return values are then used to plot
-	    up the profiles using ChIPS commands to compare the plots (the d20 results
-	    are shown in green).
+	    ratio of 10 and d20 a value of 20.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -105,13 +98,12 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; prof_delchi("src1", group_counts=100)</LINE>
 	  <LINE>&pr; da = get_delchi_prof(recalc=False)</LINE>
 	  <LINE>&pr; prof_delchi("src2", rlo=da.xlo, rhi=da.xhi, overplot=True)</LINE>
-          <LINE>&pr; set_histogram(["symbol.color", "orange"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    A profile is calculated and displayed for the dataset "src1". The bin
 	    edges from this are then used to create a profile for the dataset "src2",
-	    which is overlain on the first plot using orange symbols.
+	    which is overlain on the first plot.
 	    Note that recalc is set to False
 	    in the call to get_delchi_prof() to avoid unnescessary re-calculations.
 	  </PARA>
@@ -128,6 +120,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_delchi_prof_prefs.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_delchi_prof_prefs.xml
@@ -45,7 +45,10 @@ from sherpa_contrib.profiles import *
 
       <PARA title="Plot defaults">
 	The following table lists the allowed keys and values for
-	the object returned by get_delchi_prof_prefs().
+	the object returned by get_delchi_prof_prefs(), for when
+	the ChIPS backend is in use. The values returned
+	when Matplolib is used are similar in spirit, but use
+	the Matplotlib naming.
       </PARA>
 
       <TABLE>
@@ -101,6 +104,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_fit_prof.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_fit_prof.xml
@@ -66,20 +66,10 @@ from sherpa_contrib.profiles import *
           <LINE>&pr; d10 = get_fit_prof(group_snr=10)</LINE>
           <LINE>&pr; d = d10.dataplot</LINE>
           <LINE>&pr; m = d10.modelplot</LINE>
-          <LINE>&pr; erase()</LINE>
-          <LINE>&pr; add_histogram(d.xlo, d.xhi, d.y, d.yerr, ["line.style", "none", "symbol.style", "square"])</LINE>
-          <LINE>&pr; add_histogram(m.xlo, m.xhi, m.y, ["line.color", "red"])</LINE>
-          <LINE>&pr; set_plot_xlabel(d.xlabel)</LINE>
-          <LINE>&pr; set_plot_ylabel(d.ylabel)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    The commands above produce a plot similar to that created by a call to
-	  </PARA>
-	  <PARA>
-	    <SYNTAX>
-	      <LINE>&pr; prof_fit(group_snr=10)</LINE>
-	    </SYNTAX>
+	    Extract the data and model components for the plot.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -94,6 +84,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_model_prof.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_model_prof.xml
@@ -82,18 +82,11 @@ from sherpa_contrib.profiles import *
 	<SYNTAX>
           <LINE>&pr; d10 = get_model_prof(group_snr=10)</LINE>
           <LINE>&pr; d20 = get_model_prof(group_snr=20)</LINE>
-          <LINE>&pr; erase()</LINE>
-          <LINE>&pr; add_histogram(d10.xlo, d10.xhi, d10.y)</LINE>
-          <LINE>&pr; add_histogram(d20.xlo, d20.xhi, d20.y, ["line.color", "red"])</LINE>
-          <LINE>&pr; set_plot_xlabel(d10.xlabel)</LINE>
-          <LINE>&pr; set_plot_ylabel(d10.ylabel)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Two profiles of the same model are calculated; d10 uses a signal-to-noise
-	    ratio of 10 and d20 a value of 20. The return values are then used to plot
-	    up the profiles using ChIPS commands to compare the plots (the d20 results
-	    are shown in green).
+	    ratio of 10 and d20 a value of 20.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -104,13 +97,12 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; prof_model("src1", group_counts=100)</LINE>
 	  <LINE>&pr; da = get_model_prof(recalc=False)</LINE>
 	  <LINE>&pr; prof_model("src2", rlo=da.xlo, rhi=da.xhi, overplot=True)</LINE>
-          <LINE>&pr; set_histogram(["symbol.color", "orange"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    A profile is calculated and displayed for the dataset "src1". The bin
 	    edges from this are then used to create a profile for the dataset "src2",
-	    which is overlain on the first plot using orange symbols.
+	    which is overlain on the first plot.
 	    Note that recalc is set to False
 	    in the call to get_model_prof() to avoid unnescessary re-calculations.
 	  </PARA>
@@ -127,6 +119,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_model_prof_prefs.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_model_prof_prefs.xml
@@ -44,7 +44,10 @@ from sherpa_contrib.profiles import *
 
       <PARA title="Plot defaults">
 	The following table lists the allowed keys and values for
-	the object returned by get_model_prof_prefs().
+	the object returned by get_model_prof_prefs(), for when
+	the ChIPS backend is in use. The values returned
+	when Matplolib is used are similar in spirit, but use
+	the Matplotlib naming.
       </PARA>
       <TABLE>
 	<ROW><DATA>Key</DATA><DATA>Allowed values</DATA></ROW>
@@ -92,6 +95,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 1029</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_resid_prof.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_resid_prof.xml
@@ -83,18 +83,11 @@ from sherpa_contrib.profiles import *
 	<SYNTAX>
           <LINE>&pr; d10 = get_resid_prof(group_snr=10)</LINE>
           <LINE>&pr; d20 = get_resid_prof(group_snr=20)</LINE>
-          <LINE>&pr; erase()</LINE>
-          <LINE>&pr; add_histogram(d10.xlo, d10.xhi, d10.y, d10.yerr)</LINE>
-          <LINE>&pr; add_histogram(d20.xlo, d20.xhi, d20.y, d20.yerr, ["line.color", "red"])</LINE>
-          <LINE>&pr; set_plot_xlabel(d10.xlabel)</LINE>
-          <LINE>&pr; set_plot_ylabel(d10.ylabel)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Two profiles of the same dataset are calculated; d10 uses a signal-to-noise
-	    ratio of 10 and d20 a value of 20. The return values are then used to plot
-	    up the profiles using ChIPS commands to compare the plots (the d20 results
-	    are shown in green).
+	    ratio of 10 and d20 a value of 20.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -105,13 +98,12 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; prof_resid("src1", group_counts=100)</LINE>
 	  <LINE>&pr; da = get_resid_prof(recalc=False)</LINE>
 	  <LINE>&pr; prof_resid("src2", rlo=da.xlo, rhi=da.xhi, overplot=True)</LINE>
-          <LINE>&pr; set_histogram(["symbol.color", "orange"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    A profile is calculated and displayed for the dataset "src1". The bin
 	    edges from this are then used to create a profile for the dataset "src2",
-	    which is overlain on the first plot using orange symbols.
+	    which is overlain on the first plot.
 	    Note that recalc is set to False
 	    in the call to get_resid_prof() to avoid unnescessary re-calculations.
 	  </PARA>
@@ -128,6 +120,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_resid_prof_prefs.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_resid_prof_prefs.xml
@@ -45,7 +45,10 @@ from sherpa_contrib.profiles import *
 
       <PARA title="Plot defaults">
 	The following table lists the allowed keys and values for
-	the object returned by get_resid_prof_prefs().
+	the object returned by get_resid_prof_prefs(), for when
+	the ChIPS backend is in use. The values returned
+	when Matplolib is used are similar in spirit, but use
+	the Matplotlib naming.
       </PARA>
 
       <TABLE>
@@ -101,6 +104,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_source_prof.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_source_prof.xml
@@ -82,18 +82,11 @@ from sherpa_contrib.profiles import *
 	<SYNTAX>
           <LINE>&pr; d10 = get_source_prof(group_snr=10)</LINE>
           <LINE>&pr; d20 = get_source_prof(group_snr=20)</LINE>
-          <LINE>&pr; erase()</LINE>
-          <LINE>&pr; add_histogram(d10.xlo, d10.xhi, d10.y)</LINE>
-          <LINE>&pr; add_histogram(d20.xlo, d20.xhi, d20.y, ["line.color", "red"])</LINE>
-          <LINE>&pr; set_plot_xlabel(d10.xlabel)</LINE>
-          <LINE>&pr; set_plot_ylabel(d10.ylabel)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Two profiles of the same model are calculated; d10 uses a signal-to-noise
-	    ratio of 10 and d20 a value of 20. The return values are then used to plot
-	    up the profiles using ChIPS commands to compare the plots (the d20 results
-	    are shown in green).
+	    ratio of 10 and d20 a value of 20.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -104,13 +97,12 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; prof_source("src1", group_counts=100)</LINE>
 	  <LINE>&pr; da = get_source_prof(recalc=False)</LINE>
 	  <LINE>&pr; prof_source("src2", rlo=da.xlo, rhi=da.xhi, overplot=True)</LINE>
-          <LINE>&pr; set_histogram(["symbol.color", "orange"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    A profile is calculated and displayed for the dataset "src1". The bin
 	    edges from this are then used to create a profile for the dataset "src2",
-	    which is overlain on the first plot using orange symbols.
+	    which is overlain on the first plot.
 	    Note that recalc is set to False
 	    in the call to get_source_prof() to avoid unnescessary re-calculations.
 	  </PARA>
@@ -127,6 +119,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_source_prof_prefs.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_source_prof_prefs.xml
@@ -43,7 +43,10 @@ from sherpa_contrib.profiles import *
 
       <PARA title="Plot defaults">
 	The following table lists the allowed keys and values for
-	the object returned by get_source_prof_prefs().
+	the object returned by get_source_prof_prefs(), for when
+	the ChIPS backend is in use. The values returned
+	when Matplolib is used are similar in spirit, but use
+	the Matplotlib naming.
       </PARA>
 
       <TABLE>
@@ -92,6 +95,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_data.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_data.xml
@@ -16,7 +16,7 @@
       rstep=None, rmin=None, rmax=None, rlo=None, rhi=None,
       xpos=None, ypos=None, ellip=None, theta=None,
       group_counts=None, group_snr=None,
-      label=True, recalc=True, overplot=False] )</LINE>
+      label=True, recalc=True, overplot=False, clearwindow=True] )</LINE>
     </SYNTAX>
 
     <DESC>
@@ -264,10 +264,15 @@ from sherpa_contrib.profiles import *
         </ITEM>
 
         <ITEM>
-          overplot  - should the new plot be overlaid in the plotting window?
+          overplot - should the new plot be overlaid in the plotting window?
 	  A value of False
 	  (default) means clear the window, and True
 	  means add the new data to any existing plots.
+	</ITEM>
+
+        <ITEM>
+          clearwindow - should the plot area be cleared before creating the
+	  plot? This is only used if overplot is False.
 	</ITEM>
 
       </LIST>
@@ -291,21 +296,6 @@ from sherpa_contrib.profiles import *
 	bin - used when group_snr is given - is therefore calculated as
 	<EQUATION>N / (1 + sqrt(N+0.75))</EQUATION>
 	(there is no support for including a background level).
-      </PARA>
-
-      <PARA title="Modifying existing plots">
-        The plot is displayed in a ChIPS plotting window. If there is
-        no plotting window open, one is created.  If a plotting window
-        exists, the overplot parameter value determines whether the
-        new plot is overlaid on any existing plots in the window or if
-        the window is cleared before the plot is drawn.  
-      </PARA>
-
-      <PARA>
-        ChIPS commands may be used within Sherpa to modify plot
-        characteristics and create hardcopies; refer to the
-	<HREF link="http://cxc.harvard.edu/chips/">ChIPS website</HREF> for
-        information. 
       </PARA>
 
       <PARA title="Changing the plot defaults">
@@ -336,7 +326,6 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; set_coord("physical")</LINE>
           <LINE>&pr; set_source(beta2d.src + const2d.bgnd)</LINE>
           <LINE>&pr; prof_data()</LINE>
-          <LINE>&pr; log_scale()</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
@@ -345,8 +334,6 @@ from sherpa_contrib.profiles import *
 	    and height of 2 units due to the use of 'bin sky=2'), set a source
 	    model consisting of a beta2d component (src) and a constant (bgnd).
 	    The use the prof_data call creates a plot a profile of the data.
-	    The X and Y axes of the plot are then changed to use logarithmic
-	    scaling.
 	  </PARA>
 	  <PARA>
 	    Since no arguments were given to prof_data, the profile covers
@@ -376,8 +363,8 @@ from sherpa_contrib.profiles import *
 	  <PARA>
 	    The preferences are set so that both the x and y axes should be drawn
 	    using log scaling. Setting the get_data_prof_prefs values only
-	    affects plots made after the change; to change an existing plot
-	    you need to use ChIPS commands such as log_scale() and linear_scale().
+	    affects new plots (i.e. those made after the setting was
+	    changed).
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -454,13 +441,11 @@ from sherpa_contrib.profiles import *
         <SYNTAX>
 	  <LINE>&pr; prof_data("src1")</LINE>
 	  <LINE>&pr; prof_data("src2", overplot=True)</LINE>
-	  <LINE>&pr; set_histogram(["symbol.color", "red"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    Plots the profile for the dataset called "src1" and then overplots the 
-	    profile from the dataset "src2" (the second data set is changed to use a
-	    red symbol).
+	    profile from the dataset "src2".
 	  </PARA>
         </DESC>
       </QEXAMPLE>
@@ -544,6 +529,14 @@ from sherpa_contrib.profiles import *
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The radial-profile plots will now be created in Matplotlib
+	if the plot_pkg setting of your ~/.sherpa.rc file is set
+	to pylab.
+      </PARA>
+    </ADESC>
+
     <ADESC title="CHANGES IN THE DECEMBER 2010 RELEASE">
       <PARA title="Support for set_full_model">
 	The routines in the module have been updated to support source
@@ -564,6 +557,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_delchi.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_delchi.xml
@@ -16,7 +16,7 @@
       rstep=None, rmin=None, rmax=None, rlo=None, rhi=None,
       xpos=None, ypos=None, ellip=None, theta=None,
       group_counts=None, group_snr=None,
-      label=True, recalc=True, overplot=False] )</LINE>
+      label=True, recalc=True, overplot=False, clearwindow=True] )</LINE>
     </SYNTAX>
 
     <DESC>
@@ -81,7 +81,6 @@ from sherpa_contrib.profiles import *
       <QEXAMPLE>
 	<SYNTAX>
           <LINE>&pr; prof_delchi()</LINE>
-          <LINE>&pr; log_scale(X_AXIS)</LINE>
           <LINE>...</LINE>
           <LINE>&pr; prefs = get_delchi_prof_prefs()</LINE>
           <LINE>&pr; prefs["xlog"] = True</LINE>
@@ -91,8 +90,7 @@ from sherpa_contrib.profiles import *
 	  <PARA>
 	    The preferences are set so that the x axis should be drawn
 	    using log scaling. Setting the get_delchi_prof_prefs values only
-	    affects plots made after the change; to change an existing plot
-	    you need to use ChIPS commands such as log_scale() and linear_scale().
+	    affects new plots made after the setting was changed.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -132,6 +130,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_fit.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_fit.xml
@@ -16,7 +16,7 @@
       rstep=None, rmin=None, rmax=None, rlo=None, rhi=None,
       xpos=None, ypos=None, ellip=None, theta=None,
       group_counts=None, group_snr=None,
-      label=True, recalc=True, overplot=False] )</LINE>
+      label=True, recalc=True, overplot=False, clearwindow=True] )</LINE>
     </SYNTAX>
 
     <DESC>
@@ -69,7 +69,6 @@ from sherpa_contrib.profiles import *
       <QEXAMPLE>
 	<SYNTAX>
           <LINE>&pr; prof_fit()</LINE>
-          <LINE>&pr; log_scale()</LINE>
           <LINE>...</LINE>
           <LINE>&pr; prefs = get_data_prof_prefs()</LINE>
           <LINE>&pr; prefs["xlog"] = True</LINE>
@@ -80,8 +79,7 @@ from sherpa_contrib.profiles import *
 	  <PARA>
 	    The preferences are set so that both the x and y axes should be drawn
 	    using log scaling. Setting the get_data_prof_prefs values only
-	    affects plots made after the change; to change an existing plot
-	    you need to use ChIPS commands such as log_scale() and linear_scale().
+	    affects new plots made after the setting was changed.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -157,13 +155,11 @@ from sherpa_contrib.profiles import *
         <SYNTAX>
 	  <LINE>&pr; prof_fit("src1")</LINE>
 	  <LINE>&pr; prof_fit("src2", overplot=True)</LINE>
-	  <LINE>&pr; set_histogram(["line.color", "green"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    Plots the fit profiles (data and model) for the dataset called "src1" and then overplots the 
 	    results from dataset "src2".
-	    The model for the src2 dataset is changed to use a green line.
 	  </PARA>
         </DESC>
       </QEXAMPLE>
@@ -214,6 +210,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_fit_delchi.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_fit_delchi.xml
@@ -81,41 +81,15 @@ from sherpa_contrib.profiles import *
       <QEXAMPLE>
 	<SYNTAX>
           <LINE>&pr; prof_fit_delchi()</LINE>
-          <LINE>&pr; log_scale(X_AXIS)</LINE>
-          <LINE>&pr; current_plot("plot1")</LINE>
-          <LINE>&pr; log_scale(Y_AXIS)</LINE>
-          <LINE>...</LINE>
           <LINE>&pr; get_data_prof_prefs()["ylog"] = True</LINE>
           <LINE>&pr; get_delchi_prof_prefs()["xlog"] = True</LINE>
           <LINE>&pr; prof_fit_delchi()</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    Since the command creates two plots, we first change the X-axis to use
-	    a log scale; since the two plots share a common X axis both get changed.
-	    Then we use the ChIPS command current_plot to change to the
-	    first plot and draw its Y axis using a log scale. The ChIPS info()
-	    and info_current() commands can be used to find out what plot objects
-	    have been created and which are current.
-	  </PARA>
-	  <PARA>
-	    We then change the preference settings so that future plots created
-	    by prof_fit_delchi() are drawn in the same manner. 
-	  </PARA>
-	</DESC>
-      </QEXAMPLE>
-
-      <QEXAMPLE>
-	<SYNTAX>
-          <LINE>&pr; prof_fit_delchi()</LINE>
-          <LINE>&pr; adjust_grid_yrelsize(1, 1.5)</LINE>
-          <LINE>&pr; adjust_grid_ygap(0.05)</LINE>
-	</SYNTAX>
-	<DESC>
-	  <PARA>
-	    After creating the two plots we use ChIPS command to change the relative sizes
-	    (so that the first plot is 50 percent bigger than the second plot)
-	    and to add a small vertical gap between the plots.
+	    The plots are created, first with the default settings 
+	    and then after setting the the Y and X axes to log
+	    scaling.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -187,6 +161,7 @@ from sherpa_contrib.profiles import *
 	</DESC>
       </QEXAMPLE>
 
+<!--
       <QEXAMPLE>
         <SYNTAX>
 	  <LINE>&pr; prof_fit_delchi("src1")</LINE>
@@ -213,6 +188,7 @@ from sherpa_contrib.profiles import *
 	  </PARA>
         </DESC>
       </QEXAMPLE>
+-->
 
       <QEXAMPLE>
         <SYNTAX>
@@ -260,6 +236,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_fit_resid.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_fit_resid.xml
@@ -81,41 +81,15 @@ from sherpa_contrib.profiles import *
       <QEXAMPLE>
 	<SYNTAX>
           <LINE>&pr; prof_fit_resid()</LINE>
-          <LINE>&pr; log_scale(X_AXIS)</LINE>
-          <LINE>&pr; current_plot("plot1")</LINE>
-          <LINE>&pr; log_scale(Y_AXIS)</LINE>
-          <LINE>...</LINE>
           <LINE>&pr; get_data_prof_prefs()["ylog"] = True</LINE>
           <LINE>&pr; get_resid_prof_prefs()["xlog"] = True</LINE>
           <LINE>&pr; prof_fit_resid()</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    Since the command creates two plots, we first change the X-axis to use
-	    a log scale; since the two plots share a common X axis both get changed.
-	    Then we use the ChIPS command current_plot to change to the
-	    first plot and draw its Y axis using a log scale. The ChIPS info()
-	    and info_current() commands can be used to find out what plot objects
-	    have been created and which are current.
-	  </PARA>
-	  <PARA>
-	    We then change the preference settings so that future plots created
-	    by prof_fit_resid() are drawn in the same manner. 
-	  </PARA>
-	</DESC>
-      </QEXAMPLE>
-
-      <QEXAMPLE>
-	<SYNTAX>
-          <LINE>&pr; prof_fit_resid()</LINE>
-          <LINE>&pr; adjust_grid_yrelsize(1, 1.5)</LINE>
-          <LINE>&pr; adjust_grid_ygap(0.05)</LINE>
-	</SYNTAX>
-	<DESC>
-	  <PARA>
-	    After creating the two plots we use ChIPS command to change the relative sizes
-	    (so that the first plot is 50 percent bigger than the second plot)
-	    and to add a small vertical gap between the plots.
+	    The plots are created, first with the default settings 
+	    and then after setting the the Y and X axes to log
+	    scaling.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -187,6 +161,7 @@ from sherpa_contrib.profiles import *
 	</DESC>
       </QEXAMPLE>
 
+<!--
       <QEXAMPLE>
         <SYNTAX>
 	  <LINE>&pr; prof_fit_resid("src1")</LINE>
@@ -213,6 +188,7 @@ from sherpa_contrib.profiles import *
 	  </PARA>
         </DESC>
       </QEXAMPLE>
+-->
 
       <QEXAMPLE>
         <SYNTAX>
@@ -260,6 +236,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_model.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_model.xml
@@ -16,7 +16,7 @@
       rstep=None, rmin=None, rmax=None, rlo=None, rhi=None,
       xpos=None, ypos=None, ellip=None, theta=None,
       group_counts=None, group_snr=None,
-      label=True, recalc=True, overplot=False] )</LINE>
+      label=True, recalc=True, overplot=False, clearwindow=True] )</LINE>
     </SYNTAX>
 
     <DESC>
@@ -77,7 +77,6 @@ from sherpa_contrib.profiles import *
       <QEXAMPLE>
 	<SYNTAX>
           <LINE>&pr; prof_model()</LINE>
-          <LINE>&pr; log_scale()</LINE>
           <LINE>...</LINE>
           <LINE>&pr; prefs = get_model_prof_prefs()</LINE>
           <LINE>&pr; prefs["xlog"] = True</LINE>
@@ -88,8 +87,7 @@ from sherpa_contrib.profiles import *
 	  <PARA>
 	    The preferences are set so that both the x and y axes should be drawn
 	    using log scaling. Setting the get_model_prof_prefs values only
-	    affects plots made after the change; to change an existing plot
-	    you need to use ChIPS commands such as log_scale() and linear_scale().
+	    affects new plots made after the setting was changed.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -112,13 +110,11 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; prof_data()</LINE>
 	  <LINE>&pr; prof_source(overplot=True)</LINE>
 	  <LINE>&pr; prof_model(overplot=True)</LINE>
-	  <LINE>&pr; set_histogram(["line.color", "blue"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    Plots the profile for the data and then overplots the model profile,
-	    for the source and measured profiles (the later is changed to be
-	    drawn with a blue line).
+	    for the source and measured profiles.
 	  </PARA>
         </DESC>
       </QEXAMPLE>
@@ -133,6 +129,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_resid.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_resid.xml
@@ -16,7 +16,7 @@
       rstep=None, rmin=None, rmax=None, rlo=None, rhi=None,
       xpos=None, ypos=None, ellip=None, theta=None,
       group_counts=None, group_snr=None,
-      label=True, recalc=True, overplot=False] )</LINE>
+      label=True, recalc=True, overplot=False, clearwindow=True] )</LINE>
     </SYNTAX>
 
     <DESC>
@@ -73,7 +73,6 @@ from sherpa_contrib.profiles import *
       <QEXAMPLE>
 	<SYNTAX>
           <LINE>&pr; prof_resid()</LINE>
-          <LINE>&pr; log_scale(X_AXIS)</LINE>
           <LINE>...</LINE>
           <LINE>&pr; prefs = get_resid_prof_prefs()</LINE>
           <LINE>&pr; prefs["xlog"] = True</LINE>
@@ -83,8 +82,7 @@ from sherpa_contrib.profiles import *
 	  <PARA>
 	    The preferences are set so that the x axis should be drawn
 	    using log scaling. Setting the get_resid_prof_prefs values only
-	    affects plots made after the change; to change an existing plot
-	    you need to use ChIPS commands such as log_scale() and linear_scale().
+	    affects new plots made after the setting was changed.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -124,6 +122,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/prof_source.xml
+++ b/ciao-4.11/contrib/share/doc/xml/prof_source.xml
@@ -16,7 +16,7 @@
       rstep=None, rmin=None, rmax=None, rlo=None, rhi=None,
       xpos=None, ypos=None, ellip=None, theta=None,
       group_counts=None, group_snr=None,
-      label=True, recalc=True, overplot=False] )</LINE>
+      label=True, recalc=True, overplot=False, clearwindow=True] )</LINE>
     </SYNTAX>
 
     <DESC>
@@ -77,7 +77,6 @@ from sherpa_contrib.profiles import *
       <QEXAMPLE>
 	<SYNTAX>
           <LINE>&pr; prof_source()</LINE>
-          <LINE>&pr; log_scale()</LINE>
           <LINE>...</LINE>
           <LINE>&pr; prefs = get_source_prof_prefs()</LINE>
           <LINE>&pr; prefs["xlog"] = True</LINE>
@@ -88,8 +87,7 @@ from sherpa_contrib.profiles import *
 	  <PARA>
 	    The preferences are set so that both the x and y axes should be drawn
 	    using log scaling. Setting the get_source_prof_prefs values only
-	    affects plots made after the change; to change an existing plot
-	    you need to use ChIPS commands such as log_scale() and linear_scale().
+	    affects new plots made after the setting was changed.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -112,13 +110,11 @@ from sherpa_contrib.profiles import *
 	  <LINE>&pr; prof_data()</LINE>
 	  <LINE>&pr; prof_source(overplot=True)</LINE>
 	  <LINE>&pr; prof_model(overplot=True)</LINE>
-	  <LINE>&pr; set_histogram(["line.color","blue"])</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    Plots the profile for the data and then overplots the model profile,
-	    for the source and measured profiles (the later is changed to be
-	    drawn with a blue line).
+	    for the source and measured profiles.
 	  </PARA>
         </DESC>
       </QEXAMPLE>
@@ -133,6 +129,6 @@ from sherpa_contrib.profiles import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2009</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_contrib.xml
@@ -91,6 +91,20 @@ import sherpa_contrib.all
 	routines has been removed, so the plots may look slightly
 	different.
       </PARA>
+      <PARA>
+	The plots created by the sherpa_contrib.profiles set of functions,
+	such as prof_data() and prof_fit_resid(), also now use the
+	Sherpa plot backend.
+      </PARA>
+      <PARA>
+	To use Matplotlib, you should have:
+      </PARA>
+      <PARA>
+	<SYNTAX>
+	  <LINE>unix% grep plot_pkg ~/.sherpa.rc</LINE>
+	  <LINE>plot_pkg : pylab</LINE>
+	</SYNTAX>
+      </PARA>
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">

--- a/ciao-4.11/contrib/share/doc/xml/sherpa_profiles.xml
+++ b/ciao-4.11/contrib/share/doc/xml/sherpa_profiles.xml
@@ -77,7 +77,7 @@ from sherpa_contrib.all import *
 	</ROW>
         <ROW>
 	  <DATA>prof_delchi()</DATA>
-	  <DATA>Plot a profile of the residuals (unots of sigma).</DATA>
+	  <DATA>Plot a profile of the residuals (units of sigma).</DATA>
 	</ROW>
       </TABLE>
 
@@ -147,6 +147,14 @@ from sherpa_contrib.all import *
 
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
+      <PARA title="Plotting can now use matplotlib">
+	The radial-profile plots will now be created in Matplotlib
+	if the plot_pkg setting of your ~/.sherpa.rc file is set
+	to pylab.
+      </PARA>
+    </ADESC>
+
     <ADESC title="CHANGES IN THE DECEMBER 2010 RELEASE">
       <PARA title="Support for set_full_model">
 	The routines in the module have been updated to support source
@@ -167,6 +175,6 @@ from sherpa_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Surprisingly enough (ie I don't remember doing this) most of the code should actually already support matplotlib. It's the extra annotation (labelling and lines) that needs work, as well as sorting out the preference settings.

 - [x] generic support for labels
 - [x] generic support for "lines" (e.g. y=0)
 - [ ] update docstrings (maybe)
 - [x] update ahelp
 - [x] add changelog
 - [x] test