### PR TITLE
Cleanup chips influences in the lightcurve code

### DIFF
--- a/ciao-4.11/contrib/bin/deflare
+++ b/ciao-4.11/contrib/bin/deflare
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 #
-#  Copyright (C) 2014, 2015, 2016, 2017, 2018, 2019  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2014, 2015, 2016, 2017, 2018, 2019
+#                Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -35,9 +36,6 @@ ciao% deflare method=clean infile=lc.fits outfile=gti.fits
 
 """
 
-toolname = "deflare"
-__revision__ = "31 January 2019"
-
 import os
 import sys
 
@@ -45,8 +43,6 @@ import paramio
 
 import matplotlib
 matplotlib.interactive(True)
-
-import six
 
 # This is only needed for development.
 try:
@@ -69,8 +65,13 @@ except KeyError:
 
 from lightcurves import lc_clean, lc_sigma_clip, lc_sigma_uclip
 
-from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
+from ciao_contrib.logger_wrapper import initialize_logger, \
+    make_verbose_level, set_verbosity, handle_ciao_errors
 from ciao_contrib.param_wrapper import open_param_file
+
+
+toolname = "deflare"
+__revision__ = "11 June 2019"
 
 initialize_logger(toolname)
 
@@ -86,17 +87,17 @@ def get_par(args):
     # Common parameters:
     params = {}
 
-    params["infile"]   = paramio.pgetstr(pfile, "infile")
-    params["outfile"]  = paramio.pgetstr(pfile, "outfile")
-    params["method"]   = paramio.pgetstr(pfile, "method")
-    params["nsigma"]   = paramio.pgetd(pfile, "nsigma")
-    plot_stat = params["plot"]     = paramio.pgetb(pfile, "plot") == 1
-    params["save"]     = paramio.pgetstr(pfile, "save")
+    params["infile"] = paramio.pgetstr(pfile, "infile")
+    params["outfile"] = paramio.pgetstr(pfile, "outfile")
+    params["method"] = paramio.pgetstr(pfile, "method")
+    params["nsigma"] = paramio.pgetd(pfile, "nsigma")
+    plot_stat = params["plot"] = paramio.pgetb(pfile, "plot") == 1
+    params["save"] = paramio.pgetstr(pfile, "save")
     params["rateaxis"] = paramio.pgetstr(pfile, "rateaxis")
-    params["pattern"]       = paramio.pgetstr(pfile, "pattern")
-    params["good_color"]    = paramio.pgetstr(pfile, "good_color")
+    params["pattern"] = paramio.pgetstr(pfile, "pattern")
+    params["good_color"] = paramio.pgetstr(pfile, "good_color")
     params["exclude_color"] = paramio.pgetstr(pfile, "exclude_color")
-    params["verbose"]       = paramio.pgeti(pfile, "verbose")
+    params["verbose"] = paramio.pgeti(pfile, "verbose")
 
     if params["save"].strip() == "":
         params["save"] = None
@@ -121,9 +122,9 @@ def get_par(args):
 
     elif params["method"] == 'clean':
         # lc_clean parameters:
-        params["mean"]    = paramio.pgetd(pfile, "mean")
-        params["stddev"]  = paramio.pgetd(pfile, "stddev")
-        params["scale"]   = paramio.pgetd(pfile, "scale")
+        params["mean"] = paramio.pgetd(pfile, "mean")
+        params["stddev"] = paramio.pgetd(pfile, "stddev")
+        params["scale"] = paramio.pgetd(pfile, "scale")
         params["minfrac"] = paramio.pgetd(pfile, "minfrac")
 
     else:
@@ -132,14 +133,14 @@ def get_par(args):
         raise ValueError("Invalid method parameter: expected clean,sigma,usigma sent '{0}'".format(params["method"]))
 
     paramio.paramclose(pfile)
-    return params,plot_stat
+    return params, plot_stat
 
 
 def pause():
-    six.moves.input("Press ENTER to close the plot window and exit:")
+    input("Press ENTER to close the plot window and exit:")
 
 
-def wrapup(params,plot_stat):
+def wrapup(params, plot_stat):
     "Let the user know what has happened."
 
     labels = {"clean": "lc_clean", "sigma": "lc_sigma_clip",
@@ -168,7 +169,7 @@ def wrapup(params,plot_stat):
 #        if not oplot.endswith(".pdf"):
 #            oplot += ".pdf"
 
-        plt.savefig(oplot,format=format,frameon=True)
+        plt.savefig(oplot, format=format, frameon=True)
 
         v1("Created: {0}".format(oplot))
 
@@ -183,7 +184,7 @@ def wrapup(params,plot_stat):
 def deflare(arglist):
     "Do the work"
 
-    params,plot_stat = get_par(arglist)
+    params, plot_stat = get_par(arglist)
     set_verbosity(params["verbose"])
 
     # Set up the common arguments
@@ -210,9 +211,9 @@ def deflare(arglist):
         else:
             meanc = None
 
-        kwargs["mean"]  = meanc
+        kwargs["mean"] = meanc
         kwargs["sigma"] = sigmac
-        kwargs["clip"]  = params["nsigma"]
+        kwargs["clip"] = params["nsigma"]
         kwargs["scale"] = params["scale"]
         kwargs["minfrac"] = params["minfrac"]
         func = lc_clean
@@ -228,13 +229,13 @@ def deflare(arglist):
     # if plot_stat:
     #     matplotlib.use("TkAgg")
     #     matplotlib.interactive(True)
-        
+
     # else:
     #     matplotlib.use("PS")
     #     matplotlib.interactive(True)
 
     func(*args, **kwargs)
-    wrapup(params,plot_stat)
+    wrapup(params, plot_stat)
 
 
 if __name__ == "__main__":

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
@@ -42,35 +42,22 @@ import numpy as np
 
 import pycrates as pcr
 
+from itertools import groupby
+from operator import itemgetter
+
+from ciao_contrib.runtool import dmcopy, dmgti
+
 import matplotlib
 matplotlib.interactive(True)
 matplotlib.rcParams["toolbar"] = "None"
 
 import matplotlib.pyplot as plt
 
-from itertools import groupby
-from operator import itemgetter
-
-from ciao_contrib.runtool import dmcopy, dmgti
-
 # NOTE: the lc_sigma_uclip algorithm is not ready for release
 # __all__ = ("lc_sigma_clip", "lc_sigma_uclip", "lc_clean")
 __all__ = ("lc_sigma_clip", "lc_clean")
 
 __revision = "June 2019"
-
-
-def _protect_label(label):
-    """Return a string that can be displayed.
-    At present all that is done is to protect underscore
-    characters (i.e. so that they do not signify a sub-script)."""
-
-    if label is None:
-        rval = label
-    else:
-        rval = label.replace("_", "\\_")
-
-    return rval
 
 
 def _write_gti_text(outfile, tstart, tend):
@@ -292,14 +279,16 @@ class LightCurve:
 
     def add_label(self, crate, name, protect=True):
         """If there is a keyword of the given name in the crate, add
-        it to the store. If protect is True then ensure the value is
-        'protected' for display by ChIPS."""
+        it to the store.
 
-        if pcr.key_exists(crate, name):
-            val = pcr.get_keyval(crate, name)
-            if protect:
-                val = _protect_label(val)
-            self.labels[name] = val
+        The protect argument is now ignored.
+        """
+
+        val = pcr.get_keyval(crate, name)
+        if val is None:
+            return
+
+        self.labels[name] = val
 
     def time_to_offset(self, t):
         """Convert the time(s) in t, assumed to be in seconds, to an
@@ -644,7 +633,7 @@ class LightCurve:
             if any(bti):
                 # find consecutive indices
                 # - first group up consecutive value
-                dx2a = xhi2a-xlo2a  # get binsize
+                dx2a = xhi2a - xlo2a  # get binsize
                 x2a_test = [round(n) for n in xhi2a / dx2a]
                 # integer of the bin for grouping ID
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
@@ -36,10 +36,7 @@ Threads:
 
 """
 
-# import os
 import tempfile
-
-import six
 
 import numpy as np
 
@@ -103,7 +100,7 @@ def _write_gti_text(outfile, tstart, tend):
         tfile.write("{:<8s}= ".format(name))
 
         # following checks not ideal but sufficient for now
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             sfmt = '"{}"'
             svalue = value
         elif isinstance(value, bool):
@@ -112,7 +109,7 @@ def _write_gti_text(outfile, tstart, tend):
                 svalue = "T"
             else:
                 svalue = "F"
-        elif isinstance(value, six.integer_types):
+        elif isinstance(value, int):
             sfmt = "{:20d}"
             svalue = value
         else:

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
@@ -469,22 +469,26 @@ class LightCurve:
         plot items.
         """
 
-        plt.text(0.015,0.035,self.filename.split("/")[-1],
-                 fontsize=8,horizontalalignment="left",verticalalignment="top",
-                 transform=plt.gcf().transFigure)
-        plt.text(0.985,0.035,self.method,
-                 fontsize=8,horizontalalignment="right",verticalalignment="top",
-                 transform=plt.gcf().transFigure)
+        trans = plt.gcf().transFigure
+        plt.text(0.015, 0.035, self.filename.split("/")[-1],
+                 fontsize=8, horizontalalignment="left",
+                 verticalalignment="top",
+                 transform=trans)
+        plt.text(0.985, 0.035, self.method, fontsize=8,
+                 horizontalalignment="right", verticalalignment="top",
+                 transform=trans)
 
         if 'OBJECT' in self.labels:
-            plt.text(0.015,0.965,self.labels["OBJECT"],
-                     fontsize=8,horizontalalignment="left",verticalalignment="bottom",
-                     transform=plt.gcf().transFigure)
+            plt.text(0.015, 0.965, self.labels["OBJECT"],
+                     fontsize=8, horizontalalignment="left",
+                     verticalalignment="bottom",
+                     transform=trans)
 
         if 'OBS_ID' in self.labels:
-            plt.text(0.985,0.965,"obsid={}".format(self.labels["OBS_ID"]),
-                     fontsize=8,horizontalalignment="right",verticalalignment="bottom",
-                     transform=plt.gcf().transFigure)            
+            plt.text(0.985, 0.965, "obsid={}".format(self.labels["OBS_ID"]),
+                     fontsize=8, horizontalalignment="right",
+                     verticalalignment="bottom",
+                     transform=trans)
 
     def plot(self, rateaxis="y", gcol="lime", erase=True):
         """Plot up the light curves.
@@ -567,17 +571,18 @@ class LightCurve:
 
         # Set up the plot labels
         #
-        title = r"mean rate={0:g} {1}".format(self.clean_mean_rate,"$\mathrm{s}^{-1}$")
+        title = r"mean rate={0:g} {1}".format(self.clean_mean_rate,
+                                              r"$\mathrm{s}^{-1}$")
         ratelabel = r"Count Rate $\left[\mathrm{s}^{-1}\right]$"
 
-        ## Create the plot
+        # Create the plot
         #
         # setup figure
 
         if rateaxis == "y":
-            fig,axs = plt.subplots(2,1,tight_layout=True)
+            fig, axs = plt.subplots(2, 1, tight_layout=True)
         else:
-            fig,axs = plt.subplots(2,1,sharex=True)
+            fig, axs = plt.subplots(2, 1, sharex=True)
             fig.subplots_adjust(hspace=0)
 
         try:
@@ -588,10 +593,10 @@ class LightCurve:
 
             axs[0].minorticks_on()
             axs[1].minorticks_on()
-            axs[0].tick_params(axis="both",direction="in",which="both",
-                               bottom=True,top=True,left=True,right=True)
-            axs[1].tick_params(axis="both",direction="in",which="both",
-                               bottom=True,top=True,left=True,right=True)
+            axs[0].tick_params(axis="both", direction="in", which="both",
+                               bottom=True, top=True, left=True, right=True)
+            axs[1].tick_params(axis="both", direction="in", which="both",
+                               bottom=True, top=True, left=True, right=True)
 
             # plot 1: lightcurve
             #
@@ -599,7 +604,7 @@ class LightCurve:
             # exist, so that they are drawn behind the "good" points
             #
 
-            axs[0].set_title(title,fontsize=12)
+            axs[0].set_title(title, fontsize=12)
 
             plotopts = {"linestyle": "none", "fillstyle": "full"}
 
@@ -611,12 +616,12 @@ class LightCurve:
                     x = y1b
                     y = x1b
 
-                plotopts["gid"] = "bad" # id = "bad"
+                plotopts["gid"] = "bad"  # id = "bad"
                 plotopts["color"] = "blue"
-                plotopts["marker"] = "s" # symbol.style = "square"
-                plotopts["markersize"] = 3.5 # symbol.size = 2
+                plotopts["marker"] = "s"  # symbol.style = "square"
+                plotopts["markersize"] = 3.5  # symbol.size = 2
 
-                axs[0].plot(x,y,**plotopts)                
+                axs[0].plot(x, y, **plotopts)
 
             if rateaxis == "y":
                 x = x1g
@@ -625,88 +630,93 @@ class LightCurve:
                 x = y1g
                 y = x1g
 
-            plotopts["gid"] = "good" # id = "good"
-            plotopts["marker"] = "o" # symbol.style = "circle"
-            plotopts["markersize"] = 6 # symbol.size = 4
+            plotopts["gid"] = "good"  # id = "good"
+            plotopts["marker"] = "o"  # symbol.style = "circle"
+            plotopts["markersize"] = 6  # symbol.size = 4
             plotopts["color"] = gcol
-            
-            axs[0].plot(x,y,**plotopts)
+
+            axs[0].plot(x, y, **plotopts)
 
             if rateaxis == "y":
-                axs[0].axhline(y=self.clean_mean_rate,linestyle="dotted")
-                axs[0].set_ylabel(ratelabel,fontsize=10)
-                axs[0].set_xlabel(r"$\Delta$ Time [ks]",fontsize=10)
+                axs[0].axhline(y=self.clean_mean_rate, linestyle="dotted")
+                axs[0].set_ylabel(ratelabel, fontsize=10)
+                axs[0].set_xlabel(r"$\Delta$ Time [ks]", fontsize=10)
 
             else:
-                axs[0].axvline(x=self.clean_mean_rate,linestyle="dotted")
+                axs[0].axvline(x=self.clean_mean_rate, linestyle="dotted")
                 axs[0].tick_params(labelbottom=False)
-                axs[0].set_ylabel(r"$\Delta$ Time [ks]",fontsize=10)
-
+                axs[0].set_ylabel(r"$\Delta$ Time [ks]", fontsize=10)
 
             # plot 2: histogram
             #
             if any(bti):
-                ## find consecutive indices               
-                # first group up consecutive value
-                dx2a = xhi2a-xlo2a # get binsize
-                x2a_test = [round(n) for n in xhi2a/dx2a] # integer of the bin for grouping ID
-                
-                groups = [list(map(itemgetter(1),g)) for k,g in groupby(enumerate(x2a_test),lambda z:z[0]-z[1])]
+                # find consecutive indices
+                # - first group up consecutive value
+                dx2a = xhi2a-xlo2a  # get binsize
+                x2a_test = [round(n) for n in xhi2a / dx2a]
+                # integer of the bin for grouping ID
+
+                groups = [list(map(itemgetter(1), g))
+                          for k, g in groupby(enumerate(x2a_test),
+                                              lambda z: z[0] - z[1])]
 
                 grp_a_ind = []
 
                 # open list of indicies
                 for g in groups:
-                    if len(g) == 1:                       
+                    if len(g) == 1:
                         ind = x2a_test.index(g[0])
                         grp_a_ind.append(ind)
 
                     else:
                         ind_min = x2a_test.index(min(g))
                         ind_max = x2a_test.index(max(g))
-                        grp_a_ind.append((ind_min,ind_max))
+                        grp_a_ind.append((ind_min, ind_max))
 
                 for ind in grp_a_ind:
                     if type(ind) == int:
                         xa_lo = np.array([xlo2a[ind]])
                         xa_hi = np.array([xhi2a[ind]])
                         ya = np.array([y2a[ind]])
-                                                
+
                     else:
-                        xa_lo = np.array(xlo2a[min(ind):max(ind)+1])
-                        xa_hi = np.array(xhi2a[min(ind):max(ind)+1])
-                        ya = np.array(y2a[min(ind):max(ind)+1])
+                        xa_lo = np.array(xlo2a[min(ind):max(ind) + 1])
+                        xa_hi = np.array(xhi2a[min(ind):max(ind) + 1])
+                        ya = np.array(y2a[min(ind):max(ind) + 1])
 
-                    # 'concatenates' are to add line drop at histogram edges 
-                    xa = np.append(xa_lo,xa_hi[-1])
-                    xa = np.concatenate(([xa_lo[0]],xa))
-                    ya = np.append(ya,0)
-                    ya = np.concatenate(([0],ya))
-                    
+                    # 'concatenates' are to add line drop at histogram edges
+                    xa = np.append(xa_lo, xa_hi[-1])
+                    xa = np.concatenate(([xa_lo[0]], xa))
+                    ya = np.append(ya, 0)
+                    ya = np.concatenate(([0], ya))
+
                     # plot entire histogram as step function
-                    axs[1].step(x=xa,y=ya,where="post",label="everything",linewidth=1.25,color="blue")
+                    axs[1].step(x=xa, y=ya, where="post",
+                                label="everything", linewidth=1.25,
+                                color="blue")
 
+            # try to plot up histogram of good data points
+            # - find consecutive indices
+            # - first group up consecutive value
+            dx2g = xhi2g - xlo2g  # binsize
+            x2g_test = [round(n) for n in xhi2g / dx2g]
 
-            ### try to plot up histogram of good data points
-            ## find consecutive indices               
-            # first group up consecutive value
-            dx2g = xhi2g-xlo2g # binsize
-            x2g_test = [round(n) for n in xhi2g/dx2g]
-
-            groups = [list(map(itemgetter(1),g)) for k,g in groupby(enumerate(x2g_test),lambda z:z[0]-z[1])]
+            groups = [list(map(itemgetter(1), g))
+                      for k, g in groupby(enumerate(x2g_test),
+                                          lambda z: z[0] - z[1])]
 
             grp_g_ind = []
 
             # open list of indicies
             for g in groups:
-                if len(g) == 1:                       
+                if len(g) == 1:
                     ind = x2g_test.index(g[0])
                     grp_g_ind.append(ind)
 
                 else:
                     ind_min = x2g_test.index(min(g))
                     ind_max = x2g_test.index(max(g))
-                    grp_g_ind.append((ind_min,ind_max))
+                    grp_g_ind.append((ind_min, ind_max))
 
             for ind in grp_g_ind:
                 if type(ind) == int:
@@ -715,42 +725,43 @@ class LightCurve:
                     yg = np.array([y2g[ind]])
 
                 else:
-                    xg_lo = np.array(xlo2g[min(ind):max(ind)+1])
-                    xg_hi = np.array(xhi2g[min(ind):max(ind)+1])
-                    yg = np.array(y2g[min(ind):max(ind)+1])  
+                    xg_lo = np.array(xlo2g[min(ind):max(ind) + 1])
+                    xg_hi = np.array(xhi2g[min(ind):max(ind) + 1])
+                    yg = np.array(y2g[min(ind):max(ind) + 1])
 
-                # 'concatenates' are to add line drop at histogram edges 
-                xg = np.append(xg_lo,xg_hi[-1])
-                xg = np.concatenate(([xg_lo[0]],xg))
-                yg = np.append(yg,0)
-                yg = np.concatenate(([0],yg))
+                # 'concatenates' are to add line drop at histogram edges
+                xg = np.append(xg_lo, xg_hi[-1])
+                xg = np.concatenate(([xg_lo[0]], xg))
+                yg = np.append(yg, 0)
+                yg = np.concatenate(([0], yg))
 
                 # plot entire histogram as step function
-                axs[1].step(x=xg,y=yg,where="post",label="good",linewidth=1.25,color=gcol)
+                axs[1].step(x=xg, y=yg, where="post", label="good",
+                            linewidth=1.25, color=gcol)
 
-            axs[1].axvline(x=self.clean_mean_rate,linestyle="dotted")
+            axs[1].axvline(x=self.clean_mean_rate, linestyle="dotted")
 
             axs[1].set_xlim(auto=True)
-            axs[1].set_ylim(bottom=0,auto=True)
+            axs[1].set_ylim(bottom=0, auto=True)
 
             if rateaxis == "x":
                 y_minor_ticks = axs[1].yaxis.get_minorticklocs()
-                dytick = y_minor_ticks[1]-y_minor_ticks[0]
-                axs[1].set_ylim(bottom=0,top=y_minor_ticks[-1]+2.5*dytick)
+                dytick = y_minor_ticks[1] - y_minor_ticks[0]
+                axs[1].set_ylim(bottom=0, top=y_minor_ticks[-1] + 2.5 * dytick)
 
-            axs[1].set_ylabel("Number",fontsize=10)
-            axs[1].set_xlabel(ratelabel,fontsize=10)
+            axs[1].set_ylabel("Number", fontsize=10)
+            axs[1].set_xlabel(ratelabel, fontsize=10)
 
-        except:
+        except Exception:
             plt.close()
             raise
 
         return axs
 
-        
-    def plot_gti_limits(self, mplaxs, gtiname, rateaxis="y",pattern="crisscross", pcol="red"):
+    def plot_gti_limits(self, mplaxs, gtiname, rateaxis="y",
+                        pattern="crisscross", pcol="red"):
         "Plot up the GTI limits from the GTI block of gtiname on the rate plot"
-        
+
         if pattern == "none":
             return
 
@@ -766,23 +777,23 @@ class LightCurve:
             edges = []
 
             if rateaxis == "y":
-                start = np.append(startvals,xr[1])
-                end   = np.append(xr[0],stopvals)
+                start = np.append(startvals, xr[1])
+                end = np.append(xr[0], stopvals)
 
                 y_minor_ticks = mplaxs[0].yaxis.get_minorticklocs()
-                dytick = y_minor_ticks[1]-y_minor_ticks[0]
-                yrs = [yr[0],yr[1]+dytick]
+                dytick = y_minor_ticks[1] - y_minor_ticks[0]
+                yrs = [yr[0], yr[1] + dytick]
 
                 mplaxs[0].set_ylim(bottom=min(y_minor_ticks),
-                                   top=max(y_minor_ticks)+dytick)
+                                   top=max(y_minor_ticks) + dytick)
             else:
-                start = np.append(startvals,yr[1])
-                end   = np.append(yr[0],stopvals)
-                
+                start = np.append(startvals, yr[1])
+                end = np.append(yr[0], stopvals)
+
                 x_minor_ticks = mplaxs[0].xaxis.get_minorticklocs()
-                dxtick = x_minor_ticks[1]-x_minor_ticks[0]
-                xrs = [xr[0]-dxtick,xr[1]+dxtick]
-                
+                dxtick = x_minor_ticks[1] - x_minor_ticks[0]
+                xrs = [xr[0] - dxtick, xr[1] + dxtick]
+
                 mplaxs[0].set_xlim(left=min(x_minor_ticks),
                                    right=max(x_minor_ticks))
 
@@ -790,25 +801,25 @@ class LightCurve:
             zorder = max([line.get_zorder() for line in lines]) + 1
 
             for key in mplaxs[0].spines.keys():
-                mplaxs[0].spines[key].zorder = zorder+1
+                mplaxs[0].spines[key].zorder = zorder + 1
 
             ropts = {}
 
-#        The choices for this parameter are: nofill, solid, updiagonal, 
+#        The choices for this parameter are: nofill, solid, updiagonal,
 #        downdiagonal, horizontal, vertical, crisscross, grid, polkadot
-#       
+#
 #        No longer support: brick, zigzag, hexagon, wave
 
-            ropts["alpha"] = 0.85 # opacity = 0.85
+            ropts["alpha"] = 0.85
             ropts["facecolor"] = pcol
             ropts["zorder"] = zorder
 
             ropts["facecolor"] = "none"
-            ropts["edgecolor"] = pcol            
+            ropts["edgecolor"] = pcol
 
             if pattern.lower() == "solid":
                 ropts["hatch"] = "none"
-                ropts["facecolor"] = pcol           
+                ropts["facecolor"] = pcol
                 ropts["zorder"] = 0
 
             elif pattern.lower() == "nofill":
@@ -817,7 +828,7 @@ class LightCurve:
 
             elif pattern.lower() == "updiagonal":
                 ropts["hatch"] = "///"
-            
+
             elif pattern.lower() == "downdiagonal":
                 ropts["hatch"] = "\\\\\\"
 
@@ -837,42 +848,44 @@ class LightCurve:
                 ropts["hatch"] = "..."
 
             # add regions blocking the bad intervals
-            for s,e in zip(start,end): #zip(end,start):
+            for s, e in zip(start, end):
                 if rateaxis == "y":
                     if pattern.lower() == "nofill":
                         # edge's linestyle and linewidth need to precede all other options
-                        # to be recognized, due to bug in matplotlib >1.5.x; 
-                        # dictionary order is randomized.  From Python 3.6 onwards, 
+                        # to be recognized, due to bug in matplotlib >1.5.x;
+                        # dictionary order is randomized.  From Python 3.6 onwards,
                         # the standard dict type maintains insertion order by default.
-                        mplaxs[0].fill_betweenx(y=yrs,x1=s,x2=e,
-                                                linestyle="dashed",linewidth=1,**ropts)
+                        mplaxs[0].fill_betweenx(y=yrs, x1=s, x2=e,
+                                                linestyle="dashed",
+                                                linewidth=1, **ropts)
 
                     else:
                         ropts["linewidth"] = matplotlib.rcParams["hatch.linewidth"] = 0.25
 
-                        mplaxs[0].fill_betweenx(y=yrs,x1=s,x2=e,**ropts)
-                    
-                    edges.extend([s,e])
+                        mplaxs[0].fill_betweenx(y=yrs, x1=s, x2=e, **ropts)
+
+                    edges.extend([s, e])
 
                 else:
                     if pattern.lower() == "nofill":
-                        mplaxs[0].fill_between(x=xrs,y1=s,y2=e,
-                                                linestyle="dashed",linewidth=1,**ropts)
+                        mplaxs[0].fill_between(x=xrs, y1=s, y2=e,
+                                               linestyle="dashed",
+                                               linewidth=1, **ropts)
                     else:
                         ropts["linewidth"] = matplotlib.rcParams["hatch.linewidth"] = 0.25
 
-                        mplaxs[0].fill_between(x=xrs,y1=s,y2=e,**ropts)
+                        mplaxs[0].fill_between(x=xrs, y1=s, y2=e, **ropts)
 
-                    edges.extend([s,e])
+                    edges.extend([s, e])
 
             if rateaxis == "y":
-                mplaxs[0].set_xlim(left=min(edges),right=max(edges))
+                mplaxs[0].set_xlim(left=min(edges), right=max(edges))
             else:
-                mplaxs[0].set_ylim(bottom=min(edges),top=max(edges))
-                
-        except:
-            raise ValueError("Failed to highlight 'bad' time intervals in plotted lightcurve.")
+                mplaxs[0].set_ylim(bottom=min(edges), top=max(edges))
 
+        except Exception:
+            # Why do we need this again?
+            raise ValueError("Failed to highlight 'bad' time intervals in plotted lightcurve.")
 
     def create_gti_file(self, outfile):
         """Create a GTI file called outfile based on those time periods
@@ -972,7 +985,7 @@ class CleanLightCurve(LightCurve):
         ngood = self.clean_filter.sum()
         if ngood == 0:
             raise ValueError("Error: no bins match rate={:g} to {:g} (data range is {:g} to {:g})".format(self.clean_min_rate, self.clean_max_rate,
-                                                                                                             self.rate[self.filter].min(), self.rate.max()))
+                                                                                                          self.rate[self.filter].min(), self.rate.max()))
         if self.verbose:
             print("Number of good time bins = {}".format(ngood))
 
@@ -1233,7 +1246,6 @@ def lc_clean(filename, outfile=None, mean=None, clip=3.0, sigma=None,
                                    pattern=pattern, pcol=pcol)
             except ValueError:
                 pass
-
 
 
 def _lc_sigma_clip(obj, lbl, filename, outfile=None, sigma=3.0,

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
@@ -57,7 +57,7 @@ from ciao_contrib.runtool import dmcopy, dmgti
 # __all__ = ("lc_sigma_clip", "lc_sigma_uclip", "lc_clean")
 __all__ = ("lc_sigma_clip", "lc_clean")
 
-__revision = "February 2019"
+__revision = "June 2019"
 
 
 def _protect_label(label):
@@ -494,17 +494,12 @@ class LightCurve:
         the Y axis or X axis ("y" or "x" respectively). The gcol
         argument is the color to use to draw the "good" points.
 
-        If erase is True then erase will be called in the current
-        window before creating the plots, otherwise the current
-        frame will be used (only relevant if there is a current
-        frame). Note that we still add plot label/decorations
-        when erase is False, since it is only intended to allow
-        a plot to be created in an existing, but empty, Frame
-        rather than overplotted on a previous lc plot.
+        The erase argument is no-longer used.
         """
 
         if self.clean_gti is None:
             raise ValueError("calculate_filter() must be run before plot()")
+
         gti = self.clean_gti
         bti = self.clean_bti
 
@@ -1156,19 +1151,7 @@ def lc_clean(filename, outfile=None, mean=None, clip=3.0, sigma=None,
     points that are considered good by the iterative clipping (ignoring
     the minlength filter).
 
-    The erase setting is only important if a window exists and plot is
-    True. If erase is True then any frames in the existing window will
-    be removed (via the ChIPS erase call) before any plots are
-    created, otherwise the plots will either be added to the existing
-    frame. This is only intended to allow plots to be added to
-    multiple frames in a window - for example
-
-      lc_clean("lc.fits")
-      add_frame()
-      lc_clean("lc.hard.fits", erase=False)
-
-    and not to allow multiple lightcurves to be drawn in the same
-    plot.
+    The erase argument is no-longer used.
 
     If outfile is given and plot is True then the time intervals excluded
     by the calculated GTI file are drawn on the plot as filled regions,
@@ -1340,19 +1323,7 @@ def lc_sigma_clip(filename, outfile=None, sigma=3.0, minlength=3, plot=True,
     points that are considered good by the iterative clipping (ignoring
     the minlength filter).
 
-    The erase setting is only important if a window exists and plot is
-    True. If erase is True then any frames in the existing window will
-    be removed (via the ChIPS erase call) before any plots are
-    created, otherwise the plots will either be added to the existing
-    frame. This is only intended to allow plots to be added to
-    multiple frames in a window - for example
-
-      lc_sigma_clip("lc.fits")
-      add_frame()
-      lc_sigma_clip("lc.hard.fits", erase=False)
-
-    and not to allow multiple lightcurves to be drawn in the same
-    plot.
+    The erase argument is no-longer used.
 
     If outfile is given and plot is True then the time intervals excluded
     by the calculated GTI file are drawn on the plot as filled regions,
@@ -1405,19 +1376,7 @@ def lc_sigma_uclip(filename, outfile=None, sigma=3.0, minlength=3, plot=True,
     points that are considered good by the iterative clipping (ignoring
     the minlength filter).
 
-    The erase setting is only important if a window exists and plot is
-    True. If erase is True then any frames in the existing window will
-    be removed (via the ChIPS erase call) before any plots are
-    created, otherwise the plots will either be added to the existing
-    frame. This is only intended to allow plots to be added to
-    multiple frames in a window - for example
-
-      lc_sigma_uclip("lc.fits")
-      add_frame()
-      lc_sigma_uclip("lc.hard.fits", erase=False)
-
-    and not to allow multiple lightcurves to be drawn in the same
-    plot.
+    The erase argument is no-longer used.
 
     If outfile is given and plot is True then the time intervals excluded
     by the calculated GTI file are drawn on the plot as filled regions,

--- a/ciao-4.11/contrib/share/doc/xml/lc_clean.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lc_clean.xml
@@ -337,6 +337,13 @@ unix% dmcopy "evt2.fits[@clean.gti]" evt2_filt.fits
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the 4.11.4 (2019) release">
+      <PARA>
+	Labels with underscores in them are now properly displayed
+	by Matplotlib.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the 4.11.2 (April 2019) release">
       <PARA title="Switch to Matplotlib">
 	The plots are now created with Matplotlib rather than ChIPS.

--- a/ciao-4.11/contrib/share/doc/xml/lc_clean.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lc_clean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
- <!ENTITY pr "chips>">
+ <!ENTITY pr ">>>">
 ]>
 <cxchelptopics>
   <ENTRY key="lc_clean" context="contrib"
@@ -35,7 +35,7 @@
 
       <PARA title="Loading the routine">
         The routine can be loaded into a Python
-	interpreter - such as chips, sherpa, or ipython
+	interpreter - such as Sherpa or ipython
 	- by saying:
       </PARA>
 
@@ -85,10 +85,11 @@ from lightcurves import *
 	  <DATA>solid</DATA>
 	  <DATA>
 	    If a GTI file is created as well as a plot, then we indicate the
-	    excluded times using regions filled with this pattern. Valid values
-	    are the same as those for region and histograms - see the "Fill Patterns"
-	    section of "ahelp chipsopt".
-	    A value of "none" means no regions will be drawn.
+	    excluded times using regions filled with this pattern. A value
+	    of "none" means that the excluded regions will not be
+	    shown, otherwise it should be one of:
+	    solid, nofill, updiagonal, downdiagonal, horizontal,
+	    vertical, crisscross, grid, or polkadot.
 	  </DATA>
 	</ROW>
 	<ROW>
@@ -226,17 +227,17 @@ unix% dmcopy "evt2.fits[@evt.gti]" evt2_filt.fits
 	    printed to the screen.
 	  </PARA>
 	  <PARA>
-	    The plot can be printed using the ChIPS print_window command,
-	    for example
+	    The plot can be printed using the Matplotlib
+	    savefig command: for example
 	  </PARA>
 	  <PARA>
 	    <SYNTAX>
-	      <LINE>&pr; print_window("bg.lc.ps", ["fittopage", True, "orientation", "landscape"])</LINE>
+	      <LINE>&pr; import matplotlib.pyplot as plt</LINE>
+	      <LINE>&pr; plt.savefig("bg.lc.ps")</LINE>
 	    </SYNTAX>
 	  </PARA>
 	  <PARA>
-	    will create a postscript plot which is drawn
-	    in landscape format and fills the page.
+	    will create a postscript plot.
 	  </PARA>
 	</DESC>
 
@@ -254,7 +255,7 @@ unix% dmcopy "evt2.fits[@evt.gti]" evt2_filt.fits
 	    a GTI file (clip.gti)
 	    that represents the "good" times calculated by the algorithm.
 	    After writing out the file the filtered-out times will be displayed
-	    on the plot using red cross-hatched regions.
+	    on the plot using solid red regions.
 	  </PARA>
 	  <PARA>
 	    The output file (clean.gti)
@@ -287,13 +288,13 @@ unix% dmcopy "evt2.fits[@clean.gti]" evt2_filt.fits
       <QEXAMPLE>
 
 	<SYNTAX>
-	  <LINE>&pr; lc_clean("bg.lc", outfile="bg.gti", pattern="crosshatch", pcol="orange")</LINE>
+	  <LINE>&pr; lc_clean("bg.lc", outfile="bg.gti", pattern="grid", pcol="orange")</LINE>
 	</SYNTAX>
 
 	<DESC>
 	  <PARA>
 	    Create a GTI file (bg.gti) and use
-	    an orange cross-hatch fill to indicate the excluded times in the
+	    an orange grid fill to indicate the excluded times in the
 	    count-rate plot.
 	  </PARA>
 	</DESC>
@@ -336,6 +337,12 @@ unix% dmcopy "evt2.fits[@clean.gti]" evt2_filt.fits
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the 4.11.2 (April 2019) release">
+      <PARA title="Switch to Matplotlib">
+	The plots are now created with Matplotlib rather than ChIPS.
+      </PARA>
+    </ADESC>
+
     <ADESC title="About Contributed Software">
       <PARA>
         This script is not an official part of the CIAO release but is
@@ -354,7 +361,7 @@ unix% dmcopy "evt2.fits[@clean.gti]" evt2_filt.fits
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/lc_sigma_clip.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lc_sigma_clip.xml
@@ -336,6 +336,13 @@ unix% dmcopy "evt2.fits[@clip.gti]" evt2_filt.fits
     </ADESC>
     -->
 
+    <ADESC title="Changes in the 4.11.4 (2019) release">
+      <PARA>
+	Labels with underscores in them are now properly displayed
+	by Matplotlib.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the 4.11.2 (April 2019) release">
       <PARA title="Switch to Matplotlib">
 	The plots are now created with Matplotlib rather than ChIPS.

--- a/ciao-4.11/contrib/share/doc/xml/lc_sigma_clip.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lc_sigma_clip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
- <!ENTITY pr "chips>">
+ <!ENTITY pr ">>>">
 ]>
 <cxchelptopics>
   <ENTRY key="lc_sigma_clip" context="contrib"
@@ -34,7 +34,7 @@
 
       <PARA title="Loading the routine">
         The routine can be loaded into a Python
-	interpreter - such as chips, sherpa, or ipython 
+	interpreter - such as Sherpa or ipython 
 	- by saying:
       </PARA>
 
@@ -84,10 +84,11 @@ from lightcurves import *
 	  <DATA>solid</DATA>
 	  <DATA>
 	    If a GTI file is created as well as a plot, then we indicate the
-	    excluded times using regions filled with this pattern. Valid values
-	    are the same as those for region and histograms - see the "Fill Patterns"
-	    section of "ahelp chipsopt".
-	    A value of "none" means no regions will be drawn.
+	    excluded times using regions filled with this pattern. A value
+	    of "none" means that the excluded regions will not be
+	    shown, otherwise it should be one of:
+	    solid, nofill, updiagonal, downdiagonal, horizontal,
+	    vertical, crisscross, grid, or polkadot.
 	  </DATA>
 	</ROW>
 	<ROW>
@@ -215,17 +216,17 @@ unix% dmcopy "evt2.fits[@evt.gti]" evt2_filt.fits
 	    printed to the screen.
 	  </PARA>
 	  <PARA>
-	    The plot can be printed using the ChIPS print_window command,
-	    for example
+	    The plot can be printed using the Matplotlib
+	    savefig command: for example
 	  </PARA>
 	  <PARA>
 	    <SYNTAX>
-	      <LINE>&pr; print_window("bg.lc.ps", ["fittopage", True, "orientation", "landscape"])</LINE>
+	      <LINE>&pr; import matplotlib.pyplot as plt</LINE>
+	      <LINE>&pr; plt.savefig("bg.lc.ps")</LINE>
 	    </SYNTAX>
 	  </PARA>
 	  <PARA>
-	    will create a postscript plot which is drawn
-	    in landscape format and fills the page.
+	    will create a postscript plot.
 	  </PARA>
 	</DESC>
 
@@ -243,7 +244,7 @@ unix% dmcopy "evt2.fits[@evt.gti]" evt2_filt.fits
 	    a GTI file (clip.gti)
 	    that represents the "good" times calculated by the algorithm.
 	    After writing out the file the filtered-out times will be displayed
-	    on the plot using red cross-hatched regions.
+	    on the plot using solid red regions.
 	  </PARA>
 	  <PARA>
 	    The output file
@@ -276,13 +277,13 @@ unix% dmcopy "evt2.fits[@clip.gti]" evt2_filt.fits
       <QEXAMPLE>
 
 	<SYNTAX>
-	  <LINE>&pr; lc_sigma_clip("bg.lc", outfile="bg.gti", pattern="crosshatch", pcol="orange")</LINE>
+	  <LINE>&pr; lc_sigma_clip("bg.lc", outfile="bg.gti", pattern="grid", pcol="orange")</LINE>
 	</SYNTAX>
 
 	<DESC>
 	  <PARA>
 	    Create a GTI file (bg.gti) and use
-	    an orange cross-hatch fill to indicate the excluded times in the
+	    an orange grid fill to indicate the excluded times in the
 	    count-rate plot.
 	  </PARA>
 	</DESC>
@@ -335,6 +336,12 @@ unix% dmcopy "evt2.fits[@clip.gti]" evt2_filt.fits
     </ADESC>
     -->
 
+    <ADESC title="Changes in the 4.11.2 (April 2019) release">
+      <PARA title="Switch to Matplotlib">
+	The plots are now created with Matplotlib rather than ChIPS.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.9.3 (May 2017) release">
       <PARA>
 	The lc_sigma_clip routine has been updated so that it will run
@@ -361,7 +368,7 @@ unix% dmcopy "evt2.fits[@clip.gti]" evt2_filt.fits
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/lightcurves.xml
+++ b/ciao-4.11/contrib/share/doc/xml/lightcurves.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
- <!ENTITY pr "chips>">
+ <!ENTITY pr ">>>">
 ]>
 <cxchelptopics>
   <ENTRY key="lightcurves" context="contrib"
@@ -42,7 +42,7 @@
 
       <PARA title="Loading the module">
         The module can be loaded into a Python
-	interpreter - such as chips, sherpa, or ipython
+	interpreter - such as Sherpa or ipython
 	- by saying:
       </PARA>
 
@@ -75,8 +75,9 @@ from lightcurves import *
       <QEXAMPLE>
 
 	<SYNTAX>
+	  <LINE>&pr; import matplotlib.pyplot as plt</LINE>
 	  <LINE>&pr; lc_clean("bg.lc")</LINE>
-	  <LINE>&pr; add_window()</LINE>
+	  <LINE>&pr; plt.figure()</LINE>
 	  <LINE>&pr; lc_sigma_clip("bg.lc")</LINE>
 	</SYNTAX>
 
@@ -145,6 +146,12 @@ from lightcurves import *
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the 4.11.2 (April 2019) release">
+      <PARA title="Switch to Matplotlib">
+	The plots are now created with Matplotlib rather than ChIPS.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the December 2011 release">
       <PARA>
 	The routines have been updated to work with CIAO 4.4.
@@ -169,7 +176,7 @@ from lightcurves import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
- remove chips references from the lightcurve code base and documentation
- fix a minor issue whereby underscores in labels would appear as '\_' in the plot (not sure if this is likely to happen, but it's a holdover from the ChIPS support)
- note that the erase argument is no-longer used, but don't remove it in case someone has code that sets it
- similarly the protect argument is no-longer used
- remove use of 'import six'
- minor style changes, as suggested by `pycodestyle`
