### PR TITLE
Remove use of the six module

### DIFF
--- a/ciao-4.11/contrib/bin/check_ciao_version
+++ b/ciao-4.11/contrib/bin/check_ciao_version
@@ -2,7 +2,7 @@
 
 """
 
-Copyright (C) 2011, 2014, 2015, 2016
+Copyright (C) 2011, 2014, 2015, 2016, 2019
           Smithsonian Astrophysical Observatory
 
 
@@ -43,18 +43,15 @@ Aim:
 
 """
 
-toolname = "check_ciao_version"
-version = "09 December 2016"
-
 import os
 import sys
 import glob
 from optparse import OptionParser
 
-from six.moves import urllib
-import six
-
 import socket
+
+toolname = "check_ciao_version"
+version = "11 June 2019"
 
 try:
     from ciao_contrib.logger_wrapper import handle_ciao_errors, \
@@ -80,7 +77,8 @@ which requres that it downloads a file from the CIAO web site.
 
 
 copyright_str = """
-Copyright (C) 2011, 2014, 2015, 2016  Smithsonian Astrophysical Observatory
+Copyright (C) 2011, 2014, 2015, 2016, 2019
+              Smithsonian Astrophysical Observatory
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -132,8 +130,9 @@ def compare_versions(ciao, latest, installed):
         sys.exit(1)
 
     updates = []
-    for (ik, iv) in six.iteritems(installed):
-        if ik == "CIAO": continue
+    for (ik, iv) in installed.items():
+        if ik == "CIAO":
+            continue
         lv = latest[ik]
         if iv != lv:
             updates.append((ik, iv, lv))

--- a/ciao-4.11/contrib/bin/download_obsid_caldb
+++ b/ciao-4.11/contrib/bin/download_obsid_caldb
@@ -29,7 +29,7 @@ import ciao_contrib.logger_wrapper as lw
 
 
 toolname = "download_obsid_caldb"
-__revision__ = "11 June 2019"
+__revision__ = "18 June 2019"
 
 lw.initialize_logger(toolname)
 
@@ -487,18 +487,23 @@ def get_all_products():
     with open(cidx, "r+") as fp:
         lines = fp.readlines()
 
-    chandra = [x for x in lines if x.startswith("CHANDRA")]
-    ciao = [x for x in chandra if x.split()[1] not in ['EPHIN', 'PCAD', 'SIM']]
-    ciao = [x for x in ciao if 'pimms' not in x.lower()]
-    ciao = [x.replace(" CALDB ", " {} ".format(cdir)) for x in ciao]
-    idxfiles = [os.path.join(x.split()[2],
-                             os.path.join(x.split()[3], x.split()[4]))
-                for x in ciao]
+    idxfiles = []
+    for line in lines:
+        if not line.startswith('CHANDRA'):
+            continue
+        if line.split()[1] in ['EPHIN', 'PCAD', 'SIM']:
+            continue
+        if 'pimms' in line.lower():
+            continue
+
+        paths = line.replace(' CALDB ', ' {} '.format(cdir)).split()
+        path = os.path.join(paths[2], paths[3], paths[4])
+        idxfiles.append(path)
 
     retval = {}
     for idx in idxfiles:
         # Quality of 5 is bad, not retrieved
-        tab = read_file(idx+"[cal_qual=:4.9]")
+        tab = read_file(idx + "[cal_qual=:4.9]")
         # get list of unique code-names
         _prods = list(set(tab.get_column("cal_cnam").values))
         try:

--- a/ciao-4.11/contrib/bin/download_obsid_caldb
+++ b/ciao-4.11/contrib/bin/download_obsid_caldb
@@ -68,7 +68,7 @@ class LoggingFile:
             self.bytes = 0
         else:
             if startfrom > filesize:
-                raise ValueError("startfrom > filesize ({} vs {})".format(startfrom,filesize))
+                raise ValueError("startfrom > filesize ({} vs {})".format(startfrom, filesize))
             self.bytes = startfrom - 1
         self.hashes = 0
         self.filesize = filesize
@@ -102,21 +102,21 @@ class FtpFile():
     """
     Little wrapper class to get the file size
     """
-    def __init__( self, ftp, path ):
+    def __init__(self, ftp, path):
         self.ftp = ftp
         self.path = path
 
-    def get_ftp_filesize( self):
+    def get_ftp_filesize(self):
 
         self.filesize = None
 
-        def parse_size( line ):
+        def parse_size(line):
             toks = line.split()
             self.filesize = int(toks[4])
 
         self.ftp.retrlines("LIST " + self.path, parse_size)
 
-        return( self.filesize )
+        return self.filesize
 
 
 def parse_url():
@@ -164,7 +164,7 @@ def parse_url():
     user = "anonymous" if not url.username else url.username
     pswd = "anonymous@ciao_contrib."+toolname if not url.password else url.password
 
-    verb2("Using FTP host='{}' dir='{}' user='{}' password='{}'".format( host, path, user, pswd))
+    verb2("Using FTP host='{}' dir='{}' user='{}' password='{}'".format(host, path, user, pswd))
     return host, path, user, pswd
 
 
@@ -206,16 +206,17 @@ def retrieve_config_files(ftp, newver, rootdir, outdir):
 
     """
 
-    verb1( "Retrieving CALDB index files")
+    verb1("Retrieving CALDB index files")
 
     ftp.cwd("/{}/software/tools".format(rootdir))
-    ftp.retrbinary( "RETR caldb.config", open("{}/caldb.config".format(outdir),"wb").write)
+    ftp.retrbinary("RETR caldb.config",
+                   open("{}/caldb.config".format(outdir), "wb").write)
 
     ftp.cwd("/{}/data/chandra/".format(rootdir))
     for dd in ftp.nlst():
-        if dd in [ 'ephin', 'sim', 'pcad', 'pimms' ]:
+        if dd in ['ephin', 'sim', 'pcad', 'pimms']:
             continue
-        ftp.cwd("/{}/data/chandra/{}".format(rootdir,dd))
+        ftp.cwd("/{}/data/chandra/{}".format(rootdir, dd))
 
         #
         # We store both the chandra/$inst/caldb.indx file to make
@@ -224,26 +225,26 @@ def retrieve_config_files(ftp, newver, rootdir, outdir):
         # directory.
         #
 
-        init_output_dir( "{}/data/chandra/{}".format(outdir,dd))
-        out_indx = open("{}/data/chandra/{}/caldb.indx".format(outdir,dd),"wb")
-        out_key = open("{}/data/chandra/{}/key.config".format(outdir,dd),"wb")
-        verb2("Index name :"+out_indx.name)
-        verb2("Key Config name :"+out_key.name)
-        ftp.retrbinary( "RETR caldb.indx", out_indx.write)
-        ftp.retrbinary( "RETR key.config", out_key.write)
+        init_output_dir("{}/data/chandra/{}".format(outdir, dd))
+        out_indx = open("{}/data/chandra/{}/caldb.indx".format(outdir, dd), "wb")
+        out_key = open("{}/data/chandra/{}/key.config".format(outdir, dd), "wb")
+        verb2("Index name :" + out_indx.name)
+        verb2("Key Config name :" + out_key.name)
+        ftp.retrbinary("RETR caldb.indx", out_indx.write)
+        ftp.retrbinary("RETR key.config", out_key.write)
         out_indx.close()
         out_key.close()
 
         # Okay -- this is a bit wasteful x-ferring the file twice.  Could
         # replace with a copy
 
-        init_output_dir( "{}/config".format(outdir))
-        out_indx = open("{}/config/{}-{}.indx".format(outdir,dd,newver),"wb")
-        out_key = open("{}/config/{}-{}.config".format(outdir,dd,newver),"wb")
-        verb2("Index name :"+out_indx.name)
-        verb2("Key Config name :"+out_key.name)
-        ftp.retrbinary( "RETR caldb.indx", out_indx.write)
-        ftp.retrbinary( "RETR key.config", out_key.write)
+        init_output_dir("{}/config".format(outdir))
+        out_indx = open("{}/config/{}-{}.indx".format(outdir, dd, newver), "wb")
+        out_key = open("{}/config/{}-{}.config".format(outdir, dd, newver), "wb")
+        verb2("Index name :" + out_indx.name)
+        verb2("Key Config name :" + out_key.name)
+        ftp.retrbinary("RETR caldb.indx", out_indx.write)
+        ftp.retrbinary("RETR key.config", out_key.write)
         out_indx.close()
         out_key.close()
 
@@ -286,31 +287,32 @@ def filter_config(newver, outdir):
 
     with open("{}/caldb.config".format(outdir), "r") as fp:
         cfg = fp.readlines()
-    os.unlink( "{}/caldb.config".format(outdir) )
+    os.unlink("{}/caldb.config".format(outdir))
 
     # Copy config file to standard/classic location
     init_output_dir("{}/software/tools".format(outdir))
     orig_config = "{}/software/tools/caldb.config".format(outdir)
-    with open( orig_config, "w") as fp:
-        fp.writelines( cfg )
+    with open(orig_config, "w") as fp:
+        fp.writelines(cfg)
 
     # Generic caldb.config is setup for all HEASARC mission, just get chandra.
     chandra = [x for x in cfg if x.startswith("CHANDRA")]
 
     # remove ephin, sim, pcad, pimms
-    chandra = [x for x in chandra if x.split()[1] not in ['EPHIN', 'PCAD', 'SIM', 'PIMMS' ]]
+    chandra = [x for x in chandra
+               if x.split()[1] not in ['EPHIN', 'PCAD', 'SIM', 'PIMMS']]
 
-    for ii,cc in enumerate(chandra):
+    for ii, cc in enumerate(chandra):
         #
         # Rename files, replace values in the versioned config file to
         # use the versioned index file names.
         #
         inst = cc.split(" ")[3].split("/")[2]
-        chandra[ii] = cc.replace("data/chandra/"+inst, "config/")
-        chandra[ii] = chandra[ii].replace("caldb.indx","{}-{}.indx".format(inst,newver))
-        chandra[ii] = chandra[ii].replace("key.config","{}-{}.config".format(inst,newver))
+        chandra[ii] = cc.replace("data/chandra/" + inst, "config/")
+        chandra[ii] = chandra[ii].replace("caldb.indx", "{}-{}.indx".format(inst, newver))
+        chandra[ii] = chandra[ii].replace("key.config", "{}-{}.config".format(inst, newver))
 
-    outconfig = "{}/config/CHANDRA-{}.config".format(outdir,newver)
+    outconfig = "{}/config/CHANDRA-{}.config".format(outdir, newver)
     with open(outconfig, "w") as fp:
         fp.writelines(chandra)
 
@@ -330,7 +332,7 @@ def get_version_file(ftp, rootdir, outdir):
     outfile = "{}/caldb_version.fits".format(verdir)
 
     try:
-        tab = read_file( outfile )
+        tab = read_file(outfile)
         _oldver = tab.get_column("CALDB_VER").values[-1]  # last row
         try:
             oldver = _oldver.decode("ascii")
@@ -341,14 +343,14 @@ def get_version_file(ftp, rootdir, outdir):
 
     if ftp:
         ftp.cwd("/{}/docs/chandra/caldb_version/".format(rootdir))
-        ftp.retrbinary( "RETR caldb_version.fits", open(outfile,"wb").write)
-    elif os.path.exists( outfile ):
+        ftp.retrbinary("RETR caldb_version.fits", open(outfile, "wb").write)
+    elif os.path.exists(outfile):
         pass
     else:
         raise RuntimeError("Error: cannot locate caldb version file")
 
-    tab = read_file( outfile )
-    _newver = tab.get_column("CALDB_VER").values[-1] #last row
+    tab = read_file(outfile)
+    _newver = tab.get_column("CALDB_VER").values[-1]  # last row
 
     try:
         newver = _newver.decode("ascii")
@@ -356,9 +358,9 @@ def get_version_file(ftp, rootdir, outdir):
         newver = _newver
 
     if oldver and oldver != newver:
-        verb0( "Old CALDB version '{}', New version will be '{}'".format(oldver,newver))
+        verb0("Old CALDB version '{}', New version will be '{}'".format(oldver, newver))
 
-    verb1( "Retrieving files for CALDB_VER = {}".format(newver))
+    verb1("Retrieving files for CALDB_VER = {}".format(newver))
     return newver
 
 
@@ -372,7 +374,7 @@ def init_output_dir(outdir):
             raise
 
 
-def retrieve_caldb_file( ftp, rootdir, looking_for, outdir, clobber, missing ):
+def retrieve_caldb_file(ftp, rootdir, looking_for, outdir, clobber, missing):
     """
     Retrieve the CALDB data files
     """
@@ -390,21 +392,21 @@ def retrieve_caldb_file( ftp, rootdir, looking_for, outdir, clobber, missing ):
         # outdir path. The os.path.join() is used to get the
         # outdir path w/ the trailing "/" (but only if it's not
         # already there).
-        hasdir = os.path.dirname( products )
-        init_output_dir( hasdir )
-        zz = hasdir.replace( os.path.join(outdir,""), "", 1 )
+        hasdir = os.path.dirname(products)
+        init_output_dir(hasdir)
+        zz = hasdir.replace(os.path.join(outdir, ""), "", 1)
         hasnam = os.path.basename(products)
 
-        outfile = "{}/{}".format(hasdir,hasnam)
-        updated = os.path.exists( outfile )
+        outfile = "{}/{}".format(hasdir, hasnam)
+        updated = os.path.exists(outfile)
         outfile_size = os.path.getsize(outfile) if updated else 0
 
         sys.stderr.write("    {:<40s}".format(hasnam))
 
         if missing:
-            sys.stderr.write( "."*20)
+            sys.stderr.write("." * 20)
             good = "online" if updated else "* MISSING *"
-            sys.stderr.write( " {}".format(good))
+            sys.stderr.write(" {}".format(good))
         else:
             #
             # Note to future self:  Since FITS files are stored in 2880
@@ -419,27 +421,27 @@ def retrieve_caldb_file( ftp, rootdir, looking_for, outdir, clobber, missing ):
             # wrong so then download it.
             #
 
-            ftp.cwd("/{}/{}".format(rootdir,zz))
-            fsize = FtpFile( ftp, hasnam ).get_ftp_filesize()
+            ftp.cwd("/{}/{}".format(rootdir, zz))
+            fsize = FtpFile(ftp, hasnam).get_ftp_filesize()
 
             if (fsize == outfile_size) and not clobber:
-                sys.stderr.write( "."*20)
-                sys.stderr.write( " (skipped)\n")
+                sys.stderr.write("." * 20)
+                sys.stderr.write(" (skipped)\n")
                 continue
 
-            outfp = open(outfile,"wb")
-            logdl = LoggingFile( outfp, fsize, sys.stderr, None )
+            outfp = open(outfile, "wb")
+            logdl = LoggingFile(outfp, fsize, sys.stderr, None)
 
-            ftp.retrbinary( "RETR {}".format(hasnam), logdl.write, 8*1024)
+            ftp.retrbinary("RETR {}".format(hasnam), logdl.write, 8 * 1024)
             outfp.close()
 
             if updated:
-                sys.stderr.write( ' (updated)')
+                sys.stderr.write(' (updated)')
 
         sys.stderr.write("\n")
 
 
-def retrieve_files_by_tool( ftp, rootdir, tool, infile, outdir, clobber, missing ):
+def retrieve_files_by_tool(ftp, rootdir, tool, infile, outdir, clobber, missing):
     """
     Use the CALDB to query for each of the files to know which to
     retrieve.
@@ -447,22 +449,24 @@ def retrieve_files_by_tool( ftp, rootdir, tool, infile, outdir, clobber, missing
     from caldb4 import Caldb
 
     for prod in tool:
-        verb3("Looking up CAL_CNAM={}".format(prod) )
+        verb3("Looking up CAL_CNAM={}".format(prod))
 
         # Ideally, this would only be done once (per-infile) but there
         # look to be some memory wackiness when the same Caldb object
         # has the .product changed -- it doesn't reset/reinit cleanly.
-        cc = Caldb( infile=infile )
+        cc = Caldb(infile=infile)
         cc.product = prod
         if tool[prod]:
             for constraint in tool[prod]:
-                verb3("Overrding value {}={}".format(constraint, tool[prod][constraint] ))
-                setattr(cc, constraint, tool[prod][constraint] )
+                verb3("Overrding value {}={}".format(constraint, tool[prod][constraint]))
+                setattr(cc, constraint, tool[prod][constraint])
 
         products = cc.search
-        retrieve_caldb_file( ftp, rootdir, products, outdir, clobber, missing )
+        retrieve_caldb_file(ftp, rootdir, products, outdir, clobber, missing)
 
-        # What does the following line do?
+        # The CALDB interface is a little different to normal Python
+        # modules, with some attribute accesses acting like method calls.
+        #
         cc.close
 
 
@@ -538,14 +542,14 @@ def get_tools(infile):
                             'evtsplt' : None,      # 'threshfile'
                             'cti' : None,          # 'ctifile'
                             't_gain' : None,      # 'tgainfile'
-                            'subpix' :None         # 'subpixfile'
+                            'subpix' : None         # 'subpixfile'
                             }
-    pixlib =  { "geom" : None,                # 'instruments' : None,
-                "aimpts" : None,              # 'aimpoints' : None,
-                "tdet" : None,                # 'tdet' : None,
-                "sky" : None,                 # 'sky' : None,
-                "sgeom" : None                # 'shell' : None,
-              }
+    pixlib = { "geom" : None,                # 'instruments' : None,
+               "aimpts" : None,              # 'aimpoints' : None,
+               "tdet" : None,                # 'tdet' : None,
+               "sky" : None,                 # 'sky' : None,
+               "sgeom" : None                # 'shell' : None,
+             }
     #acis_build_badpix = { 'badpix' : None }   # 'infile'
     ardlib = { 'axeffa' :  None,        # 'effarea_file'
                'vignet' : None,         # 'vignet_file'
@@ -558,15 +562,15 @@ def get_tools(infile):
                ### 'rmf_file' : None,  # ???
                ### 'gain_file' : None # ???
                }
-    mkacisrmf = {'sc_matrix' : None, } #infile
-    mkarf = { 'dead_area' :   None  } # 'dafile'
-    mkwarf = { 'fef_pha' : None } # + dead_area
+    mkacisrmf = {'sc_matrix' : None, }  # infile
+    mkarf = { 'dead_area' :   None  }  # 'dafile'
+    mkwarf = { 'fef_pha' : None }  # + dead_area
     mkpsfmap = {'reef' : None }
     tg_create_mask = {'wpsf' : None  }  # input_pos_tab
-    tg_resolve_events ={'osip' : None}
+    tg_resolve_events = {'osip' : None}
     tgextract2 = {'DISP_REG' : None }  # 'region_file'
-    tgextract = {'TGMASK2' : None, } # 'inregion_file'
-    hrc_process_events  =  {
+    tgextract = {'TGMASK2' : None, }  # 'inregion_file'
+    hrc_process_events = {
             'GAPLOOKUP' : None,
             'DEGAP' : None,
             'T_GMAP' : None,
@@ -585,24 +589,24 @@ def get_tools(infile):
         'TGPIMASK2' : None
         }
 
-    return [ pixlib , ardlib, acis_process_events, mkwarf, mkarf, mkpsfmap, mkacisrmf , tg_create_mask, tg_resolve_events, tgextract, tgextract2, hrc_process_events, misc]
+    return [pixlib, ardlib, acis_process_events, mkwarf, mkarf, mkpsfmap, mkacisrmf, tg_create_mask, tg_resolve_events, tgextract, tgextract2, hrc_process_events, misc]
 
 
-def create_config_files( ftp, rootdir, outdir  ):
+def create_config_files(ftp, rootdir, outdir):
     """
     Setup the config and index files for the partial CALDB directory.
     """
-    init_output_dir( outdir )
+    init_output_dir(outdir)
 
     newver = get_version_file(ftp, rootdir, outdir)
     retrieve_config_files(ftp, newver, rootdir, outdir)
     newconfig = filter_config(newver, outdir)
-    oldver = setup_caldb_environment( outdir, newconfig )
+    oldver = setup_caldb_environment(outdir, newconfig)
 
     return oldver
 
 
-def setup_caldb_environment( outdir, newconfig ):
+def setup_caldb_environment(outdir, newconfig):
     """
     Setup the new CALDB environment variables.
     """
@@ -612,13 +616,13 @@ def setup_caldb_environment( outdir, newconfig ):
     else:
         oldcaldb = None
 
-    os.environ["CALDB"]=outdir
-    os.environ["CALDBCONFIG"] = "{}/software/tools/caldb.config".format(outdir) #newconfig
+    os.environ["CALDB"] = outdir
+    os.environ["CALDBCONFIG"] = "{}/software/tools/caldb.config".format(outdir)  # newconfig
 
     return oldcaldb
 
 
-def get_background_files( ftp, rootdir, infile, outdir, clobber, background_files, missing):
+def get_background_files(ftp, rootdir, infile, outdir, clobber, background_files, missing):
     """
     """
 
@@ -631,11 +635,10 @@ def get_background_files( ftp, rootdir, infile, outdir, clobber, background_file
         from ciao_contrib.runtool import acis_bkgrnd_lookup
         acis_bkgrnd_lookup.punlearn()
         try:
-            acis_bkgrnd_lookup( infile )
-            bkgfiles = stk.build( acis_bkgrnd_lookup.outfile )
-            retrieve_caldb_file( ftp, rootdir, bkgfiles, outdir, clobber, missing )
+            acis_bkgrnd_lookup(infile)
+            bkgfiles = stk.build(acis_bkgrnd_lookup.outfile)
+            retrieve_caldb_file(ftp, rootdir, bkgfiles, outdir, clobber, missing)
         except Exception as e:
-            #print e
             pass
 
     elif 'HRC' == inst:
@@ -643,37 +646,36 @@ def get_background_files( ftp, rootdir, infile, outdir, clobber, background_file
         hrc_bkgrnd_lookup.punlearn()
         try:
             hrc_bkgrnd_lookup(infile, "event")
-            bkgfiles = stk.build( hrc_bkgrnd_lookup.outfile)
-            retrieve_caldb_file( ftp, rootdir, bkgfiles, outdir, clobber, missing )
+            bkgfiles = stk.build(hrc_bkgrnd_lookup.outfile)
+            retrieve_caldb_file(ftp, rootdir, bkgfiles, outdir, clobber, missing)
         except Exception:
             pass
 
         try:
             hrc_bkgrnd_lookup(infile, "spectrum")
-            bkgfiles = stk.build( hrc_bkgrnd_lookup.outfile)
-            retrieve_caldb_file( ftp, rootdir, bkgfiles, outdir, clobber, missing )
+            bkgfiles = stk.build(hrc_bkgrnd_lookup.outfile)
+            retrieve_caldb_file(ftp, rootdir, bkgfiles, outdir, clobber, missing)
         except Exception as e:
-            # print e
             pass
     else:
         # Should have failed much sooner than now!
         raise RuntimeError("Unknown instrument")
 
 
-def get_caldb_files( ftp, rootdir, infile, outdir, clobber, background_files, missing):
+def get_caldb_files(ftp, rootdir, infile, outdir, clobber, background_files, missing):
     """
     Get all possible CALDB files needed for this observation.
 
     """
 
-    verb1( "Retrieving CALDB data files")
+    verb1("Retrieving CALDB data files")
     sys.stderr.write("    {:<40s}0------------------1\n".format('Filename:'))
 
     for tool in get_tools(infile):
-        retrieve_files_by_tool( ftp, rootdir, tool, infile, outdir, clobber, missing )
+        retrieve_files_by_tool(ftp, rootdir, tool, infile, outdir, clobber, missing)
 
     if background_files:
-        get_background_files( ftp, rootdir, infile, outdir, clobber, background_files, missing)
+        get_background_files(ftp, rootdir, infile, outdir, clobber, background_files, missing)
 
 
 def print_new_setup(oldcaldb):
@@ -682,20 +684,20 @@ def print_new_setup(oldcaldb):
     setup.
     """
 
-    if (oldcaldb and os.path.abspath(oldcaldb) != os.path.abspath(os.environ["CALDB"])) or ( not oldcaldb):
-        verb0( "\nBe sure to setup the following environment variables to")
-        verb0( "use these CALDB files.")
-        verb0( "")
-        verb0( "(t)csh:")
-        verb0( "setenv CALDB "+os.path.abspath(os.environ["CALDB"]))
-        verb0( "setenv CALDBCONFIG "+os.path.abspath(os.environ["CALDBCONFIG"]))
-        verb0( "setenv CALDBALIAS none")
-        verb0( "")
-        verb0( "bash:")
-        verb0( "export CALDB="+os.path.abspath(os.environ["CALDB"]))
-        verb0( "export CALDBCONFIG="+os.path.abspath(os.environ["CALDBCONFIG"]))
-        verb0( "export CALDBALIAS=none")
-        verb0( "")
+    if (oldcaldb and os.path.abspath(oldcaldb) != os.path.abspath(os.environ["CALDB"])) or not oldcaldb:
+        verb0("\nBe sure to setup the following environment variables to")
+        verb0("use these CALDB files.")
+        verb0("")
+        verb0("(t)csh:")
+        verb0("setenv CALDB " + os.path.abspath(os.environ["CALDB"]))
+        verb0("setenv CALDBCONFIG " + os.path.abspath(os.environ["CALDBCONFIG"]))
+        verb0("setenv CALDBALIAS none")
+        verb0("")
+        verb0("bash:")
+        verb0("export CALDB=" + os.path.abspath(os.environ["CALDB"]))
+        verb0("export CALDBCONFIG=" + os.path.abspath(os.environ["CALDBCONFIG"]))
+        verb0("export CALDBALIAS=none")
+        verb0("")
 
 
 def locate_infile(infile):
@@ -705,21 +707,22 @@ def locate_infile(infile):
 
     import glob as glob
 
-    infile = infile.split("[")[0] # strip off any filters
+    infile = infile.split("[")[0]  # strip off any filters
 
     if os.path.isfile(infile):
         return infile
 
-    if os.path.isfile(infile+".gz"):
-        return infile+".gz"
+    if os.path.isfile(infile + ".gz"):
+        return infile + ".gz"
 
     if os.path.isdir(infile):
 
-        for dd in [ infile, infile+"/repro", infile+"/primary", infile+"/secondary" ]:
-            gg = glob.glob( dd+"/*evt*" )
+        for suffix in ['', '/repro', '/primary', '/secondary']:
+            dd = infile + suffix
+            gg = glob.glob(dd + "/*evt*")
             if len(gg) == 0:
                 continue
-            if len(gg) > 1 :
+            if len(gg) > 1:
                 verb1("Multiple event file found, using {}".format(gg[0]))
                 return gg[0]
             verb2("Using event file {}".format(gg[0]))
@@ -728,25 +731,30 @@ def locate_infile(infile):
     raise IOError("Cannot locate event file in '{}'".format(infile))
 
 
-def setup_check_missing( outdir ):
+def setup_check_missing(outdir):
     """
     setup CALDB environment variable for new output dir
     """
-    if not os.path.exists( outdir ):
+    if not os.path.exists(outdir):
         raise ValueError("ERROR: The output directory must already exist in missing mode.")
 
-    if not os.path.exists( outdir+"/software/tools/caldb.config"):
+    if not os.path.exists(outdir + "/software/tools/caldb.config"):
         raise ValueError("ERROR: The CALDB configuration file must already exist in missing mode.")
 
     os.environ["CALDB"] = os.path.abspath(outdir)
-    os.environ["CALDBCONFIG"] = os.environ["CALDB"]+"/software/tools/caldb.config"
+    os.environ["CALDBCONFIG"] = os.environ["CALDB"] + "/software/tools/caldb.config"
     return os.environ["CALDB"]
+
+
+def is_par_set(value):
+    """Convert a yes to True, anything else to False"""
+    return value == 'yes'
 
 
 #
 # Main Routine
 #
-@lw.handle_ciao_errors( toolname, __revision__)
+@lw.handle_ciao_errors(toolname, __revision__)
 def main():
     # get parameters
     from ciao_contrib.param_soaker import get_params
@@ -755,25 +763,25 @@ def main():
     pars = get_params(toolname, "rw", sys.argv,
                       verbose={"set": lw.set_verbosity, "cmd": verb1})
 
-    infiles= pars["infile"]
+    infiles = pars["infile"]
     outdir = pars["outdir"]
-    missing = "yes" == pars["missing"]
-    background_files = "yes" == pars["background"]
-    clobber = "yes" == pars["clobber"]
+    missing = is_par_set(pars["missing"])
+    background_files = is_par_set(pars["background"])
+    clobber = is_par_set(pars["clobber"])
 
     if missing:
         ftp = None
         rootdir = None
-        oldcaldb = setup_check_missing( outdir )
-        get_version_file( ftp, rootdir, outdir )
+        oldcaldb = setup_check_missing(outdir)
+        get_version_file(ftp, rootdir, outdir)
     else:
         ftp, rootdir = init_ftp()
-        oldcaldb = create_config_files( ftp, rootdir, outdir )
+        oldcaldb = create_config_files(ftp, rootdir, outdir)
 
     import stk as stk
-    for infile in stk.build( infiles ):
+    for infile in stk.build(infiles):
         try:
-            infile = locate_infile( infile )
+            infile = locate_infile(infile)
             verb1("Processing infile={}".format(infile))
         except Exception:
             verb0("WARNING: Unable to locate evt2 file in '{}'.  Skipping it.".format(infile))
@@ -782,7 +790,7 @@ def main():
         get_caldb_files(ftp, rootdir, infile, outdir, clobber, background_files, missing)
 
     close_ftp(ftp)
-    print_new_setup( oldcaldb )
+    print_new_setup(oldcaldb)
 
 
 if __name__ == "__main__":

--- a/ciao-4.11/contrib/bin/download_obsid_caldb
+++ b/ciao-4.11/contrib/bin/download_obsid_caldb
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 #
-# Copyright (C) 2013-2018 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013-2018, 2019 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,18 +20,19 @@
 
 from __future__ import print_function
 
-toolname = "download_obsid_caldb"
-__revision__ = "01 August 2018"
-
 import os
 import sys
 
-CDA_SERVER = "ftp://cda.cfa.harvard.edu/pub/arcftp/ChandraCalDB"
-CDA_ENV = "CALDB_MIRROR_SITE" 
-
+from urllib.parse import urlparse
 
 import ciao_contrib.logger_wrapper as lw
+
+
+toolname = "download_obsid_caldb"
+__revision__ = "11 June 2019"
+
 lw.initialize_logger(toolname)
+
 lgr = lw.get_logger(toolname)
 verb0 = lgr.verbose0
 verb1 = lgr.verbose1
@@ -39,8 +40,8 @@ verb2 = lgr.verbose2
 verb3 = lgr.verbose3
 verb5 = lgr.verbose5
 
-
-import six
+CDA_SERVER = "ftp://cda.cfa.harvard.edu/pub/arcftp/ChandraCalDB"
+CDA_ENV = "CALDB_MIRROR_SITE"
 
 
 #
@@ -63,7 +64,7 @@ class LoggingFile:
         if nhash < 1:
             raise ValueError("nhash must be >= 1, sent {}".format(nhash))
         self.fp = fp
-        if startfrom == None:
+        if startfrom is None:
             self.bytes = 0
         else:
             if startfrom > filesize:
@@ -83,7 +84,7 @@ class LoggingFile:
                 self.outfp.write(self.hashchr)
                 self.outfp.flush()
                 self.hashes = self.hashes + 1
-                
+
         self.fp.write(data)
 
     def close(self):
@@ -114,9 +115,8 @@ class FtpFile():
             self.filesize = int(toks[4])
 
         self.ftp.retrlines("LIST " + self.path, parse_size)
-        
-        return( self.filesize )
 
+        return( self.filesize )
 
 
 def parse_url():
@@ -124,39 +124,38 @@ def parse_url():
     Allow user to override CALDB location via env variable similar to
     how download_chandra_obsid works.  Also ripped off from Doug's
     stuff.
-    
+
     setenv CALDB_MIRROR_SITE "ftp://user:password@host:port/dir"
 
     Only FTP protocol is supported.
-        
+
     """
 
     def get_id():
         """
         DEPRECATED ---
-        get a real user name if there is one.  
+        get a real user name if there is one.
         """
         u = "anonymous"
         for o in ["USER", "USERNAME"]:
             if o in os.environ:
-                u=os.environ[o]
+                u = os.environ[o]
 
         from socket import getfqdn
         mybox = getfqdn()
         if not mybox:
             mybox = toolname
-        
-        return "{}@{}".format(u, mybox)  
 
+        return "{}@{}".format(u, mybox)
 
-    try: 
+    try:
         if CDA_ENV not in os.environ:
-            url = six.moves.urllib.parse.urlparse( CDA_SERVER )
+            url = urlparse(CDA_SERVER)
         else:
-            url = six.moves.urllib.parse.urlparse( os.environ[CDA_ENV])
-    except:
+            url = urlparse(os.environ[CDA_ENV])
+    except Exception:
         raise ValueError("Bad {} setting".format(CDA_ENV))
-        
+
     if url.scheme != "ftp":
         raise ValueError('The mirror site must begin with ftp://')
 
@@ -173,7 +172,7 @@ def init_ftp():
     """
     Connect to ftp site
     """
-    
+
     from ftplib import FTP
 
     host, path, user, pswd = parse_url()
@@ -195,18 +194,17 @@ def retrieve_config_files(ftp, newver, rootdir, outdir):
     Retrieve the instrument specific CALDB caldb.indx and key.config files.
 
     In classic mode, the caldb.indx and key.config files will be stored
-    under data/chandra/{instrume}.  
-    
+    under data/chandra/{instrume}.
+
     In the non-classic mode, the caldb.indx and key.config files
     will be stored in
-    
+
     config/{instrume}-{version}.indx and .config
-    
+
     which allows the user to change versions without having to manipulate
     symbolic links.
 
     """
-
 
     verb1( "Retrieving CALDB index files")
 
@@ -214,15 +212,15 @@ def retrieve_config_files(ftp, newver, rootdir, outdir):
     ftp.retrbinary( "RETR caldb.config", open("{}/caldb.config".format(outdir),"wb").write)
 
     ftp.cwd("/{}/data/chandra/".format(rootdir))
-    for dd in ftp.nlst():            
-        if dd in [ 'ephin', 'sim', 'pcad', 'pimms' ]:  
+    for dd in ftp.nlst():
+        if dd in [ 'ephin', 'sim', 'pcad', 'pimms' ]:
             continue
         ftp.cwd("/{}/data/chandra/{}".format(rootdir,dd))
 
         #
         # We store both the chandra/$inst/caldb.indx file to make
         # old-school caldb happy, but then we also store versioned
-        # copies of the index and key.config files in the config/ 
+        # copies of the index and key.config files in the config/
         # directory.
         #
 
@@ -254,39 +252,38 @@ def filter_config(newver, outdir):
     """
     Rename/replace the generic CALDB config files with version specific
     files.
-    
+
     The Chandra caldb uses a generic configuration files
-    
+
         root/software/tools/caldb.config
-    
+
     that points to each of the instrument specific index files and
     key config files:
-    
+
         root/data/chandra/instrument/caldb.indx
         root/data/chandra/instrument/key.config
-    
+
     Where these are symbolic links to "version" specific files.
-    
+
         caldb.indx -> ./index/caldbN0400.indx
-    
+
     This makes keeping track of versions, and if desired using multiple
     versions a real headache.
-    
+
     Instead, this script will download the generic index and config
     files, and tweak them to be version specific.
-    
+
         caldb.config -> CHANDRA-${version}.config
         caldb.indx -> INSTRUMENT-${version}.indx
         key.config -> INSTRUMENT-${version}.config
 
-    This makes keeping old version of the CALDB a lot easier.    
+    This makes keeping old version of the CALDB a lot easier.
 
-    In classic mode the caldb.config file is copied to the 
+    In classic mode the caldb.config file is copied to the
     traditional software/tools/caldb.config location.   How boring is
     that.
     """
 
-        
     with open("{}/caldb.config".format(outdir), "r") as fp:
         cfg = fp.readlines()
     os.unlink( "{}/caldb.config".format(outdir) )
@@ -296,7 +293,7 @@ def filter_config(newver, outdir):
     orig_config = "{}/software/tools/caldb.config".format(outdir)
     with open( orig_config, "w") as fp:
         fp.writelines( cfg )
-    
+
     # Generic caldb.config is setup for all HEASARC mission, just get chandra.
     chandra = [x for x in cfg if x.startswith("CHANDRA")]
 
@@ -324,7 +321,7 @@ def get_version_file(ftp, rootdir, outdir):
     """
     Read the Chandra caldb version file.  Get the old version if
     it exists then download the new file.
-    
+
     """
     from pycrates import read_file
 
@@ -334,12 +331,12 @@ def get_version_file(ftp, rootdir, outdir):
 
     try:
         tab = read_file( outfile )
-        _oldver = tab.get_column("CALDB_VER").values[-1] #last row
+        _oldver = tab.get_column("CALDB_VER").values[-1]  # last row
         try:
             oldver = _oldver.decode("ascii")
-        except:
+        except Exception:
             oldver = _oldver
-    except: 
+    except Exception:
         oldver = None
 
     if ftp:
@@ -352,19 +349,17 @@ def get_version_file(ftp, rootdir, outdir):
 
     tab = read_file( outfile )
     _newver = tab.get_column("CALDB_VER").values[-1] #last row
-    
+
     try:
         newver = _newver.decode("ascii")
-    except:
+    except Exception:
         newver = _newver
 
-    
     if oldver and oldver != newver:
         verb0( "Old CALDB version '{}', New version will be '{}'".format(oldver,newver))
 
     verb1( "Retrieving files for CALDB_VER = {}".format(newver))
     return newver
-
 
 
 def init_output_dir(outdir):
@@ -381,7 +376,7 @@ def retrieve_caldb_file( ftp, rootdir, looking_for, outdir, clobber, missing ):
     """
     Retrieve the CALDB data files
     """
-    if looking_for == None or 0 == len(looking_for):
+    if looking_for is None or 0 == len(looking_for):
         return
 
     # strip off the extension numbers, we want the whole file
@@ -403,13 +398,13 @@ def retrieve_caldb_file( ftp, rootdir, looking_for, outdir, clobber, missing ):
         outfile = "{}/{}".format(hasdir,hasnam)
         updated = os.path.exists( outfile )
         outfile_size = os.path.getsize(outfile) if updated else 0
-        
+
         sys.stderr.write("    {:<40s}".format(hasnam))
 
         if missing:
             sys.stderr.write( "."*20)
             good = "online" if updated else "* MISSING *"
-            sys.stderr.write( " {}".format(good))            
+            sys.stderr.write( " {}".format(good))
         else:
             #
             # Note to future self:  Since FITS files are stored in 2880
@@ -441,14 +436,13 @@ def retrieve_caldb_file( ftp, rootdir, looking_for, outdir, clobber, missing ):
             if updated:
                 sys.stderr.write( ' (updated)')
 
-
         sys.stderr.write("\n")
-        
+
 
 def retrieve_files_by_tool( ftp, rootdir, tool, infile, outdir, clobber, missing ):
     """
     Use the CALDB to query for each of the files to know which to
-    retrieve. 
+    retrieve.
     """
     from caldb4 import Caldb
 
@@ -456,7 +450,7 @@ def retrieve_files_by_tool( ftp, rootdir, tool, infile, outdir, clobber, missing
         verb3("Looking up CAL_CNAM={}".format(prod) )
 
         # Ideally, this would only be done once (per-infile) but there
-        # look to be some memory wackiness when the same Caldb object 
+        # look to be some memory wackiness when the same Caldb object
         # has the .product changed -- it doesn't reset/reinit cleanly.
         cc = Caldb( infile=infile )
         cc.product = prod
@@ -467,6 +461,8 @@ def retrieve_files_by_tool( ftp, rootdir, tool, infile, outdir, clobber, missing
 
         products = cc.search
         retrieve_caldb_file( ftp, rootdir, products, outdir, clobber, missing )
+
+        # What does the following line do?
         cc.close
 
 
@@ -476,8 +472,8 @@ def get_all_products():
 
     This is a different way to find the caldb products -- it looks for
     all the index files and gets the unique set of CAL_CNAM values.
-    
-    The problem with this is that the same single fits file can have 
+
+    The problem with this is that the same single fits file can have
     multiple extensions, and each extension may have a different
     CAL_CNAM (eg ACIS CTI file p2_resp files).  This then makes the retreival
     look more messy since the file will be 'skipped' even in a clean caldb tree.
@@ -485,55 +481,57 @@ def get_all_products():
     complicated then the get_by_tool method below
     """
     from pycrates import read_file
-        
+
     cidx = os.environ["CALDBCONFIG"]
     cdir = os.environ["CALDB"]
-    with open( cidx, "r+") as fp:
+    with open(cidx, "r+") as fp:
         lines = fp.readlines()
-    
+
     chandra = [x for x in lines if x.startswith("CHANDRA")]
-    ciao = [x for x in chandra if x.split()[1] not in  ['EPHIN', 'PCAD', 'SIM' ]]
+    ciao = [x for x in chandra if x.split()[1] not in ['EPHIN', 'PCAD', 'SIM']]
     ciao = [x for x in ciao if 'pimms' not in x.lower()]
-    ciao = [ x.replace(" CALDB ", " {} ".format(cdir)) for x in ciao]
-    idxfiles = [ os.path.join( x.split()[2], os.path.join( x.split()[3],x.split()[4] )) for x in ciao ]
+    ciao = [x.replace(" CALDB ", " {} ".format(cdir)) for x in ciao]
+    idxfiles = [os.path.join(x.split()[2],
+                             os.path.join(x.split()[3], x.split()[4]))
+                for x in ciao]
 
     retval = {}
-    for idx in idxfiles:        
+    for idx in idxfiles:
         # Quality of 5 is bad, not retrieved
         tab = read_file(idx+"[cal_qual=:4.9]")
         # get list of unique code-names
-        _prods = list(set(tab.get_column("cal_cnam").values)) 
+        _prods = list(set(tab.get_column("cal_cnam").values))
         try:
-            prods = [x.decode("ascii") for x in _prods ]
-        except:
+            prods = [x.decode("ascii") for x in _prods]
+        except Exception:
             prods = _prods
- 
+
         for p in prods:
             retval[p] = None
-        
+
     return [retval]
-        
+
 
 def get_tools(infile):
     """
     Identify the CALDB data product codes by tool.
-    
+
     This list is not complete.  Duplicates are not included or they
     would be retrieve twice.
-    
+
     So while OSIP is needed by mkgarf and tg_resolve_events, it
     only should up in tg_resolve_events.  Same thing with badpixel
     and gain files.
 
     TODO:  HRC RMF, others?
-    
+
     """
 
     acis_process_events = { 'grade' : None,        # 'gradefile'
                             'grdimg' : None,       # 'grade_image_file'
                             'det_gain' : None,     # 'gainfile'
                             'evtsplt' : None,      # 'threshfile'
-                            'cti' : None,          # 'ctifile' 
+                            'cti' : None,          # 'ctifile'
                             't_gain' : None,      # 'tgainfile'
                             'subpix' :None         # 'subpixfile'
                             }
@@ -543,7 +541,7 @@ def get_tools(infile):
                 "sky" : None,                 # 'sky' : None,
                 "sgeom" : None                # 'shell' : None,
               }
-    #acis_build_badpix = { 'badpix' : None }   # 'infile' 
+    #acis_build_badpix = { 'badpix' : None }   # 'infile'
     ardlib = { 'axeffa' :  None,        # 'effarea_file'
                'vignet' : None,         # 'vignet_file'
                'qe' : None,             # 'qe'
@@ -556,7 +554,7 @@ def get_tools(infile):
                ### 'gain_file' : None # ???
                }
     mkacisrmf = {'sc_matrix' : None, } #infile
-    mkarf = { 'dead_area' :   None  } # 'dafile'  
+    mkarf = { 'dead_area' :   None  } # 'dafile'
     mkwarf = { 'fef_pha' : None } # + dead_area
     mkpsfmap = {'reef' : None }
     tg_create_mask = {'wpsf' : None  }  # input_pos_tab
@@ -573,18 +571,16 @@ def get_tools(infile):
             'TAPRINGTEST' : None,
             'EFTEST' : None,
             'SATTEST' : None,
-            'AMP_SF_COR' : None,        
+            'AMP_SF_COR' : None,
         }
     misc = {
         'GTI_LIM' : None,  # dmgti (mtl_build_gti)
-        'MATRIX' : None,    # HRC RMF files    
+        'MATRIX' : None,    # HRC RMF files
         'lsfparm' : { 'grattype' : 'HEG' },
         'TGPIMASK2' : None
         }
 
-    
     return [ pixlib , ardlib, acis_process_events, mkwarf, mkarf, mkpsfmap, mkacisrmf , tg_create_mask, tg_resolve_events, tgextract, tgextract2, hrc_process_events, misc]
-
 
 
 def create_config_files( ftp, rootdir, outdir  ):
@@ -592,7 +588,7 @@ def create_config_files( ftp, rootdir, outdir  ):
     Setup the config and index files for the partial CALDB directory.
     """
     init_output_dir( outdir )
-    
+
     newver = get_version_file(ftp, rootdir, outdir)
     retrieve_config_files(ftp, newver, rootdir, outdir)
     newconfig = filter_config(newver, outdir)
@@ -610,9 +606,9 @@ def setup_caldb_environment( outdir, newconfig ):
         oldcaldb = os.environ["CALDB"]
     else:
         oldcaldb = None
-        
+
     os.environ["CALDB"]=outdir
-    os.environ["CALDBCONFIG"] = "{}/software/tools/caldb.config".format(outdir) #newconfig    
+    os.environ["CALDBCONFIG"] = "{}/software/tools/caldb.config".format(outdir) #newconfig
 
     return oldcaldb
 
@@ -620,7 +616,7 @@ def setup_caldb_environment( outdir, newconfig ):
 def get_background_files( ftp, rootdir, infile, outdir, clobber, background_files, missing):
     """
     """
-    
+
     import stk as stk
     from pycrates import read_file
     tab = read_file(infile)
@@ -643,27 +639,26 @@ def get_background_files( ftp, rootdir, infile, outdir, clobber, background_file
         try:
             hrc_bkgrnd_lookup(infile, "event")
             bkgfiles = stk.build( hrc_bkgrnd_lookup.outfile)
-            retrieve_caldb_file( ftp, rootdir, bkgfiles, outdir, clobber, missing )                
-        except:
+            retrieve_caldb_file( ftp, rootdir, bkgfiles, outdir, clobber, missing )
+        except Exception:
             pass
-        
+
         try:
             hrc_bkgrnd_lookup(infile, "spectrum")
             bkgfiles = stk.build( hrc_bkgrnd_lookup.outfile)
-            retrieve_caldb_file( ftp, rootdir, bkgfiles, outdir, clobber, missing )                
+            retrieve_caldb_file( ftp, rootdir, bkgfiles, outdir, clobber, missing )
         except Exception as e:
             # print e
-            pass            
+            pass
     else:
         # Should have failed much sooner than now!
         raise RuntimeError("Unknown instrument")
 
 
-
 def get_caldb_files( ftp, rootdir, infile, outdir, clobber, background_files, missing):
     """
     Get all possible CALDB files needed for this observation.
-    
+
     """
 
     verb1( "Retrieving CALDB data files")
@@ -709,12 +704,12 @@ def locate_infile(infile):
 
     if os.path.isfile(infile):
         return infile
-    
+
     if os.path.isfile(infile+".gz"):
         return infile+".gz"
-    
+
     if os.path.isdir(infile):
-        
+
         for dd in [ infile, infile+"/repro", infile+"/primary", infile+"/secondary" ]:
             gg = glob.glob( dd+"/*evt*" )
             if len(gg) == 0:
@@ -724,20 +719,20 @@ def locate_infile(infile):
                 return gg[0]
             verb2("Using event file {}".format(gg[0]))
             return gg[0]
-    
+
     raise IOError("Cannot locate event file in '{}'".format(infile))
 
-    
+
 def setup_check_missing( outdir ):
     """
     setup CALDB environment variable for new output dir
     """
     if not os.path.exists( outdir ):
         raise ValueError("ERROR: The output directory must already exist in missing mode.")
-    
+
     if not os.path.exists( outdir+"/software/tools/caldb.config"):
         raise ValueError("ERROR: The CALDB configuration file must already exist in missing mode.")
-        
+
     os.environ["CALDB"] = os.path.abspath(outdir)
     os.environ["CALDBCONFIG"] = os.environ["CALDB"]+"/software/tools/caldb.config"
     return os.environ["CALDB"]
@@ -752,40 +747,37 @@ def main():
     from ciao_contrib.param_soaker import get_params
 
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
-        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+    pars = get_params(toolname, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
 
-    infiles= pars["infile"]   
-    outdir = pars["outdir"]   
-    missing = ( "yes" == pars["missing"] )
-    background_files = ("yes" == pars["background"] ) 
-    clobber = ("yes" == pars["clobber"]) 
-        
+    infiles= pars["infile"]
+    outdir = pars["outdir"]
+    missing = "yes" == pars["missing"]
+    background_files = "yes" == pars["background"]
+    clobber = "yes" == pars["clobber"]
 
     if missing:
         ftp = None
         rootdir = None
-        oldcaldb = setup_check_missing( outdir )    
+        oldcaldb = setup_check_missing( outdir )
         get_version_file( ftp, rootdir, outdir )
     else:
         ftp, rootdir = init_ftp()
         oldcaldb = create_config_files( ftp, rootdir, outdir )
 
-
-    import stk as stk    
+    import stk as stk
     for infile in stk.build( infiles ):
         try:
             infile = locate_infile( infile )
             verb1("Processing infile={}".format(infile))
-        except:
+        except Exception:
             verb0("WARNING: Unable to locate evt2 file in '{}'.  Skipping it.".format(infile))
             continue
-            
+
         get_caldb_files(ftp, rootdir, infile, outdir, clobber, background_files, missing)
 
     close_ftp(ftp)
     print_new_setup( oldcaldb )
-
 
 
 if __name__ == "__main__":
@@ -795,4 +787,3 @@ if __name__ == "__main__":
         print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
-  

--- a/ciao-4.11/contrib/bin/gti_align
+++ b/ciao-4.11/contrib/bin/gti_align
@@ -1,7 +1,8 @@
 #! /usr/bin/env python
 
 #
-# Copyright (C) 2015-2016, 2018 Smithsonian Astrophysical Observatory
+# Copyright (C) 2015-2016, 2018, 2019
+#               Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,9 +21,6 @@
 
 from __future__ import print_function
 
-
-toolname = "gti_align"
-__revision__ = "06 March 2018"
 
 import os
 import sys
@@ -47,6 +45,11 @@ except KeyError:
     raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
 
 import ciao_contrib.logger_wrapper as lw
+
+
+toolname = "gti_align"
+__revision__ = "11 June 2019"
+
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
 verb0 = lgr.verbose0
@@ -58,7 +61,7 @@ verb5 = lgr.verbose5
 
 import numpy as np
 from pycrates import read_file
-from six.moves import zip
+
 
 class ExposureStatsFile():
 
@@ -88,7 +91,6 @@ class ExposureStatsFile():
 
         self.flushtime = tab.get_key_value("flshtime")
 
-
     def get_per_chip_exposure_time_boundaries( self, ccd_id ):
         """
         The stat1 file has the mid-time for each exposure number that is sent.
@@ -111,7 +113,6 @@ class ExposureStatsFile():
         if len(ee) ==  0:
             raise RuntimeError("CCD_ID={} is not in exposure stats file {}".format(ccd_id, infile))
 
-
         # setup output arrays
         self.tlo[ccd_id] = np.zeros_like(tt)
         self.thi[ccd_id] = np.zeros_like(tt)
@@ -132,14 +133,12 @@ class ExposureStatsFile():
         for xx in range(len(tt)):
             verb5( "{}\t{}\t{}\t{}".format(ee[xx], self.tlo[ccd_id][xx], tt[xx], self.thi[ccd_id][xx]))
 
-
     def get_exposure_time_boundaries( self ):
         """
         Wrapper around above for each chip
         """
         for ccd_id in self.ccds:
             self.get_per_chip_exposure_time_boundaries(ccd_id)
-
 
     def _align_boundary( self, ss, tt, ccd_id ):
         """
@@ -169,7 +168,6 @@ class ExposureStatsFile():
         else:
             return None, None
 
-
     def align_boundary( self, gti ):
         """
         Loop over ccd_id's found in the stat1 file and match to
@@ -196,11 +194,9 @@ class ExposureStatsFile():
             nt = np.array([x[1] for x in new_limits if x[1]])
             self.per_chip_output[ccd_id] = ( ns, nt )
 
-
         # Preserve the order of GTIs in infile (if any)
         if gti.ccd_order:
             self.ccds = [ x for x in gti.ccd_order if x in self.ccds ]
-
 
     def write_output( self, outfile ):
         """Write the output file using cxcdm routines"""
@@ -238,7 +234,8 @@ class ExposureStatsFile():
                 dmBlockCreateSubspaceCpt(tab)
                 if verbstr:  verbstr += "||"
 
-        if verbstr:  verb1(verbstr)
+        if verbstr:
+            verb1(verbstr)
         dmTableClose(tab)
 
 
@@ -247,9 +244,9 @@ class GTI():
 
     """
     sentinal = "no_ccd_dss"  # if input gti has no ccd_id subspace
+
     def __init__(self):
         pass
-
 
 
 class GTIString(GTI):
@@ -288,7 +285,6 @@ class GTIString(GTI):
         self.cpts[self.sentinal] = ( lo_vals, hi_vals )
 
 
-
 class GTIFile(GTI):
     """
     Hold multi component gti.  It only keys off the ccd_id being
@@ -321,7 +317,7 @@ class GTIFile(GTI):
                         self.cpts[ccd] = ( start, stop )
                         self.ccd_order.append(ccd)
 
-            except:
+            except Exception:
                 self.cpts[self.sentinal] = ( start, stop )
 
 
@@ -332,11 +328,10 @@ def load_gti( infile ):
 
     try:
         gti = GTIFile( infile )
-    except:
+    except Exception:
         gti = GTIString( infile )
 
     return gti
-
 
 
 #
@@ -362,7 +357,7 @@ def main():
 
     try:
         gti = load_gti( infile )
-    except:
+    except Exception:
         raise ValueError("ERROR: could not open times value as either a file nor parse as a string.")
 
     if evtfile and len(evtfile) and "none" != evtfile.lower():
@@ -378,8 +373,6 @@ def main():
     stats.write_output( outfile )
 
     add_tool_history( outfile, toolname, pars, toolversion=__revision__)
-
-
 
 
 if __name__ == "__main__":

--- a/ciao-4.11/contrib/bin/monitor_photom
+++ b/ciao-4.11/contrib/bin/monitor_photom
@@ -1,25 +1,23 @@
 #!/usr/bin/env python
 
-# Copyright (C) 2005,2014,2016 Smithsonian Astrophysical Observatory
-# 
+# Copyright (C) 2005,2014,2016,2019
+#               Smithsonian Astrophysical Observatory
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 from __future__ import print_function
-
-toolname = "monitor_photom"
-__revision__ = "13 Sep 2016"
 
 import stk
 import pycrates as pc
@@ -27,10 +25,12 @@ import numpy as np
 
 import sys
 import os
-import six
-
 
 import ciao_contrib.logger_wrapper as lw
+
+toolname = "monitor_photom"
+__revision__ = "11 June 2019"
+
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
 verb0 = lgr.verbose0
@@ -47,12 +47,10 @@ verb5 = lgr.verbose5
 #%
 #% $Id: monitor_photom,v 1.0 2005/06/23 taldcroft Exp $
 #%
-#% Purpose: Generate a photometric light curve for a Chandra 
-#%	   target which was observed using an ACA monitor 
+#% Purpose: Generate a photometric light curve for a Chandra
+#%	   target which was observed using an ACA monitor
 #%	   window.
 #%
-
-
 
 
 def get_data( infile):
@@ -62,7 +60,7 @@ def get_data( infile):
 
     class FlatCrate():
         pass
-    
+
     tab = pc.read_file(infile)
 
     # Make something crate-like to make translation from S-Lang easier
@@ -73,21 +71,20 @@ def get_data( infile):
     dat.img_row0 = tab.get_column("img_row0").values* 1
     dat.img_col0 = tab.get_column("img_col0").values* 1
     dat.aca_comp_bkg_avg = tab.get_column("aca_comp_bkg_avg").values* 1.0
-    
-    dat.integ_time = tab.get_key_value("INTGTIME")* 1.0
-    
-    return dat
 
+    dat.integ_time = tab.get_key_value("INTGTIME")* 1.0
+
+    return dat
 
 
 def cosmic_ray_removal( dat ):
     """
-    
+
     %%--------------------------------------------------------------------------
     % Median filter the image data in time, taking care of the fact that the image
     % window can shift in position
     %%--------------------------------------------------------------------------
-    
+
     """
     n = len(dat.img_row0)
     img_size = dat.img_raw[0].shape[0]
@@ -96,47 +93,46 @@ def cosmic_ray_removal( dat ):
 
     img_corr = dat.img_raw*5.0  # TBR:  Where does '5' come from?
 
-
     verb1("Filtering image data (cosmic ray removal)...")
-    
-    for i in six.moves.range( n ):
+
+    for i in range(n):
         if 0 == (i % 100):
             verb2("  image {} of {}".format(i+1,n))
-        
+
         for r in img_size_range:         # Rows of one readout image
             for c in img_size_range:     # Cols of one readout image
 
                 #
                 # Median is taken from current image +/-2 images
-                # 
+                #
                 samp = np.zeros(5, dtype=np.float)
                 n_samp = 0
-                
+
                 for j in plus_minus_two:
                     ij = i+j
                     if ij >= 0 and ij < n:
                         r0 = r+dat.img_row0[i] - dat.img_row0[ij]  # Account for row offset between images
                         c0 = c+dat.img_col0[i] - dat.img_col0[ij]  # Account for column offset between images
-                        
+
                         if r0 >=0 and r0<img_size and c0 >=0 and c0 < img_size:
                             samp[n_samp] = img_corr[ij, r0, c0]
                             n_samp = n_samp+1
-                
+
                 if n_samp >= 3:
                     # Only compute median if at least 3 values
                     img_corr[i,r,c] = np.median( samp[0:n_samp] )
-                
+
     return img_corr
-    
-                    
+
+
 def get_edge_pixels( img_size ):
     """
         %  Define the 'edge pixels' for detecting warm pixels
     """
-    
+
     if 6 == img_size:
         r = [0, 0, 0, 0, 5, 5, 5, 5, 1, 2, 3, 4, 1, 2, 3, 4]
-        c = [1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0, 0, 5, 5, 5, 5] 
+        c = [1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0, 0, 5, 5, 5, 5]
     elif 8 == img_size:
         r = [0, 0, 0, 0, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7, 7, 7, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 6, 1, 6 ]
         c = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7, 1, 1, 6, 6 ]
@@ -152,7 +148,7 @@ def stack_dark_current_data(dat, img_corr, rc0 ):
         %---------------------------------------------------------------------
         % Make a stack of dark current measurements
         %---------------------------------------------------------------------
-    
+
     """
     n = len(dat.img_row0)
     img_size = dat.img_raw[0].shape[0]
@@ -165,15 +161,15 @@ def stack_dark_current_data(dat, img_corr, rc0 ):
     dark = np.zeros( [n, sz, sz], dtype=np.float)
     i_dark = np.zeros( [n, sz, sz], dtype=np.long)  # Not used anywhere, keep for now
     n_dark = np.zeros( [sz, sz], dtype=np.long )
-    
+
     verb1("Stacking dark current data...")
-    for i in six.moves.range( n ):        
+    for i in range(n):
         if 0 == (i % 100):
             verb2("  image {} of {}".format(i+1,n))
 
         rowoff = rc0 + dat.img_row0[i] - dat.img_row0[0]  # Account for shift between images
         coloff = rc0 + dat.img_col0[i] - dat.img_col0[0]  # Account for shift between images
-        
+
         for j in n_r:
             c0 = c[j] + coloff
             r0 = r[j] + rowoff
@@ -185,23 +181,23 @@ def stack_dark_current_data(dat, img_corr, rc0 ):
                 n_dark[r0, c0]   = nd + 1
             else:
                 verb0("Warning: pixel ({},{},{})) has out-of-bounds (c0,r0)=({},{})".format(i, c[j], r[j], c0, r0))
-    
+
     return dark, i_dark, n_dark
 
 
 def make_median_dark_current( dat, img_corr, n_dark, dark, pars ):
     """
-    
+
     %---------------------------------------------------------------------
-    % Make the median dark current for each pixel with at least 
+    % Make the median dark current for each pixel with at least
     % min_dark_measurements measurements
     %---------------------------------------------------------------------
 
     """
     min_dark_measurements = int(pars["min_dark_meas"])
     min_dark_limit = float(pars["min_dark_limit"])
-    dark_ratio = float(pars["dark_ratio"])        # hot limit as a fraction of image counts    
-    rc0 = int(pars["max_dither_motion"]) # Maximum possible dither motion in ACA pixels  
+    dark_ratio = float(pars["dark_ratio"])        # hot limit as a fraction of image counts
+    rc0 = int(pars["max_dither_motion"]) # Maximum possible dither motion in ACA pixels
 
     img_size = dat.img_raw[0].shape[0] # must be at least 1 row.
     sz = 2*rc0 + img_size  # Size of pixel region on CCD that completely contains all mon. window data
@@ -212,23 +208,22 @@ def make_median_dark_current( dat, img_corr, n_dark, dark, pars ):
     verb1( "Average counts  (e-) = {}".format( avg_cts))
     verb1( "Warm dark limit (e-) = {}".format(warm_dark_limit))
 
-
     median_dark = np.zeros( [sz, sz], dtype=np.float) - 9999.0
     sz_range = range(sz)
-    
+
     for c0 in sz_range:
         for r0 in sz_range:
 
             if n_dark[r0,c0] <= min_dark_measurements:
                 continue
-            
+
             median_dark[r0,c0] = np.median( dark[ range(n_dark[r0,c0]), r0, c0] )
             if median_dark[r0,c0] > warm_dark_limit:
                 r_ccd = int(r0 - rc0 + dat.img_row0[0])
                 c_ccd = int(c0 - rc0 + dat.img_col0[0])
                 verb1( "Warm pixel at CCD (row,col) = ({},{})\t Dark current (e-) = {}".format( r_ccd, c_ccd, median_dark[r0,c0]))
- 
-    # Calculate the median reported dark current   
+
+    # Calculate the median reported dark current
     avg_median_dark = np.median( dat.aca_comp_bkg_avg )
 
     # Use the median dark current reported by ACA for all pixels that are not "warm"
@@ -243,25 +238,24 @@ def subtract_dark( dat, img_corr, rc0, median_dark ):
     Now subtract dark current from each image
 
     """
-    
+
     n = len(dat.img_row0)
     img_size = dat.img_raw[0].shape[0]
     img_size_range = range(img_size)
-    
+
     img_sub = np.zeros_like( img_corr )
 
-    for i in six.moves.range( n ):
+    for i in range(n):
         rowoff = rc0 + dat.img_row0[i] - dat.img_row0[0] # Account for image offsets
         coloff = rc0 + dat.img_col0[i] - dat.img_col0[0] # Account for image offsets
-        
+
         for c in img_size_range:
             for r in img_size_range:
                 c0 = c+coloff
                 r0 = r+rowoff
                 img_sub[i,r,c] = img_corr[i,r,c]-median_dark[r0,c0]
-    
+
     return img_sub
-    
 
 
 def write_output(dat, img_sub, outfile, clobber ):
@@ -270,7 +264,7 @@ def write_output(dat, img_sub, outfile, clobber ):
 
     from crates_contrib.utils import write_columns
 
-    counts = np.sum( img_sub, axis=(1,2) )    
+    counts = np.sum( img_sub, axis=(1,2) )
     mag0 = 10.32                # e-
     cnt_rate_mag0 = 5263.0       # e-/sec
     min_cnt_rate  = 10.0        # min allowed count rate (e-/sec)
@@ -281,11 +275,9 @@ def write_output(dat, img_sub, outfile, clobber ):
     mag = mag0 - 2.5 * np.log10(mag/cnt_rate_mag0)
 
     clb = ('yes' == clobber)
-    write_columns( outfile, dat.time, counts, cnt_rate, mag, img_sub, 
+    write_columns( outfile, dat.time, counts, cnt_rate, mag, img_sub,
         colnames=["time", "counts", "count_rate", "mag", "img_sub"],
         clobber=clb, format="fits" )
-        
-
 
 
 @lw.handle_ciao_errors( toolname, __revision__)
@@ -296,31 +288,25 @@ def main():
     from ciao_contrib._tools.fileio import outfile_clobber_checks
     from ciao_contrib.runtool import add_tool_history
 
-    pars = get_params(toolname, "rw", sys.argv, 
+    pars = get_params(toolname, "rw", sys.argv,
          verbose={"set":lw.set_verbosity, "cmd":verb1} )
 
     outfile_clobber_checks(pars["clobber"], pars["outfile"] )
-    rc0 = int(pars["max_dither_motion"]) # Maximum possible dither motion in ACA pixels  
+    rc0 = int(pars["max_dither_motion"]) # Maximum possible dither motion in ACA pixels
 
-    
     dat = get_data( pars["infile"] )
 
     img_corr = cosmic_ray_removal( dat )
-    
+
     dark, i_dark, n_dark = stack_dark_current_data( dat, img_corr, rc0)
 
     median_dark = make_median_dark_current( dat, img_corr, n_dark, dark, pars )
 
     img_sub = subtract_dark( dat, img_corr, rc0, median_dark )
-    
+
     write_output( dat, img_sub, pars["outfile"], pars["clobber"] )
-    
+
     add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
-    
-
-    
-    
-
 
 
 if __name__ == "__main__":
@@ -330,4 +316,3 @@ if __name__ == "__main__":
         print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
-  

--- a/ciao-4.11/contrib/bin/reproject_obs
+++ b/ciao-4.11/contrib/bin/reproject_obs
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017
+# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2019
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -21,7 +21,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-"""
+r"""
 Reproject observations to a common tangent point and (optionally)
 merge the event files.
 
@@ -36,16 +36,10 @@ can be broken down into
 
 """
 
-toolname = 'reproject_obs'
-__revision__  = '31 March 2017'
-
 import os
 import sys
 import shutil
 import tempfile
-
-import six
-import six.moves
 
 import paramio
 
@@ -79,6 +73,9 @@ import ciao_contrib._tools.run as run
 import ciao_contrib._tools.utils as utils
 
 from ciao_contrib._tools.taskrunner import TaskRunner
+
+toolname = 'reproject_obs'
+__revision__ = '11 June 2019'
 
 lgr = lw.initialize_logger(toolname)
 v1 = lgr.verbose1
@@ -204,7 +201,7 @@ def _link_or_copy_file(infile, outfile, linkfile=True):
         v3("Soft linking {} to {}".format(outfile, infile))
         try:
             os.symlink(ifile, ofile)
-        except:
+        except Exception:
             v3("Soft link failed; copying file to {}".format(ofile))
             shutil.copyfile(ifile, ofile)
 
@@ -227,7 +224,7 @@ def dmhedit_line(key, value):
         else:
             out += "F"
 
-    elif isinstance(value, six.string_types):
+    elif isinstance(value, str):
         if '/' in value:
             out += "'{}'".format(value)
         else:
@@ -255,7 +252,7 @@ def update_ancillary_header(infile, adict, tmpdir="/tmp/"):
                                         suffix=".dmhedit")
     try:
         tfile.write("#add\n")
-        for (k, v) in six.iteritems(adict):
+        for (k, v) in adict.items():
             tfile.write(dmhedit_line("{}FILE".format(k), v))
 
         tfile.flush()
@@ -369,8 +366,7 @@ def link_ancillary_files(taskrunner,
 
             else:
                 newnames = []
-                zs = zip(six.moves.xrange(0, nfiles), afiles)
-                for (idx, afile) in zs:
+                for (idx, afile) in enumerate(afiles):
                     idval = chr(97 + idx)
                     newname = "{}{}{}.asol".format(outroot, label, idval)
                     newnames.append(os.path.basename(newname))
@@ -469,7 +465,7 @@ def link_ancillary_files(taskrunner,
 
     # Let the user know about missing files
     nmiss = 0
-    for (filetype, mobsids) in six.iteritems(missing):
+    for (filetype, mobsids) in missing.items():
         nmiss += len(mobsids)
         if len(mobsids) == 1:
             v1("Unable to find {} file for ObsId ".format(filetype) +

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/fileio.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/fileio.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016
+#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -25,8 +25,6 @@ File I/O utility routines: intended for processing FIS/data files.
 import glob
 import os
 import tempfile
-
-import six
 
 import numpy as np
 
@@ -232,7 +230,7 @@ def _get_key_values(blockinfo):
     """
 
     kdict = blockinfo['records']
-    keys = dict([(k, v.value) for (k, v) in six.iteritems(kdict)])
+    keys = dict([(k, v.value) for (k, v) in kdict.items()])
     if blockinfo['type'] in ['TABLE', 'EMPTY-TABLE']:
         keys['__NCOLS'] = len(blockinfo['columns'])
         keys['__NROWS'] = blockinfo['nrows']
@@ -282,7 +280,7 @@ def get_keys_cols_from_file(fname):
         # get_block_info_from_file loses the ordering
         # of the columns, so need to reconstruct it
         colinfo = [None] * keys['__NCOLS']
-        for cinfo in six.itervalues(bi['columns']):
+        for cinfo in bi['columns'].values():
             colinfo[cinfo.pos - 1] = cinfo
 
     else:
@@ -349,7 +347,7 @@ def get_aimpoint(infile):
     try:
         nblocks = cxcdm.dmDatasetGetNoBlocks(ds)
         v4("File has {} blocks".format(nblocks))
-        for blnum in six.moves.range(1, nblocks + 1):
+        for blnum in range(1, nblocks + 1):
             blname = cxcdm.dmDatasetGetBlockName(ds, blnum)
             v4("Block #{} = {}".format(blnum, blname))
             if blname.startswith("GTI") and \
@@ -357,7 +355,7 @@ def get_aimpoint(infile):
                 bl = cxcdm.dmDatasetGetBlock(ds, blnum)
                 try:
                     nkeys = cxcdm.dmBlockGetNoKeys(bl)
-                    for keynum in six.moves.range(1, nkeys + 1):
+                    for keynum in range(1, nkeys + 1):
                         dd = cxcdm.dmBlockGetKey(bl, keynum)
                         # TODO: is it CHIP for HRC data? Does it matter?
                         if cxcdm.dmGetName(dd) == 'CCD_ID':
@@ -467,7 +465,7 @@ def validate_outdir(outdir):
     else:
         try:
             os.mkdir(outdir)
-        except:
+        except Exception:
             raise IOError("Unable to create directory {}".format(outdir))
 
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/fluximage.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/fluximage.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2018
+# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2018, 2019
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -52,8 +52,6 @@ import tempfile
 import shutil
 import numpy as np
 import subprocess as sbp
-
-import six
 
 import paramio
 import pycrates as pcr
@@ -142,7 +140,7 @@ def add_dmh_keyword(fh, keyval):
 
     # need to be careful with string values
     fh.write("{} = ".format(name))
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         if "/" in value:
             fh.write("'{}'".format(value))
         else:
@@ -678,7 +676,9 @@ def calc_count_ratio(file1, file2, filterstr):
 
     nr1 = _get_nrows(file1 + filterstr)
     nr2 = _get_nrows(file2 + filterstr)
-    v2("Count scaling {}: {}={} {}={}".format(filterstr, file1, nr1, file2, nr2))
+    v2("Count scaling {}: {}={} {}={}".format(filterstr,
+                                              file1, nr1,
+                                              file2, nr2))
 
     return (nr1, nr2)
 
@@ -876,7 +876,8 @@ def make_images_hrci(enbands,
         # could change (i.e. if the restriction on the number
         # of bands to 1 is relaxed).
         #
-        for (enband, img, bkgimg, rawimg) in zip(enbands, imgs, imgs_pcle, imgs_unsub):
+        for (enband, img, bkgimg, rawimg) in \
+                zip(enbands, imgs, imgs_pcle, imgs_unsub):
 
             scale_hrci_background(enband,
                                   bkgmethod,
@@ -959,7 +960,8 @@ def make_event_images(taskrunner, labelconv,
     tasks = []
     for enband in enbands:
         v3("Creating an image with {}".format(enband.dmfilterstr))
-        ifile = "{}[bin {}]{}[opt type=i4]".format(filename, grid, enband.dmfilterstr)
+        ifile = "{}[bin {}]{}[opt type=i4]".format(filename, grid,
+                                                   enband.dmfilterstr)
         ofile = name_image(outpath, enband)
 
         task = labelconv("evtbin-{}".format(enband.bandlabel))
@@ -1947,7 +1949,7 @@ def make_fluxed_images(taskrunner, labelconv, preconditions,
     imcalc_args = []
     for enband in enbands:
         imgfile = name_image(outhead, enband)
-        expmap  = name_expmap(outhead, enband)
+        expmap = name_expmap(outhead, enband)
         fluxmap = name_fluxed(outhead, enband)
 
         # thresh arguments are: imgfile, expmap, img_outfile, exp_outfile
@@ -2324,7 +2326,7 @@ def blanksky_hrci(caldbfile, infile, tmpdir, obsid, verbose):
                          "key=OBI_NUM",
                          "verbose=0",
                          "mode=h"])
-            except:
+            except Exception:
                 pass
 
         # change status bits to match infile; do not add option=all
@@ -2349,15 +2351,15 @@ def clobber_checks(files, clobber=False):
 
     v3("Clobber checks with clobber={}".format(clobber))
     fnames = []
-    for (key, vals) in six.iteritems(files):
+    for (key, vals) in files.items():
         v4("Checking for {} files.".format(key))
-        if isinstance(vals, six.string_types):
+        if isinstance(vals, str):
             v4(" ... a single file")
             fnames.append(vals)
 
         elif isinstance(vals, dict):
             v4(" ... a dictionary")
-            for val in six.itervalues(vals):
+            for val in vals.values():
                 fnames.extend(val)
 
         else:
@@ -2431,7 +2433,7 @@ def get_output_filenames(outpath, enbands, chips,
         outputs["blanksky"] = [outpath + HRCI_BG_EVTS]
 
         pcle = []
-        raw  = []
+        raw = []
         for enband in enbands:
             pcle.append(name_hrci_particle_background(outpath, enband))
             raw.append(name_hrci_unsubtracted_background(outpath, enband))
@@ -2463,7 +2465,7 @@ def add_history(outputs, cmdline_pars, toolname, toolversion,
         files = outputs[0]
 
     out = set()
-    for vs in six.itervalues(files):
+    for vs in files.values():
         out |= set(vs)
 
     # Assume that cmdline_pars contains all the parameter

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/merging.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/merging.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018
+#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
 #    Smithsonian Astrophysical Observatory
 #
 #
@@ -25,8 +25,6 @@ Routines used when merging and combining data.
 import os
 import tempfile
 import math
-
-import six
 
 import numpy as np
 
@@ -159,7 +157,7 @@ def match_obsid(obsinfos, infiles, label):
 
     # Let the user know if we have any unmatched files.
     #
-    for (key, filename) in six.iteritems(cache):
+    for (key, filename) in cache.items():
         obsid = key[0]
         obscycle = key[1]
         msg = "Skipping {} file {} (ObsId {}".format(label, filename, obsid)
@@ -233,7 +231,7 @@ def match_obsid_asol(obsinfos, asolfiles):
         out.append(fileio.sort_mjd(fnames))
 
     # Let the user know what files we could not match
-    for (key, infiles) in six.iteritems(aobsids):
+    for (key, infiles) in aobsids.items():
         if key in keys:
             continue
         for infile in infiles:
@@ -1092,7 +1090,7 @@ def validate_obsinfo(infiles, colcheck=True):
         except KeyError:
             nobsids[obsidval] = 1
 
-    multis = [k for (k, v) in six.iteritems(nobsids) if v > 1]
+    multis = [k for (k, v) in nobsids.items() if v > 1]
     if len(multis) > 0:
         v3("Found interleaved/multi-OBI ObsIds: {}".format(multis))
         if len(multis) == 1:
@@ -1406,7 +1404,7 @@ def merge_event_files(infiles,
 
                 cmatch[ci.name] += 1
 
-        for (cname, nfound) in six.iteritems(cmatch):
+        for (cname, nfound) in cmatch.items():
             if nfound != nfiles:
                 excl_cols.add(cname)
 
@@ -1440,8 +1438,9 @@ def merge_event_files(infiles,
     # is removed.
     #
     excl_subspace_acis = ["expno"]
-    excl_subspace_hrc  = ["clkticks", "av1", "au1", "mjf", "mnf",
-                          "endmnf", "sub_mjf"]
+    excl_subspace_hrc = ["clkticks", "av1", "au1", "mjf", "mnf",
+                         "endmnf", "sub_mjf"]
+
     if inst == 'ACIS':
         excl_subspace = excl_subspace_acis
     elif inst == 'HRC':
@@ -1821,13 +1820,13 @@ def list_observations(instrume, ranom, decnom, obsinfos):
     # Try and make the display "readable", even if it makes the code
     # somewhat messy and full of heuristics.
     #
-    for (keyname, values) in six.iteritems(checks):
+    for (keyname, values) in checks.items():
         if len(values) < 2:
             continue
 
         v1("WARNING - {} values differ:".format(keyname))
         out = [(len(value), key, value)
-               for (key, value) in six.iteritems(values)]
+               for (key, value) in values.items()]
         out.sort(reverse=True)
         if len(out) == 2:
             larger = out[0]
@@ -2817,7 +2816,7 @@ def merge(process,
     #
     def extract_fileinfo(finfo):
         out = {}
-        for (key, files) in six.iteritems(finfo):
+        for (key, files) in finfo.items():
             out[key] = [fname
                         for (flag, fname) in zip(process, files) if flag]
 
@@ -3018,7 +3017,7 @@ def handle_xygrid(pfile, instrument, pars, params):
         params['bin'] = binsize
         params['xrange'] = xrng
         params['yrange'] = yrng
-        params['sizes']  = sizes
+        params['sizes'] = sizes
 
     params['xygrid'] = xygrid
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/taskrunner.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/taskrunner.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
-# Python35Support
-
 #
-# Copyright (C) 2012, 2015, 2016
+# Copyright (C) 2012, 2015, 2016, 2019
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -30,14 +28,12 @@ before being run.
 
 """
 
-import six
-
 import time
 import multiprocessing
+from queue import Empty
 
 import pickle
 
-# from ciao_contrib.logger_wrapper import initialize_module_logger
 from ..logger_wrapper import initialize_module_logger
 
 """
@@ -316,7 +312,7 @@ class TaskRunner:
         #
         v4("TaskRunner (parallel, processes={}): starting workers".format(processes))
         workers = [TaskHandler(task_queue, queue)
-                   for i in six.moves.range(processes)]
+                   for i in range(processes)]
 
         for w in workers:
             w.start()
@@ -344,10 +340,10 @@ class TaskRunner:
                     # try to remove any jobs that have not been run yet
                     try:
                         task_queue.get_nowait()
-                    except six.moves.queue.Empty:
+                    except Empty:
                         break
 
-                for i in six.moves.range(processes):
+                for i in range(processes):
                     task_queue.put(None)
 
                 raise taskout
@@ -358,7 +354,7 @@ class TaskRunner:
             finished.add(taskout)
             if len(finished) == ntasks:
                 v4("TaskRunner: all tasks completed; stopping.")
-                for i in six.moves.range(processes):
+                for i in range(processes):
                     task_queue.put(None)
 
                 break

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/versioninfo.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/versioninfo.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2014, 2015, 2016
+#  Copyright (C) 2011, 2014, 2015, 2016, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -27,13 +27,11 @@ the CXC website.
 """
 
 import glob
-# import subprocess as sbp
 import os
-
-from six.moves import urllib
-import six
-
 import socket
+
+from urllib.request import urlopen
+from urllib.error import URLError
 
 from ciao_contrib import logger_wrapper as lw
 
@@ -46,7 +44,6 @@ __all__ = ('get_installed_versions', 'get_latest_versions',
 #       set up a logger or its verbosity.
 #
 lgr = lw.initialize_module_logger('_tools.versioninfo')
-# v1 = lgr.verbose1
 v3 = lgr.verbose3
 v4 = lgr.verbose4
 
@@ -116,7 +113,8 @@ def parse_version_file(lines):
     out = {}
     for l in lines:
         l = l.strip()
-        if l == "": continue
+        if l == "":
+            continue
         idx = l.find(" ")
         if idx == -1:
             raise IOError("Unable to parse line: '{0}'".format(l))
@@ -156,7 +154,7 @@ def parse_version_file(lines):
 #     text = ans.stdout.read()
 #
 #     # Ugly code; what is the better way to do this
-#     if not isinstance(text, six.string_types):
+#     if not isinstance(text, str):
 #         text = text.decode('utf8')
 #
 #     return text.strip()
@@ -213,12 +211,11 @@ def get_url_contents(url, timeout=None):
 
     try:
         if timeout is None:
-            contents = urllib.request.urlopen(url).read()
+            contents = urlopen(url).read()
         else:
-            contents = urllib.request.urlopen(url,
-                                              timeout=timeout).read()
+            contents = urlopen(url, timeout=timeout).read()
 
-    except urllib.error.URLError as ue:
+    except URLError as ue:
         # Probably excessive attempt to make a "nice" error message
         #
         out = {'is404': False}
@@ -234,7 +231,7 @@ def get_url_contents(url, timeout=None):
                 out['errortext'] = "Unable to reach the CIAO " + \
                     "site - {}".format(ue.reason)
 
-        except:
+        except Exception:
             pass
 
         if 'errortext' not in out:
@@ -244,7 +241,7 @@ def get_url_contents(url, timeout=None):
         return out
 
     # Ugly code; what is the better way to do this
-    if not isinstance(contents, six.string_types):
+    if not isinstance(contents, str):
         contents = contents.decode('utf8')
 
     return {'contents': contents}

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/caldb.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/caldb.py
@@ -1,8 +1,5 @@
-
-# Python35Support
-
 #
-#  Copyright (C) 2010, 2011, 2012, 2014, 2015, 2016
+#  Copyright (C) 2010, 2011, 2012, 2014, 2015, 2016, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -29,10 +26,9 @@ import copy
 import socket
 import time
 
-import six
-from six.moves.html_parser import HTMLParser
-from six.moves.urllib import request
-from six.moves.urllib.error import URLError
+from html.parser import HTMLParser
+from urllib.request import urlopen
+from urllib.error import URLError
 
 import pycrates
 
@@ -43,7 +39,7 @@ __all__ = (
     "get_caldb_installed",
     "get_caldb_installed_version",
     "get_caldb_installed_date"
-    )
+)
 
 release_notes_url = "http://cxc.harvard.edu/caldb/downloads/releasenotes.html"
 
@@ -112,10 +108,10 @@ class CALDBReleaseParser(HTMLParser):
 
     state = "need-table"
     open_mode = {"need-table":
-                     {"tag": "table",
-                      "attribute": ("id", "caldbver"),
-                      "newstate": "check-header"
-                      },
+                 {"tag": "table",
+                  "attribute": ("id", "caldbver"),
+                  "newstate": "check-header"
+                  },
                  }
 
     close_mode = {"check-header": {"tag": "tr",
@@ -256,9 +252,9 @@ def get_caldb_releases(timeout=None):
 
     try:
         if timeout is None:
-            h = request.urlopen(release_notes_url).read()
+            h = urlopen(release_notes_url).read()
         else:
-            h = request.urlopen(release_notes_url, timeout=timeout).read()
+            h = urlopen(release_notes_url, timeout=timeout).read()
 
     except URLError as ue:
         # Probably excessive attempt to make a "nice" error message
@@ -280,9 +276,7 @@ def get_caldb_releases(timeout=None):
         else:
             raise IOError("Unable to access the CALDB site - {}".format(ue))
 
-    # convert to a string if necessary
-    if not six.PY2:
-        h = h.decode('utf-8')
+    h = h.decode('utf-8')
 
     try:
         p = CALDBReleaseParser()
@@ -469,13 +463,13 @@ def check_caldb_version(version=None):
     # a tuple of integers means we can just use Python's comparison
     # operator and it handles cases like
     #
-    # chips-24> (4,2,1) > (3,2,0,1)
-    #           True
-    # chips-25> (4,2,2) > (4,2,2,2)
-    #           False
+    # >>> (4,2,1) > (3,2,0,1)
+    #     True
+    # >>> (4,2,2) > (4,2,2,2)
+    #     False
     #
-    # We are relying on the CALDB release numbers to be dotted integers,
-    # with no alphanumerics (e.g. 4.4.1a)
+    # We are relying on the CALDB release numbers to be dotted
+    # integers, with no alphanumerics (i.e. not 4.4.1a)
     #
     rels = get_caldb_releases()
     if version is None:

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/csccli.py
@@ -1,21 +1,21 @@
-#!/usr/bin/env pyretthon
-# 
-# Copyright (C) 2013, 2016d Smithsonian Astrophysical Observatory
-# 
+#
+# Copyright (C) 2013, 2016, 2019
+#               Smithsonian Astrophysical Observatory
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 """
 Collection of routines to access the Chandra Source Catalog
 command line interface to perform specific queries.
@@ -24,8 +24,13 @@ Additionally can be used to retrieve files using the CSC file
 retrieve interface.
 
 """
+
+import os
+
 import ciao_contrib.logger_wrapper as lw
-logger= lw.initialize_module_logger("cda.csccli")
+
+
+logger = lw.initialize_module_logger("cda.csccli")
 
 verb0 = logger.verbose0
 verb1 = logger.verbose1
@@ -47,7 +52,7 @@ __all__ = (
     'get_default_columns',
     'check_required_names',
     'extra_cols_to_summarize'
-    )
+)
 
 
 fileTypes_csc1 = {
@@ -71,7 +76,7 @@ fileTypes_csc1 = {
     "psf"    : { "extn" : "psf3",    "filetype" : "psf",        "version" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
     "lc"     : { "extn" : "lc3",     "filetype" : "lightcurve", "version" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False }
     }
-    
+
 
 fileTypes_cur = {
     "evt"    : { "extn" : "evt3",    "filetype" : "evt3",       "prodlevel" : "obi", "obilevel" : True,  "bands" : False,  "acisonly" : False },
@@ -100,7 +105,7 @@ fileTypes_cur = {
     "draws"   : { "extn" : "draws3",  "filetype" : "draws",      "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
     "aperphot": { "extn" : "phot3",   "filetype" : "aperphot",   "prodlevel" : "src", "obilevel" : False, "bands" : True ,  "acisonly" : False },
 
-    # Stack 
+    # Stack
     "stkevt"      : { "extn" : "evt3",    "filetype" : "stkevt3",    "prodlevel" : "stk", "obilevel" : True , "bands" : False,  "acisonly" : False },
     "stkfov"      : { "extn" : "fov3",    "filetype" : "stkfov3",    "prodlevel" : "stk", "obilevel" : True , "bands" : False,  "acisonly" : False },
     "stkecorrimg" : { "extn" : "img3",    "filetype" : "stkecorrimg","prodlevel" : "stk", "obilevel" : True , "bands" : True ,  "acisonly" : False },
@@ -130,7 +135,7 @@ fileTypes = {
 }
 
 
-bands = { 
+bands = {
     "ACIS" : { 'broad' : 'b', 'soft' : 's', 'medium' : 'm', 'hard' : 'h', 'ultrasoft' : 'u' },
     "HRC"  : { 'wide' : 'w' }
     }
@@ -138,10 +143,10 @@ bands = {
 matchtypes = {
     'a' : 'confused',
     'u' : 'unique'
-}   
+}
 
 
-default_cols="""
+default_cols = """
 m.name,
 m.ra,
 m.dec,
@@ -207,21 +212,21 @@ o.var_index_w
 """.replace("\n", "").split(",")
 
 
-csc1_columns = { 
+csc1_columns = {
     'master_source_basic_summary' : """
     m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,
     m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,
     m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,
     m.flux_aper_hilim_w
     """.replace("\n", "").replace(" ","").split(",") ,
-    
+
     'master_source_summary' : """
     m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
     m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,
     m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.extent_flag,
     m.hard_hm,m.hard_hm_lolim,m.hard_hm_hilim,m.hard_ms,m.hard_ms_lolim,
     m.hard_ms_hilim,m.var_intra_index_b,m.var_inter_index_b,
-    m.var_intra_index_w,m.var_inter_index_w 
+    m.var_intra_index_w,m.var_inter_index_w
     """.replace("\n", "").replace(" ","").split(",") ,
 
     'master_source_photometry':"""
@@ -235,7 +240,7 @@ csc1_columns = {
     m.flux_powlaw_aper_w,m.flux_powlaw_aper_lolim_w,
     m.flux_powlaw_aper_hilim_w,m.flux_bb_aper_b,m.flux_bb_aper_lolim_b,
     m.flux_bb_aper_hilim_b,m.flux_bb_aper_w,m.flux_bb_aper_lolim_w,
-    m.flux_bb_aper_hilim_w 
+    m.flux_bb_aper_hilim_w
     """.replace("\n", "").replace(" ","").split(","),
 
     'master_source_variability': """
@@ -263,8 +268,8 @@ csc1_columns = {
     o.src_rate_aper_w,o.flux_aper_b,o.flux_aper_lolim_b,
     o.flux_aper_hilim_b,o.flux_aper_w,o.flux_aper_lolim_w,
     o.flux_aper_hilim_w,o.hard_hm,o.hard_hm_lolim,o.hard_hm_hilim,
-    o.hard_ms,o.hard_ms_hilim,o.hard_ms_lolim,o.var_index_b,o.var_index_w 
-    """.replace("\n", "").replace(" ","").split(","), 
+    o.hard_ms,o.hard_ms_hilim,o.hard_ms_lolim,o.var_index_b,o.var_index_w
+    """.replace("\n", "").replace(" ","").split(","),
 
     'source_observation_photometry' : """
     m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
@@ -279,8 +284,8 @@ csc1_columns = {
     o.flux_aper_hilim_w,o.flux_aper_s,o.flux_aper_lolim_s,
     o.flux_aper_hilim_s,o.flux_aper_m,o.flux_aper_lolim_m,
     o.flux_aper_hilim_m,o.flux_aper_h,o.flux_aper_lolim_h,
-    o.flux_aper_hilim_h 
-    """.replace("\n", "").replace(" ","").split(","), 
+    o.flux_aper_hilim_h
+    """.replace("\n", "").replace(" ","").split(","),
 
     'source_observation_variability' :"""
     m.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,
@@ -293,12 +298,12 @@ csc1_columns = {
     o.var_mean_w,o.var_sigma_w,o.ks_prob_s,o.kp_prob_s,o.var_prob_s,
     o.var_index_s,o.var_mean_s,o.var_sigma_s,o.ks_prob_m,o.kp_prob_m,
     o.var_prob_m,o.var_index_m,o.var_mean_m,o.var_sigma_m,o.ks_prob_h,
-    o.kp_prob_h,o.var_prob_h,o.var_index_h,o.var_mean_h,o.var_sigma_h 
+    o.kp_prob_h,o.var_prob_h,o.var_index_h,o.var_mean_h,o.var_sigma_h
     """.replace("\n", "").replace(" ","").split(",")
 }
 
 
-csc2_columns = { 
+csc2_columns = {
   'master_source_basic_summary' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w'.split(","),
   'master_source_summary' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.extent_flag,m.hard_hm,m.hard_hm_lolim,m.hard_hm_hilim,m.hard_ms,m.hard_ms_lolim,m.hard_ms_hilim,m.var_intra_index_b,m.var_inter_index_b,m.var_intra_index_w,m.var_inter_index_w'.split(","),
   'master_source_photometry' : 'm.name,m.ra,m.dec,m.err_ellipse_r0,m.conf_flag,m.sat_src_flag,m.significance,m.flux_aper_b,m.flux_aper_lolim_b,m.flux_aper_hilim_b,m.flux_aper_w,m.flux_aper_lolim_w,m.flux_aper_hilim_w,m.flux_aper_s,m.flux_aper_lolim_s,m.flux_aper_hilim_s,m.flux_aper_m,m.flux_aper_lolim_m,m.flux_aper_hilim_m,m.flux_aper_h,m.flux_aper_lolim_h,m.flux_aper_hilim_h,m.flux_powlaw_aper_b,m.flux_powlaw_aper_lolim_b,m.flux_powlaw_aper_hilim_b,m.flux_powlaw_aper_w,m.flux_powlaw_aper_lolim_w,m.flux_powlaw_aper_hilim_w,m.flux_bb_aper_b,m.flux_bb_aper_lolim_b,m.flux_bb_aper_hilim_b,m.flux_bb_aper_w,m.flux_bb_aper_lolim_w,m.flux_bb_aper_hilim_w'.split(","),
@@ -311,8 +316,7 @@ csc2_columns = {
 }
 
 
-
-required_cols="""
+required_cols = """
 m.name,
 m.ra,
 m.dec,
@@ -323,28 +327,25 @@ o.region_id,
 a.match_type
 """.replace("\n", "").split(",")
 
-__all_retieved_files__={}
+__all_retieved_files__ = {}
 
 __filename_cache__ = []
 
 __filename_version_db__ = {}
 
-import os
-
-
 
 def get_radec_lim( ra_deg, dec_deg, radius_arcmin ):
     """
     To improve performance, the dbo.cone_dist() search is augmented with
-    a range check on ra and dec.  Need special logic to deal with 
+    a range check on ra and dec.  Need special logic to deal with
     ra's crossing 0:360 and for decs at the poles.
-    
+
     This will return two conditional expressions that are added
-    to the CSC query.    
+    to the CSC query.
     """
     from math import cos, radians
     radius_deg = radius_arcmin / 60.0
-    cos_rad = radius_deg / cos( radians( dec_deg )) 
+    cos_rad = radius_deg / cos( radians( dec_deg ))
     ra_min = ra_deg - cos_rad
     ra_max = ra_deg + cos_rad
 
@@ -360,11 +361,11 @@ def get_radec_lim( ra_deg, dec_deg, radius_arcmin ):
     dec_max = dec_deg + radius_deg
 
     if ( dec_min < -90 ) | ( dec_max > 90 ):
-        #Crosses pole, so all ra's are allowed.  
-        #CSCView is OK w/ dec outside -90:90 
-        ra_condition = "m.ra >= 0"    
+        #Crosses pole, so all ra's are allowed.
+        #CSCView is OK w/ dec outside -90:90
+        ra_condition = "m.ra >= 0"
     dec_condition = "m.dec BETWEEN {0:.8f} AND {1:.8f}".format( dec_min, dec_max)
-    
+
     return ra_condition, dec_condition
 
 
@@ -373,33 +374,34 @@ def make_URL_request( resource, vals ):
     Query and retrieve results from resourse using dictionary of
     vals values.
     """
-    import six.moves.urllib as urllib
+    from urllib.parse import urlencode
+    from urllib.request import Request, urlopen
 
     verb5( "Querying resource " + resource )
     verb5( "with parameters" + str( vals ) )
 
-    params = urllib.parse.urlencode( vals )  # Encode into URL string, escape stuff/etc.
-    request = urllib.request.Request( resource, params.encode("ascii") )
-    request.add_header('User-Agent', 'ciao_contrib.cda.csccli/1.1') #make easy to ID in logs
+    params = urlencode( vals )  # Encode into URL string, escape stuff/etc.
+    request = Request( resource, params.encode("ascii") )
+
+    # make easy to ID in logs
+    request.add_header('User-Agent', 'ciao_contrib.cda.csccli/1.1')
 
     try:
-        response = urllib.request.urlopen( request )
+        response = urlopen( request )
         page = response.read()
 
         verb5( "URL Code: {0}".format( response.getcode() ))
         if response.getcode() != 200:
             # If we get a redirect, 30x, then fall through to curl too
             raise Exception( page )
-            
-    except:
+
+    except Exception:
         page = make_CURL_request( resource, vals )
-    
+
     if len(page) == 0:
         raise Exception("Problem accessing resource {0}".format(resource))
-    
-    
-    return page
 
+    return page
 
 
 def make_CURL_request( resource, vals ):
@@ -409,25 +411,25 @@ def make_CURL_request( resource, vals ):
     in python.
     """
 
-    import six.moves.urllib as urllib
-    params = urllib.parse.urlencode( vals )  # Encode into URL string, escape stuff/etc.
-    url = "{}?{}".format(resource,params)
+    from urllib.parse import urlencode
+
+    params = urlencode( vals )  # Encode into URL string, escape stuff/etc.
+    url = "{}?{}".format(resource, params)
 
     verb2("Contacting resource '{}'".format(url))
 
     import subprocess as sp
-    
+
     try:
-        page = sp.check_output( ['curl', '--silent', '-L', url ]) # Need the '-L' to enable curl to follow redirect 
+        page = sp.check_output( ['curl', '--silent', '-L', url ]) # Need the '-L' to enable curl to follow redirect
     except Exception as e:
         print(e)
         raise
-    
+
     if len(page) == 0:
         raise RuntimeError("Problem accessing resource {0}".format(resource))
 
     return page
-
 
 
 def cone_query_cli_cscview( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_condition, columns):
@@ -444,13 +446,13 @@ def cone_query_cli_cscview( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_co
     selstr+=",".join(columns)
 
     query_string="""
-        SELECT 
+        SELECT
           {5}
-        FROM 
-          master_obi_assoc a , master_source m , obi_source o 
-        WHERE 
-          ({3}) AND 
-          ({4}) AND   
+        FROM
+          master_obi_assoc a , master_source m , obi_source o
+        WHERE
+          ({3}) AND
+          ({4}) AND
           dbo.cone_distance(ra,dec,{0:.8f},{1:.8f})<={2:.8f} AND
           a.posid=o.posid  AND a.msid=m.msid
         ORDER BY
@@ -462,16 +464,16 @@ def cone_query_cli_cscview( ra_deg, dec_deg, radius_arcmin, ra_condition, dec_co
     vals = {
         'query' : " ".join(query_string.split()) , # removes excess white spaces
         'coordFormat' : 'decimal',
-        'nullAppearance' : 'NaN'        
-        } 
+        'nullAppearance' : 'NaN'
+        }
 
     page = make_URL_request( resource, vals )
     page = page.decode("ascii")
-    
+
     if "Error executing query:" in page:
         k=page.replace( "\n", " ")
         raise Exception( k )
-        
+
     cols = ["sep"]
     cols.extend( columns )
     return page,cols
@@ -491,13 +493,13 @@ def cone_query_cli_cscview_ver2( ra_deg, dec_deg, radius_arcmin, ra_condition, d
     selstr+=",".join(columns)
 
     query_string="""
-        SELECT 
+        SELECT
           {5}
-        FROM 
-          master_source m , master_stack_assoc a , observation_source o , stack_observation_assoc b , stack_source s 
-        WHERE 
-          ((( ({3}) AND 
-          ({4})) AND   
+        FROM
+          master_source m , master_stack_assoc a , observation_source o , stack_observation_assoc b , stack_source s
+        WHERE
+          ((( ({3}) AND
+          ({4})) AND
           dbo.cone_distance(m.ra,m.dec,{0:.8f},{1:.8f})<={2:.8f})) AND
           (m.name = a.name) AND (s.detect_stack_id = a.detect_stack_id and s.region_id = a.region_id) AND (s.detect_stack_id = b.detect_stack_id and s.region_id = b.region_id) AND (o.obsid = b.obsid and o.obi = b.obi and o.region_id = b.region_id)
         ORDER BY
@@ -511,17 +513,15 @@ def cone_query_cli_cscview_ver2( ra_deg, dec_deg, radius_arcmin, ra_condition, d
         'version' : 'cur',
         'coordFormat' : 'decimal',
         'nullAppearance' : 'NaN',
-        } 
-
-
+        }
 
     page = make_URL_request( resource, vals )
     page = page.decode("ascii")
-    
+
     if "Error executing query:" in page:
         k=page.replace( "\n", " ")
         raise Exception( k )
-        
+
     cols = ["sep"]
     cols.extend( columns )
     return page,cols
@@ -530,7 +530,7 @@ def cone_query_cli_cscview_ver2( ra_deg, dec_deg, radius_arcmin, ra_condition, d
 def obsid_query_cli_cscview( obsid, columns ):
     """
     Perform the cone search query on the CSC using the getProperties API.
-    
+
     """
 
     resource="http://cda.cfa.harvard.edu/csccli/getProperties"
@@ -540,10 +540,10 @@ def obsid_query_cli_cscview( obsid, columns ):
     query_string="""
         SELECT
           {1}
-        FROM 
-          master_obi_assoc a , master_source m , obi_source o 
-        WHERE 
-          o.obsid IN ({0}) AND 
+        FROM
+          master_obi_assoc a , master_source m , obi_source o
+        WHERE
+          o.obsid IN ({0}) AND
           a.posid=o.posid  AND a.msid=m.msid
         ORDER BY
           name ASC
@@ -554,25 +554,24 @@ def obsid_query_cli_cscview( obsid, columns ):
     vals = {
         'query' : " ".join(query_string.split()) , # removes excess white spaces
         'coordFormat' : 'decimal',
-        'nullAppearance' : 'NaN'        
-        } 
+        'nullAppearance' : 'NaN'
+        }
 
     page = make_URL_request( resource, vals )
     page = page.decode("ascii")
     if "Error executing query:" in page:
         k=page.replace( "\n", " ")
         raise Exception( k )
-        
 
     cols = columns
-    
+
     return page,cols
 
 
 def obsid_query_cli_cscview_ver2( obsid, columns ):
     """
     Perform the cone search query on the CSC using the getProperties API.
-    
+
     """
 
     resource="http://cda.cfa.harvard.edu/csccli/getProperties"
@@ -582,10 +581,10 @@ def obsid_query_cli_cscview_ver2( obsid, columns ):
     query_string="""
         SELECT
           {1}
-        FROM 
-          master_source m , master_stack_assoc a , observation_source o , stack_observation_assoc b , stack_source s 
-        WHERE 
-          ((o.obsid IN ({0}))) AND 
+        FROM
+          master_source m , master_stack_assoc a , observation_source o , stack_observation_assoc b , stack_source s
+        WHERE
+          ((o.obsid IN ({0}))) AND
           (m.name = a.name) AND (s.detect_stack_id = a.detect_stack_id and s.region_id = a.region_id) AND (s.detect_stack_id = b.detect_stack_id and s.region_id = b.region_id) AND (o.obsid = b.obsid and o.obi = b.obi and o.region_id = b.region_id)
         ORDER BY
           name ASC
@@ -598,17 +597,16 @@ def obsid_query_cli_cscview_ver2( obsid, columns ):
         'coordFormat' : 'decimal',
         'nullAppearance' : 'NaN',
         'version' : 'cur'
-        } 
+        }
 
     page = make_URL_request( resource, vals )
     page = page.decode("ascii")
     if "Error executing query:" in page:
         k=page.replace( "\n", " ")
         raise Exception( k )
-        
 
     cols = columns
-    
+
     return page,cols
 
 
@@ -637,7 +635,7 @@ def summarize_properties( cols, results ):
             retstr += cc[1].format( cc[2]( mysrc[cc[0]]))
             retstr += "\t"
         verb1( retstr)
-        
+
     #verb1("\nIf you use this data, please cite Evans et al 2010, ApJS 189, 37\n")
 
 
@@ -663,17 +661,16 @@ def summarize_source_short( results, units, extracols=None ):
     Provide a short on-screen summary of results
     """
     # TODO: should probaly use a named tuple or dict instead of list
-    
-    #This list contains a 3-tuple:
+
+    # This list contains a 3-tuple:
     #   column name
     #   format
-    #   conversion function   
+    #   conversion function
     cols = [ ("name", "{:20s}", str),
              ("ra" , "{:12s}", str),
              ("dec","{:12s}", str),
              ("obsid","{:5s}", str),
              ]
-             
 
     if 'sepn' in results[0]:
         if "arcsec" == units:
@@ -684,15 +681,14 @@ def summarize_source_short( results, units, extracols=None ):
             fun = __arcsec_to_deg
         else:
             raise ValueError("Unknown units")
-        
+
         cols.insert(3, ("sepn", "{}", fun ))
-    
+
     if extracols:
         for ecol in extracols:
             if ecol not in ["name", "ra", "dec", "obsid"]:
                 cols.append( (ecol, "{}", str ) )
 
-             
     summarize_properties( cols, results )
 
 
@@ -703,7 +699,7 @@ def extra_cols_to_summarize( mysrcs, requested_cols, cat_ver ):
     if both obi and master level properties are returned.
     """
     import stk as stk
-    
+
     if "INDEF" == requested_cols or len(requested_cols) == 0:
         return None
 
@@ -711,14 +707,14 @@ def extra_cols_to_summarize( mysrcs, requested_cols, cat_ver ):
 
     if len(mysrcs) == 0:
         return None
-        
+
     row = mysrcs[0]
 
     retval = []
     for rc in rc_stk:
         just_name = rc.split()  # col name may be o.blah as obi_ already
         rc_parts = just_name[0].split(".")
-        
+
         if len(rc_parts) == 1:
             if rc_parts[0] in row and rc_parts[0] not in retval:
                 retval.append( rc_parts[0] )
@@ -738,7 +734,6 @@ def extra_cols_to_summarize( mysrcs, requested_cols, cat_ver ):
             raise IOError("Column {} was not returned by cscview".format( rc ))
 
     return retval
-    
 
 
 def summarize_results( results, units="arcmin", extracols=None):
@@ -757,16 +752,16 @@ def summarize_results( results, units="arcmin", extracols=None):
 
     if len(results) > 0:
         summarize_source_short(results, units, extracols)
-    
+
 
 def parse_csc_result( page_and_cols ):
     """
     The table returned is TSV format.  First N-many rows are "#" comments
     with column information, one for each column
-    
+
     Then 1 row w/ column names, tab separated (no comment character)
     Then 1 row for each source, values are tab separated will contain spaces.
-    
+
     finished off with 1 blank line.
 
         #Column sepn      (E9.6)          (.sepn)   [""]    []
@@ -774,17 +769,17 @@ def parse_csc_result( page_and_cols ):
         sepn      name    ra      dec     err_ellipse_r0  conf_flag ...
         1.555089e+01    CXO J162623.5-242439     16 26 23.59    -24 24 39.58       0.44 TRUE
         ...
-    
+
     We parse this into a list of dictionaries.  Each item in the list
     is 1 row with a dictionary of columnname = value.
-    
+
     Currenly we only use the name, region_id, obsid, and obi but other values
     are available for future expansion.
-    
+
     """
     #
     # parse rows, make list of lists
-    # 
+    #
     page = page_and_cols[0]
     cols = page_and_cols[1]
 
@@ -807,8 +802,8 @@ def parse_csc_result( page_and_cols ):
     # we add an extra dictionary item, ["tag"] that is obsid_obi
     # which is used in the file names and in the directories.
     for pp in retvals:
-        pp["tag"]="{0:05d}_{1:03d}".format( int(pp["obsid"]),int(pp["obi"])) 
-    
+        pp["tag"]="{0:05d}_{1:03d}".format( int(pp["obsid"]),int(pp["obi"]))
+
     return retvals
 
 
@@ -818,24 +813,23 @@ def fix_dm_no_g_type( page ):
       cscview returns.  The distinction between D, E, F and G,
       are only on output.  When read in, they are all parsed the
       same (atof or strtod) so we can just change the "(Gnumber)"
-      to be "(Fnumber)"    
+      to be "(Fnumber)"
     """
     import re as re
-    
-    fixed = re.sub( '\(G[0-9\.]*\)',
-                lambda x: x.group(0).replace("G", "F"),
-                page )
-    return fixed
 
+    fixed = re.sub(r'\(G[0-9\.]*\)',
+                   lambda x: x.group(0).replace("G", "F"),
+                   page)
+    return fixed
 
 
 def save_results( page_and_cols, outfile, clobber ):
     """
     DM ascii kernel can read .tsv format returned by cscview just
     need to be told that it is tsv format.
-    
+
     dmlist out.tsv[opt kernel=text/tsv] cols
-    
+
     """
     page = page_and_cols[0]
     cols = page_and_cols[1]
@@ -847,18 +841,18 @@ def save_results( page_and_cols, outfile, clobber ):
         return
 
     outfile_clobber_checks( clobber, outfile )
-    
+
     p2 = fix_dm_no_g_type( page )
     with open( outfile, "w+") as fp:
         fp.write( p2 )
-    
+
 
 def search_src_by_ra_dec( ra, dec, radius_arcmin, columns, cat_ver ):
     """
     Perform a cone search on CSC CLI.
-    """    
+    """
     from coords.format import sex2deg
-    ra_deg,dec_deg = sex2deg(ra, dec ) 
+    ra_deg,dec_deg = sex2deg(ra, dec )
     ra_condition, dec_condition = get_radec_lim( ra_deg, dec_deg, radius_arcmin )
 
     if "csc1" == cat_ver:
@@ -869,12 +863,12 @@ def search_src_by_ra_dec( ra, dec, radius_arcmin, columns, cat_ver ):
         raise ValueError("Unknown catalog version")
 
     return page
-    
+
 
 def search_src_by_obsid( obsid, columns, cat_ver ):
     """
     Perform a obsid search on CSC CLI.
-    """    
+    """
 
     if 'csc1' == cat_ver :
         page = obsid_query_cli_cscview( obsid, columns )
@@ -883,7 +877,6 @@ def search_src_by_obsid( obsid, columns, cat_ver ):
     else:
         raise ValueError("Unknown catalog version")
     return page
-
 
 
 #~ def find_filename_match_in_rows( rows, filetype, obsid, obi, region, band, instrume):
@@ -897,7 +890,7 @@ def search_src_by_obsid( obsid, columns, cat_ver ):
         #~ regs = rows
 
     #~ if band:
-        #~ # Look for band_ 
+        #~ # Look for band_
         #~ bnds = filter( lambda x: "{0}_".format(band) in x, regs)
     #~ else:
         #~ bnds = regs
@@ -909,13 +902,12 @@ def search_src_by_obsid( obsid, columns, cat_ver ):
     #~ # Finally filter on obi number, usually a no-op
     #~ obis = filter( lambda x: "f{0:05d}_{1:03d}N".format(int(obsid),int(obi)) in x, ftyp )
 
-
     #~ # Check return, should have 1 row left from service
     #~ if len(obis) > 1:
         #~ oo = [ o.split("\t")[0] for o in obis ]
         #~ oo.sort()
         #~ obis=[oo[-1]]  # sort, take last one, highest version
-        #~ verb2("Found multiple files for {0}\n".format( (filetype, obsid, obi, region, band, instrume)))        
+        #~ verb2("Found multiple files for {0}\n".format( (filetype, obsid, obi, region, band, instrume)))
         #~ #raise IOError("Only 1 file should be found")
     #~ if len(obis) == 0 :
         #~ raise IOError("No files found matching query")
@@ -924,14 +916,10 @@ def search_src_by_obsid( obsid, columns, cat_ver ):
     #~ return filename
 
 
-
-
-
-
 def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
     """
     This is only for catalog='csc1'
-    
+
     """
     global __filename_version_db__
     if 0 == len(__filename_version_db__):
@@ -939,18 +927,18 @@ def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
         tab = tab.decode("ascii")
         __filename_version_db__ = {}
         for row in tab.split("\n"):
-            vals = row.split()            
+            vals = row.split()
             if len(vals) == 5:
                 __filename_version_db__[vals[0]] = { 'calver' : vals[3], 'detver' : vals[1], 'srcver' : vals[2], 'inst' : vals[4] }
             else:
                 pass
     obistr = "{0:05d}_{1:03d}".format( int(obsid), int(obi) )
     filename = "{0}f{1}N".format( instrume.lower(),obistr)
-    
+
     if obistr not in __filename_version_db__:
         print("Version info not available for {}".format(obistr))
         return None
-        
+
     if fileTypes['csc1'][filetype]["version"] == "cal":
         ver = __filename_version_db__[obistr]["calver"]
     elif fileTypes['csc1'][filetype]["version"] == "det":
@@ -966,16 +954,14 @@ def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
         pass
     else:
         filename += "r{:04d}".format( int(region))
-    
+
     if fileTypes['csc1'][filetype]["bands"]:
-        
+
         filename += band
-    
+
     filename += "_"+fileTypes['csc1'][filetype]["extn"]+".fits"
-    
+
     return filename.replace("__", "_")
-    
-        
 
 
 #~ def discover_filename_from_archive( filetype, obsid, obi, region, band, instrume):
@@ -985,9 +971,6 @@ def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
     #~ observation info
     #~ """
 
-
-
-    
     #~ filename = ""
     #~ try:
         #~ # try cache of filenames 1st
@@ -1017,11 +1000,11 @@ def discover_filename_by_force( filetype, obsid, obi, region, band, instrume):
 def discover_filename_via_archive(myfile, obsid, obi, region, band, instrume):
     """
     Use the csccli browse interface for release 2 file names.
-    
+
     """
 
-    pkg = "{obs}.{obi}.{reg}/{typ}/{band}".format( 
-        obs=obsid.strip(), obi=obi.strip(), 
+    pkg = "{obs}.{obi}.{reg}/{typ}/{band}".format(
+        obs=obsid.strip(), obi=obi.strip(),
         reg=region.strip(), typ=myfile, band=band)
 
     resource = "http://cda.cfa.harvard.edu/csccli/browse"
@@ -1037,11 +1020,10 @@ def discover_filename_via_archive(myfile, obsid, obi, region, band, instrume):
         import json as json
         retval = json.loads(qry)
         filename = [ f["filename"] for f in retval ]
-    except:
+    except Exception:
         filename = [None]
 
-    return filename[0]    
-
+    return filename[0]
 
 
 def discover_filenames_per_type( mysrc, myfile, mybands, catalog ):
@@ -1049,11 +1031,10 @@ def discover_filenames_per_type( mysrc, myfile, mybands, catalog ):
     To discover the filename we need to make a wide query to the
     archive for data products associated with the obisid
     for the filetype.  Then we will parse by band, obi, and
-    region id.    
+    region id.
     """
     myfileType = fileTypes[catalog][myfile]
     myinst = mysrc["instrument"].replace(" ", "")
-
 
     if ("ACIS" != myinst ) & myfileType["acisonly"]:
         verb1("{0} is not available for {1} observation {2}".format( myfile, myinst, mysrc["tag"]))
@@ -1068,9 +1049,9 @@ def discover_filenames_per_type( mysrc, myfile, mybands, catalog ):
         filenames = []
         for name in bands[ myinst ]:
             abbrv=bands[myinst][name]
-            # compare list of all bands to those requested 
+            # compare list of all bands to those requested
             if name not in mybands.split(","):
-                continue            
+                continue
 
             if 'csc1' == catalog:
                 ff = discover_filename_by_force( myfile, mysrc["obsid"], mysrc["obi"], rr, abbrv, myinst )
@@ -1082,11 +1063,11 @@ def discover_filenames_per_type( mysrc, myfile, mybands, catalog ):
             ff = discover_filename_by_force( myfile , mysrc["obsid"], mysrc["obi"], rr, "", myinst )
         else:
             ff = discover_filename_via_archive( myfileType["filetype"], mysrc["obsid"], mysrc["obi"], rr, "", myinst )
-        filenames = [ ff ]    
-    
+        filenames = [ ff ]
+
     return filenames
 
-    
+
 def check_existing( ff, off ):
     """
     Check if a file exists or has already been downloaded
@@ -1096,26 +1077,26 @@ def check_existing( ff, off ):
     if exists( off ) :
         verb2("File {0} already exists".format(off))
         return True
-        
+
     if exists( off+".gz" ):
         verb2("File {0}.gz already exists".format(off))
         return True
-    
+
     if ff in __all_retieved_files__:
         verb2("File {0} already retrieved, will make a copy".format(ff))
         import shutil as shutil
         shutil.copyfile( __all_retieved_files__[ff]+"/{0}.gz".format(ff) , off+".gz")
         return True
-    
+
     return False
 
 
 def retrieve_files_per_type( filenames, filetype, root, catalog ):
     """
     Retrieve the files using the retrieveFile interface.
-    
+
     This requires the file name and the file type.
-    
+
     Added extra logic to skip if the file already exists on
     disk. Also if already retrieve, then skip.  File may
     already have been retrieved if the source is an
@@ -1128,22 +1109,21 @@ def retrieve_files_per_type( filenames, filetype, root, catalog ):
             continue
 
         off = root + os.sep + ff # path + filename
-    
+
         if check_existing( ff, off ):
             continue
 
         resource = "http://cda.cfa.harvard.edu/csccli/retrieveFile"
-        vals = { 
+        vals = {
             "filetype" : fileTypes[catalog][filetype]["filetype"],
             "filename" : ff,
             }
         if 'cur' == catalog:
             vals['version'] = catalog
 
-
         try:
             page = make_URL_request( resource, vals )
-        except:
+        except Exception:
             verb0("Problem retrieveing file {0}".format(ff))
             raise
 
@@ -1152,7 +1132,7 @@ def retrieve_files_per_type( filenames, filetype, root, catalog ):
             fp.write(page)
 
         verb1("Retrieved file {}".format(off))
-        
+
         # Save file name and directory where 1st saved
         __all_retieved_files__[ff] = root
 
@@ -1169,7 +1149,7 @@ def create_output_dir( inroot, mysrc, myfiletype, byObi, catalog ):
             if not fileTypes[catalog][myfiletype]["obilevel"]:
                 root += (os.sep+mysrc["name"]).replace(" ", "")
 
-        else:    
+        else:
             root = (inroot+os.sep+mysrc["name"]+os.sep+mysrc["tag"] ).replace(" ","") # remove space in name
             if not fileTypes[catalog][myfiletype]["obilevel"]:
                 root += os.sep+"r{0:04d}".format(int(mysrc["region_id"]))
@@ -1183,30 +1163,29 @@ def create_output_dir( inroot, mysrc, myfiletype, byObi, catalog ):
                 root = os.path.join( root, mysrc["name"])
             elif fileTypes[catalog][myfiletype]["prodlevel"] == 'src':
                 root = os.path.join( root, "r{:04d}".format(int(mysrc["region_id"])))
-        else:    
+        else:
             root = os.path.join( inroot, mysrc["name"] )
             if fileTypes[catalog][myfiletype]["prodlevel"] == 'stk':
                 root = os.path.join(root, mysrc["detect_stack_id"])
             elif fileTypes[catalog][myfiletype]["prodlevel"] in ['obi','src']:
                 root = os.path.join( root, mysrc["tag"])
-                    
+
     root=root.replace(" ","")
 
     if not os.path.exists( root ):
         os.makedirs( root )
-    
+
     if not os.path.isdir( root ):
         raise IOError("{0} exists but is not a directory".format(root))
-    
+
     return root
 
 
 def process_ask( ask, pp ):
     """
-    
+
     """
-    from six.moves import input
-   
+
     if 'all' == ask:
         return 'y'
     elif 'none' == ask:
@@ -1215,7 +1194,7 @@ def process_ask( ask, pp ):
         pass
     else:
         raise NotImplementedError("Internal Error: invalid ask value")
-    
+
     while True:
         resp = input( "Download data for {} [y,n,a,q]: ".format(pp) )
         ans = resp.strip().lower()
@@ -1246,17 +1225,18 @@ def retrieve_files( mysrcs, root, myfiles, mybands, ask, catalog, byObi=False ):
             pass
         else:
             raise NotImplementedError("Internal Error: invalid ask value")
-        
+
         try:
             retrieve_files_per_src( mysrc, root, myfiles, mybands, catalog, byObi )
         except ValueError as e:
             verb0( str(e) )
             verb0("  Continuing")
 
-def retrieve_files_per_src( mysrc, inroot, myfiles, mybands, catalog, byObi=False ): 
+
+def retrieve_files_per_src( mysrc, inroot, myfiles, mybands, catalog, byObi=False ):
     """
     For a single source, loop over file types and retrieve each
-    """    
+    """
     verb1("Retrieving files for obsid_obi {}".format(mysrc["tag"]))
 
     #
@@ -1270,13 +1250,13 @@ def retrieve_files_per_src( mysrc, inroot, myfiles, mybands, catalog, byObi=Fals
         fnames = discover_filenames_per_type( mysrc, ft, mybands, catalog )
         if fnames:
             retrieve_files_per_type( fnames, ft, root, catalog )
-        
+
 
 def check_filetypes( alist, catalog ):
     """
     Check list of files against those input and shorten list
     """
-    
+
     retval=[]
     for aa in alist.split(","):
         aa=aa.strip()
@@ -1290,7 +1270,7 @@ def check_filetypes( alist, catalog ):
 def all_bands( ):
     """
     return list of all bands regardless of instrumet
-    """    
+    """
     return [ band for inst in bands for band in bands[inst]]
 
 
@@ -1307,8 +1287,9 @@ def check_bandtypes( alist ):
         else:
             verb1("Unrecongnized energy band '{0}', skipping it".format(aa))
     rr=",".join( retval )
-    
+
     return rr
+
 
 def get_default_columns(cat_version=None):
     """
@@ -1329,12 +1310,12 @@ def append_cols_check_conflict( retval, val ):
     in the per-obi source table which makes for a bad  .tsv file
     (file should not contain duplicate column names).  This routine
     will check if column is already in list and if so rename
-    it will not cause conflict.    
+    it will not cause conflict.
     """
     vv = val.split(".")
 
     ## TODO: replace dups in likely stack, detect stack, ...
-    
+
     if vv[0] == 'o':
         if "m.{}".format(vv[1]) in retval:
             verb2( "OBI column {} has same name as master column and has been renamed obi_{}".format(vv[1],vv[1]))
@@ -1359,10 +1340,10 @@ def append_cols_check_conflict( retval, val ):
             val = val + " as stk_{}".format(vv[1])
     else:
         pass
-    
-    if val not in retval:    
+
+    if val not in retval:
         retval.append(val)
-    
+
 
 def expand_standard_cols( cols, cat_version=None ):
     """
@@ -1400,7 +1381,6 @@ def expand_standard_cols( cols, cat_version=None ):
             append_cols_check_conflict( retval, cc )
 
     return retval
-        
 
 
 def check_required_names( cols, cat_version=None ):
@@ -1420,9 +1400,8 @@ def check_required_names( cols, cat_version=None ):
         if mm not in c2:
             verb2( "Required column {} was added to columns".format(mm))
             c2.insert( 0, mm )
-    
-    return c2
 
+    return c2
 
 
 def query_csc1_limsens( ra, dec ):
@@ -1432,10 +1411,10 @@ def query_csc1_limsens( ra, dec ):
     vals = {
       "ra" : str(ra),
       "dec" : str(dec),
-      "_submit_radec" : "1" 
+      "_submit_radec" : "1"
       }
-    
-    page = make_URL_request( resource, vals )    
+
+    page = make_URL_request( resource, vals )
     page = page.decode("ascii")
     return page
 
@@ -1449,10 +1428,10 @@ def parse_limsens( page ):
     The limiting sensitivity page is (bad) HTML with multiple
     html, head, and body elements so it cannot be simply parsed with
     existing routines.
-    
+
     We strip out just the sensitivity <table ... /table> data
-    and parse that into a dictionary of { 'band' : value }    
-    
+    and parse that into a dictionary of { 'band' : value }
+
     The HTML looks like
       <table stuff>
       <tr>
@@ -1465,15 +1444,15 @@ def parse_limsens( page ):
       </tr>
       </table>
 
-    which is sufficiently close to valid XML to be parsed 
+    which is sufficiently close to valid XML to be parsed
     as an xml ElementTree.
-    
+
     The a 2-element tuple is returned:
       a dictionary of band and values
-      and the units.    
+      and the units.
 
     The old CSC limsens .php only accepts POST requests, not GETs
-    so the CURL path doesn't work.  That's OK since different 
+    so the CURL path doesn't work.  That's OK since different
     server shouldn't go down that path anyways.
     """
     import re as re
@@ -1482,31 +1461,31 @@ def parse_limsens( page ):
     if mytab is None:
         raise RuntimeError("No table found in limsens results")
     mytab = mytab.group(0).replace("\n","")
-    
+
     import xml.etree.ElementTree as ET
- 
+
     tree = ET.fromstring(mytab)
     rows = tree.findall( "tr" ) # <tr>, find both rows.
     if len(rows) != 2:
         raise Exception("Should only be two rows returned by CSC LimSens service")
-    
+
     #
     # Parse columns, 1st row, they are wrapped in <th>'s.  We lower
     # case them to make dictionary easier to match
     #
-    reversebands = { 
-        'B' : 'broad', 
-        'U' : 'ultrasoft', 
-        'S' : 'soft', 
+    reversebands = {
+        'B' : 'broad',
+        'U' : 'ultrasoft',
+        'S' : 'soft',
         'M' : 'medium',
-        'H' : 'hard', 
-        'W' : 'wide', 
-        'Q' : 'q', 
-        'QW' : 'qw' 
+        'H' : 'hard',
+        'W' : 'wide',
+        'Q' : 'q',
+        'QW' : 'qw'
         }
 
     cols = [ reversebands[ee.text]  for ee in rows[0].findall("th")]
-    
+
     #
     # Parse the values, 2nd row, they are wrapped in <td>'s.
     # When the area is not covered, the limsens returns a
@@ -1516,4 +1495,3 @@ def parse_limsens( page ):
     vals = [ ee.text.strip().replace("-999", "NaN")  for ee in rows[1].findall("td")]
 
     return dict(zip( cols, vals )), "photons/cm^2/s"
-

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/data.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/data.py
@@ -204,11 +204,12 @@ def extract_file_type(fname):
         return "oif"
     if fn.lower() == "00readme":
         return "readme"
-    if fn.find("vv") != -1:
+    if 'vv' in fn:
         return "vv"
 
     for ft in known_file_types:
-        if fn.find("_{}".format(ft)) != -1:
+        suffix = '_{}'.format(ft)
+        if suffix in fn:
             return ft
 
     return None
@@ -339,18 +340,12 @@ class ObsIdFile:
     def is_type(self, types):
         """Given a list of file types, returns True if
         the file is one of these types."""
-        for ft in types:
-            if ft == self.filetype:
-                return True
-        return False
+        return self.filetype in types
 
     def is_format(self, formats):
         """Given a list of file formats, returns True if
         the file is one of these formats."""
-        for ff in formats:
-            if ff == self.fileformat:
-                return True
-        return False
+        return self.fileformat in formats
 
     def get_filesize(self, ftp):
         """Returns the file size in bytes.

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/data.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/cda/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016, 2017
+#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -48,7 +48,7 @@ import time
 import socket
 import ftplib
 
-from six.moves import urllib
+from urllib.parse import urlparse
 
 import ciao_contrib.logger_wrapper as lw
 
@@ -112,6 +112,7 @@ class LoggingFile:
                 self.outfp.write('#' * nh)
 
             self.outfp.flush()
+
 
 __mirror_environ = "CDA_MIRROR_SITE"
 
@@ -181,7 +182,7 @@ known_file_types = [
     "sum", "pha2", "dtf", "plt",
     "adat",  # adat71 are PCAD Level 1 ACA image data files,
     "readme"
-    ]
+]
 known_file_types_str = known_file_types[:]
 known_file_types_str.sort()
 known_file_types_str = " ".join(known_file_types_str)
@@ -199,15 +200,19 @@ def extract_file_type(fname):
     if fn[-1] == "/":
         return None
 
-    if fn == "oif.fits": return "oif"
-    if fn.lower() == "00readme": return "readme"
-    if fn.find("vv") != -1: return "vv"
+    if fn == "oif.fits":
+        return "oif"
+    if fn.lower() == "00readme":
+        return "readme"
+    if fn.find("vv") != -1:
+        return "vv"
 
     for ft in known_file_types:
-        if fn.find("_%s" % ft) != -1:
+        if fn.find("_{}".format(ft)) != -1:
             return ft
 
     return None
+
 
 known_file_formats = ["fits", "jpg", "pdf", "ps", "html", "ascii"]
 known_file_formats.sort()
@@ -223,7 +228,8 @@ def extract_file_format(fname):
     if fn[-1] == "/":
         return None
 
-    if fname == "00README": return "ascii"
+    if fname == "00README":
+        return "ascii"
 
     for ff in known_file_formats:
         if fn.find(ff) != -1:
@@ -334,14 +340,16 @@ class ObsIdFile:
         """Given a list of file types, returns True if
         the file is one of these types."""
         for ft in types:
-            if ft == self.filetype: return True
+            if ft == self.filetype:
+                return True
         return False
 
     def is_format(self, formats):
         """Given a list of file formats, returns True if
         the file is one of these formats."""
         for ff in formats:
-            if ff == self.fileformat: return True
+            if ff == self.fileformat:
+                return True
         return False
 
     def get_filesize(self, ftp):
@@ -366,7 +374,7 @@ class ObsIdFile:
 
             try:
                 ftp.retrlines("LIST " + path, hdlr)
-            except:
+            except Exception:
                 v3("Problem parsing LIST for filesize of " + path)
                 self.filesize = ftp.size(path)
 
@@ -505,11 +513,11 @@ class ObsId:
 
         # Hard code the directories rather than use a generic parser
         #
-        topfiles  = ftp.nlst()
+        topfiles = ftp.nlst()
         primfiles = ftp.nlst("primary")
-        secfiles  = ftp.nlst("secondary")
-        ephfiles  = ftp.nlst("secondary/ephem")
-        aspfiles  = ftp.nlst("secondary/aspect")
+        secfiles = ftp.nlst("secondary")
+        ephfiles = ftp.nlst("secondary/ephem")
+        aspfiles = ftp.nlst("secondary/aspect")
         infiles = topfiles + primfiles + secfiles + ephfiles + aspfiles
 
         self.files = [ObsIdFile(obsid, f) for f in infiles
@@ -581,7 +589,7 @@ def _parse_mirror(mirror, username=None, userpass=None):
     DEFAULT_USERNAME and DEFAULT_PASSWORD respectively.
     """
 
-    url = urllib.parse.urlparse(mirror)
+    url = urlparse(mirror)
 
     # The ftp scheme is required to make it easier to support
     # other schemes (e.g. file:// for local access) in the future.

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/parallel_wrapper.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/parallel_wrapper.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
-# Python35Support
-
 #
-#  Copyright (C) 2011, 2015, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016, 2019
+#                Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -40,14 +39,11 @@ http://www.bryceboe.com/2010/08/26/python-multiprocessing-and-keyboardinterrupt/
 
 """
 
-import six
-from six.moves import queue
-
 import time
 import signal
 import multiprocessing
+from queue import Empty
 
-# from ciao_contrib.logger_wrapper import initialize_module_logger
 from .logger_wrapper import initialize_module_logger
 
 __all__ = ("parallel_pool", )
@@ -75,7 +71,7 @@ def task(func, arg_queue, result_queue):
             ans = func(arg)
             result_queue.put((i, ans))
 
-        except queue.Empty:
+        except Empty:
             pass
 
 
@@ -120,7 +116,7 @@ def parallel_pool(func, args, ncores=None):
     v4("# Parallel start time: {0}".format(time.asctime(stime)))
 
     workers = []
-    for i in six.moves.range(nc):
+    for i in range(nc):
         v5("# Starting parallel worker: {0}".format(i + 1))
         w = multiprocessing.Process(target=task,
                                     args=(func, job_queue, result_queue))

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/proptools.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/proptools.py
@@ -1,7 +1,5 @@
 #
-# Python35Support
-#
-# Copyright (C) 2013, 2014, 2015, 2016
+# Copyright (C) 2013, 2014, 2015, 2016, 2019
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -94,8 +92,6 @@ import numpy as np
 
 import datetime
 
-import six
-
 __all__ = ("colden", "precess", "dates")
 
 # Allow use in a system without the logging code, as it is not
@@ -146,14 +142,7 @@ def _run_proc(label, args):
     v4("* {} output: stdout={}".format(label, sout))
     v4("* {} output: stderr={}".format(label, serr))
 
-    # Python 2.7 returns a string for sout, Python 3.5 returns
-    # bytes.
-    #
-    # Question: is this the best approach?
-    if not six.PY2:
-        sout = sout.decode()
-
-    return rval, sout
+    return rval, sout.decode()
 
 
 def _colden(ra, dec, dataset):
@@ -250,11 +239,11 @@ def colden(ra, dec, dataset='NRAO'):
         raise ValueError("Invalid dataset={}; must be NRAO or Bell".format(dataset))
 
     try:
-        args = six.moves.zip(ra, dec)
+        args = zip(ra, dec)
         multi = True
 
     except TypeError:
-        args = six.moves.zip([ra], [dec])
+        args = zip([ra], [dec])
         multi = False
 
     args = list(args)
@@ -442,20 +431,20 @@ def precess(x, y, fromsys="B", tosys="J", fromfmt="DEG", tofmt="DEG"):
 
     if ffmt == "DEG":
         try:
-            args = six.moves.zip(x, y)
+            args = zip(x, y)
             multi = True
 
         except TypeError:
-            args = six.moves.zip([x], [y])
+            args = zip([x], [y])
             multi = False
 
     elif ffmt == "HMS":
         try:
             # let np.asarray worry about converting "foo" into ["foo"]
-            args = six.moves.zip(np.asarray(x), np.asarray(y))
+            args = zip(np.asarray(x), np.asarray(y))
             multi = True
         except TypeError:
-            args = six.moves.zip([x], [y])
+            args = zip([x], [y])
             multi = False
 
     else:
@@ -473,7 +462,7 @@ def precess(x, y, fromsys="B", tosys="J", fromfmt="DEG", tofmt="DEG"):
         out.append(_precess(a, b, fromfmt=ffmt, tofmt=tfmt, fromsys=fsys, tosys=tsys))
 
     if multi:
-        (xout, yout) = list(six.moves.zip(*out))
+        (xout, yout) = list(zip(*out))
         if tfmt == 'DEG':
             return (np.asarray(xout), np.asarray(yout))
         elif tfmt == 'HMS':
@@ -568,11 +557,12 @@ def _validate_calendar(cal):
     else:
         return None
 
+
 _timefmt_nosec = "%Y-%m-%dT%H:%M:%S"
-_timefmt_full  = _timefmt_nosec + ".%f"
+_timefmt_full = _timefmt_nosec + ".%f"
 
 _timefmt_nosec_not = _timefmt_nosec.replace("T", " ")
-_timefmt_full_not  = _timefmt_full.replace("T", " ")
+_timefmt_full_not = _timefmt_full.replace("T", " ")
 
 # looks like dates always reports seconds with two decimal places
 _timefmt_dates = "%Y %b %d %H:%M:%S.%f"

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/runtool.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/runtool.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
+# Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -36,8 +36,8 @@ function with the name of the tool: for example
   dmcopy("in.fits", "out.fits", clobber=True, option="all")
   print(dmstat(infile="img.fits", centroid=False, verbose=0))
 
-If using ChIPS, Sherpa, or IPython then the output will be displayed
-on-screen, so you can just say
+If using an interactive Python session - such as IPython or Sherpa - the
+output will be displayed on-screen, so you can just say
 
   dmstat(infile="img.fits", centroid=False, verbose=0)
 
@@ -333,7 +333,7 @@ An IOError is raised if the tool returns a non-zero exit
 status. Unfortunately some CIAO tools still return a zero exit status
 when they error out; for such cases it will appear as if the tool ran
 successfully. The full screen output is included in the error, with
-each line indented for readability at the ChIPS/Sherpa/IPython prompt.
+each line indented for readability at the IPython/Sherpa prompt.
 
 As an example,
 
@@ -459,8 +459,6 @@ import shutil
 import glob
 import re
 
-import six
-
 from collections import namedtuple
 from contextlib import contextmanager
 
@@ -478,7 +476,7 @@ from ciao_contrib.logger_wrapper import initialize_module_logger
 # (e.g. since we know the first digit of month must be 0 or 1) but
 # leave that for now.
 #
-dtime = re.compile("_\d{8}\.\d{2}:\d{2}:\d{2}\.par$")
+dtime = re.compile(r"_\d{8}\.\d{2}:\d{2}:\d{2}\.par$")
 
 logger = initialize_module_logger("runtool")
 
@@ -489,8 +487,8 @@ v5 = logger.verbose5
 
 ParValue = namedtuple("ParValue",
                       ["name", "type", "help", "default"])
-ParSet   = namedtuple("ParSet",
-                      ["name", "type", "help", "default", "options"])
+ParSet = namedtuple("ParSet",
+                    ["name", "type", "help", "default", "options"])
 ParRange = namedtuple("ParRange",
                       ["name", "type", "help", "default", "lo", "hi"])
 
@@ -706,9 +704,11 @@ def _log_par_file_contents(parfile):
 
 
 class CIAOPrintableString(str):
-    """Wraps strings so that they are formatted nicely when
-    'auto-displayed' by ipython. Essentially the same as
-    pychips.utils.ChipsPrintableString."""
+    """Wraps strings for "nice" formatting.
+
+    This is intended for interactive use, such as IPython and
+    notebooks. Is it still needed?
+    """
 
     def __init__(self, string):
         self.str = string
@@ -727,10 +727,12 @@ def is_an_iterable(val):
     conversion, since in 2.7 strings did not have an __iter__
     method but they do now. Ideally the code would be rewritten
     to avoid this logic.
+
+    Currently unclear what needs to be changed now we have dropped
+    Python 2.7 support, so leave in.
     """
 
-    return not isinstance(val, six.string_types) \
-        and hasattr(val, "__iter__")
+    return not isinstance(val, str) and hasattr(val, "__iter__")
 
 
 # See
@@ -807,19 +809,19 @@ class CIAOParameter(object):
         self._optional = [p.name.replace('-', '_') for p in opts]
         self._parnames = self._required + self._optional
 
-        z1 = list(six.moves.zip(self._required, reqs))
-        z2 = list(six.moves.zip(self._optional, opts))
+        z1 = list(zip(self._required, reqs))
+        z2 = list(zip(self._optional, opts))
         self._store = dict(z1 + z2)
 
         # we include names that are not mapped just to make it easier
-        z1 = list(six.moves.zip(self._required,
-                                [p.name for p in reqs]))
-        z2 = list(six.moves.zip(self._optional,
-                                [p.name for p in opts]))
+        z1 = list(zip(self._required,
+                      [p.name for p in reqs]))
+        z2 = list(zip(self._optional,
+                      [p.name for p in opts]))
         self._orig_parnames = dict(z1 + z2)
 
-        self._defaults = dict([(pname, self._store[pname].default)
-                               for pname in self._parnames])
+        self._defaults = {pname: self._store[pname].default
+                          for pname in self._parnames}
         # should only be accessed via _set/get_param_value
         self._settings = {}
         self._index = 0
@@ -1147,7 +1149,7 @@ class CIAOParameter(object):
 
             pfh.close()
 
-        except:
+        except Exception:
             v5("Deleting par file due to error: {0}".format(parfile))
             os.unlink(parfile)
             raise
@@ -1362,10 +1364,10 @@ class CIAOParameter(object):
             self._update_parfile_write(parfile, stackfiles)
             self._update_parfile_verify(parfile, stackfiles)
 
-        except:
+        except Exception:
 
             # ensure any temporary stack files are cleaned up
-            for sname in six.itervalues(stackfiles):
+            for sname in stackfiles.values():
                 try:
                     v5("Deleting temporary stack file due to error: {0}".format(sname))
                     os.unlink(sname)
@@ -1502,8 +1504,7 @@ class CIAOParameter(object):
             return None
         else:
             v3("Parameters contain temporary stacks:")
-            for (k, v) in six.iteritems(stackfiles):
-                # v3("   {0}.{1} -> @{2}".format(self._toolname, k, v))
+            for (k, v) in stackfiles.items():
                 v3("   {0}.{1} -> @-{2}".format(self._toolname, k, v))
 
             return stackfiles
@@ -1575,8 +1576,8 @@ class CIAOTool(CIAOParameter):
 
     The call returns the screen output of the tool (both the stdout
     and stderr channels). This can be stored in a variable or - if
-    called from an interactive Python session such as ChIPS, Sherpa or
-    IPython - it can be automatically displayed, e.g.
+    called from an interactive Python session such as IPython or
+    Sherpa - it can be automatically displayed, e.g.
 
      dmstat("sources.dat[z=0.3:0.8][cols z,lx,kt]", median=True)
 
@@ -1693,7 +1694,7 @@ class CIAOTool(CIAOParameter):
         store.update(kwargs)
 
         nstore = {}
-        for (pname, pval) in six.iteritems(store):
+        for (pname, pval) in store.items():
             parname = self._expand_parname(pname)
             nstore[parname] = pval
 
@@ -1732,7 +1733,7 @@ class CIAOTool(CIAOParameter):
 
         rval = {}
         if self._runtimes is not None:
-            for (k, v) in six.iteritems(self._runtimes):
+            for (k, v) in self._runtimes.items():
                 rval[k] = v
 
         return rval
@@ -1784,14 +1785,7 @@ class CIAOToolParFile(CIAOTool):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
         out = proc.communicate()
-        sout = out[0]
-
-        # Python 2.7 returns a string for sout, Python 3.5 returns
-        # bytes.
-        #
-        # Question: is this the best approach?
-        if not six.PY2:
-            sout = sout.decode()
+        sout = out[0].decode()
 
         etime = time.localtime()
         rval = proc.returncode
@@ -1825,7 +1819,9 @@ class CIAOToolParFile(CIAOTool):
                     oval = self._get_param_value(pname)
                     v5("Replacing {0}.{1} = {2}".format(self._toolname, pname, oval))
                     nval = stk.build(oval)
-                    if len(nval) == 1: nval = nval[0]
+                    if len(nval) == 1:
+                        nval = nval[0]
+
                     v5("  by {0}".format(nval))
                     self._set_param_value(pname, nval)
 
@@ -1896,14 +1892,7 @@ class CIAOToolDirect(CIAOTool):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
         out = proc.communicate()
-        sout = out[0]
-
-        # Python 2.7 returns a string for sout, Python 3.5 returns
-        # bytes.
-        #
-        # Question: is this the best approach?
-        if not six.PY2:
-            sout = sout.decode()
+        sout = out[0].decode()
 
         etime = time.localtime()
         rval = proc.returncode
@@ -2333,7 +2322,7 @@ def add_comment_lines(infile, comments):
     but comments=[""] will add a blank comment line)
     """
 
-    if isinstance(comments, six.string_types):
+    if isinstance(comments, str):
         cs = [comments]
     else:
         cs = comments
@@ -2379,7 +2368,7 @@ def add_tool_history(infiles, toolname, params,
     v3("Params: {}".format(params))
 
     # special case a single file
-    if isinstance(infiles, six.string_types):
+    if isinstance(infiles, str):
         infiles = [infiles]
 
     tool = make_tool('dmhistory')
@@ -2390,7 +2379,7 @@ def add_tool_history(infiles, toolname, params,
         #
         pio.punlearn(toolname)
         fp = pio.paramopen(toolname, "wL")
-        for (k, v) in six.iteritems(params):
+        for (k, v) in params.items():
             v3("Checking parameter <{}> value <{}> type={}".format(k, v,
                                                                    type(v)))
             if isinstance(v, bool):
@@ -2443,7 +2432,7 @@ def list_tools(tools=True, params=True):
     if params:
         allowed.append(False)
 
-    out = [pname for (pname, pi) in six.iteritems(parinfo)
+    out = [pname for (pname, pi) in parinfo.items()
            if pi["istool"] in allowed]
     out.sort()
     return out

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/utils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/utils.py
@@ -1,8 +1,5 @@
-
-# Python35Support
-
 #
-#  Copyright (C) 2009, 2010, 2015, 2016
+#  Copyright (C) 2009, 2010, 2015, 2016, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -23,15 +20,8 @@
 
 "Simple utility routines for CIAO analysis"
 
-import six
-
 import numpy as np
 
-# We could make the code conditional on the presence of Sherpa
-# - e.g. only use print_fields if it can be imported - but the
-# assumption between the ciao_contrib package is that all elements
-# are available.
-#
 from sherpa.utils import print_fields
 
 __all__ = ["simple_stats", "simple_hist",
@@ -57,8 +47,8 @@ class SimpleStats:
     def __str__(self):
 
         names = ["npts", "min", "max", "total", "mean", "median", "stddev"]
-        vals  = [getattr(self, n) for n in names]
-        return print_fields(names, dict(six.moves.zip(names, vals)))
+        vals = [getattr(self, n) for n in names]
+        return print_fields(names, dict(zip(names, vals)))
 
 
 class SimpleHistogram:
@@ -99,7 +89,7 @@ class SimpleHistogram:
             max = array.max()
 
         if max <= min:
-            raise ValueError("Maximum value ({0}) is <= minimum ({1})".format(max,min))
+            raise ValueError("Maximum value ({0}) is <= minimum ({1})".format(max, min))
 
         if step is None:
             if nbins < 1:
@@ -124,8 +114,8 @@ class SimpleHistogram:
     def __str__(self):
 
         names = ["xlow", "xhigh", "y"]
-        vals  = [getattr(self, n) for n in names]
-        return print_fields(names, dict(six.moves.zip(names, vals)))
+        vals = [getattr(self, n) for n in names]
+        return print_fields(names, dict(zip(names, vals)))
 
 
 def simple_stats(array):

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/coords/format.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/coords/format.py
@@ -1,8 +1,5 @@
-
-# Python35Support
-
 #
-#  Copyright (C) 2011, 2013, 2015, 2016
+#  Copyright (C) 2011, 2013, 2015, 2016,2019
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -44,8 +41,6 @@ converting RA and Dec to degrees, the module uses the following rules:
 
 import re
 import math
-
-import six
 
 import unittest
 
@@ -189,7 +184,9 @@ def dec2deg(dec):
         # if both degrees and hms fail then
         # there was an error
         if len(retval) != 0:
-           raise ValueError('Could not parse the Dec value, {0}. The following segment was not expected {1}'.format(dec, retval))
+            raise ValueError('Could not parse the Dec value, ' +
+                             '{}. The following segment'.format(dec) +
+                             ' was not expected {}'.format(retval))
 
     return deg
 
@@ -221,7 +218,7 @@ def deg2ra(deg, format):
     if not _check_float_(deg):
         try:
             deg = float(deg)
-        except:
+        except ValueError:
             raise TypeError("The input degree must be a float or a value that can be converted to type float")
 
     if deg < 0:
@@ -280,7 +277,7 @@ def deg2dec(deg, format):
     if not _check_float_(deg):
         try:
             deg = float(deg)
-        except:
+        except ValueError:
             raise TypeError("The input degree must be a float or a value that can be converted to type float")
 
     if deg > 90 or deg < -90:
@@ -382,7 +379,7 @@ def _ra_degree_(val):
        <drad> := {<["0"]["0"]"0".."9">|<["0"]"10".."99">|<"100".."359">}[[<frac>]][<ws>][{<"D">|<"d">}]
     """
     sep = False
-    match = re.match("^((3[0-5]\d)|([0-2]?\d?\d))", val)
+    match = re.match(r"^((3[0-5]\d)|([0-2]?\d?\d))", val)
     if match is None:
         return (None, val, sep)
 
@@ -408,7 +405,7 @@ def _ra_degree_hour_(val):
     Use following rule to convert to ra hours to degrees
        <drah> := {<["0"]"0".."9">|<"10".."23">}[[<frac>]][<ws>]{<"H">|<"h">}
     """
-    match = re.match("^((2[0-3])|([0-1]?\d))", val)
+    match = re.match(r"^((2[0-3])|([0-1]?\d))", val)
 
     drah = (None, val, False)
     if match is None:
@@ -440,7 +437,7 @@ def _hour_(val):
     Use following rule to convert to hours to degrees
        <hr> := {<["0"]"0".."9">|<"10".."23">}[<ws>][<"H">|<"h">]
     """
-    match = re.match("^(((2[0-3])|([0-1]?\d))(\s*(H|h))?)", val)
+    match = re.match(r"^(((2[0-3])|([0-1]?\d))(\s*(H|h))?)", val)
     sep = False
 
     hr = (None, val, sep)
@@ -448,7 +445,7 @@ def _hour_(val):
         deg = float(match.group(2)) * DEG_PER_HR
 
         # see if the input ends in a local seperator
-        search = re.search('(\s*(H|h))$', match.group(1))
+        search = re.search(r'(\s*(H|h))$', match.group(1))
         sep = search is not None
 
         # everything passed return the degree
@@ -465,13 +462,13 @@ def _ra_minutes_(val):
        <rmn> := {<["0"]"0".."9">|<"10".."59">}[<ws>][<"M">|<"m">]
     """
     sep = False
-    match = re.match("^(([0-5]?\d)(\s*(M|m))?)", val)
+    match = re.match(r"^(([0-5]?\d)(\s*(M|m))?)", val)
     rmn = (None, val, sep)
     if match is not None and match.group(2) is not None:
         deg = float(match.group(2)) * DEG_PER_MIN
 
         # see if the input ends in a local seperator
-        search = re.search('(\s*(M|m))$', match.group(1))
+        search = re.search(r'(\s*(M|m))$', match.group(1))
         sep = search is not None
 
         # everything passed return the degree
@@ -488,7 +485,7 @@ def _ra_seconds_(val):
        <rsc> := {<["0"]"0".."9">|<"10".."59">}[[<frac>]][<ws>][<"S">|<"s">]
     """
     sep = False
-    match = re.match("^([0-5]?\d)", val)
+    match = re.match(r"^([0-5]?\d)", val)
 
     if match is None:
         return (None, val, False)
@@ -523,7 +520,7 @@ def _degree_dec_(val):
        <ddec> := {<["0"]"0".."9">|<"10".."89">}[[<frac>]][<ws>][<"D">|<"d">][<ws>]
     """
     local_sep = False
-    match = re.match("^((\+|-)?([0-8]?\d))", val)
+    match = re.match(r"^((\+|-)?([0-8]?\d))", val)
     if match is None:
         return (None, val, local_sep)
 
@@ -534,7 +531,7 @@ def _degree_dec_(val):
         deg += frac
     ws, val = _ws_(val)
 
-    match = re.match("^(D|d)\s*|\s+", val)
+    match = re.match(r"^(D|d)\s*|\s+", val)
     if match is not None:
         val = val[match.end():]
 
@@ -597,13 +594,13 @@ def _degree_(val):
     """
 
     sep = False
-    match = re.match("^(((\+|-)?([0-8]?\d))(\s*(D|d))?)", val)
+    match = re.match(r"^(((\+|-)?([0-8]?\d))(\s*(D|d))?)", val)
     if match is None or match.group(2) is None:
         return (None, val, sep)
 
     deg = float(match.group(2))
 
-    search = re.search("(\s*(D|d))$", match.group(1))
+    search = re.search(r"(\s*(D|d))$", match.group(1))
     sep = search is not None
 
     # everything passed return the degree
@@ -618,13 +615,13 @@ def _arc_minutes_(val):
     """
 
     sep = False
-    match = re.match("^(([0-5]?\d)(\s*('))?)", val)
+    match = re.match(r"^(([0-5]?\d)(\s*('))?)", val)
     if match is None or match.group(2) is None:
         return (None, val, sep)
 
     deg = float(match.group(2)) * DEG_PER_AMIN
 
-    search = re.search("(\s*('))$", match.group(1))
+    search = re.search(r"(\s*('))$", match.group(1))
     sep = search is not None
 
     # everything passed return the degree
@@ -639,7 +636,7 @@ def _arc_seconds_(val):
     """
 
     sep = False
-    match = re.match("^([0-5]?\d)", val)
+    match = re.match(r"^([0-5]?\d)", val)
     if match is None:
         return (None, val, sep)
 
@@ -671,7 +668,7 @@ def _frac_(val):
     Use following rule to identify fractions
        <frac> := .[<"0".."9">]*
     """
-    match = re.match("^\.\d*", val)
+    match = re.match(r"^\.\d*", val)
 
     if match is not None:
         frac = (float(match.group(0)), val[match.end():])
@@ -686,7 +683,7 @@ def _sep_(val):
     Use following rule to identify seperator
        <sep> := {":"[<ws>]|<ws>}
     """
-    match = re.match("^\s*:\s*|\s+", val)
+    match = re.match(r"^\s*:\s*|\s+", val)
 
     if match is not None:
         sep = (match.group(0), val[match.end():])
@@ -701,7 +698,7 @@ def _ws_(val):
     Use following rule to identify white space
        <ws> := {" "|<tab>}[<ws>]
     """
-    match = re.match("^\s+", val)
+    match = re.match(r"^\s+", val)
 
     if match is not None:
         space = (match.group(0), val[match.end():])
@@ -716,7 +713,7 @@ def _check_str_(s):
         try:
             s += 'a'
             s.split
-        except:
+        except (TypeError, AttributeError):
             return False
 
     return True
@@ -729,7 +726,7 @@ def _check_float_(n):
     try:
         if n + 0 == float(n):
             return True
-    except:
+    except (TypeError, ValueError):
         pass
 
     return False
@@ -741,14 +738,14 @@ def _check_float_(n):
 class TestModule(unittest.TestCase):
 
     def _test_fmtconvert(self, val, formatter, results):
-        for fmt, expval in six.iteritems(results):
+        for fmt, expval in results.items():
             gotval = formatter(val, fmt)
             # ignore floating-point differences for now
             self.assertEqual(expval, gotval,
                              msg="format='{}'".format(fmt))
 
     def _test_convert(self, expval, converter, results):
-        for _, val in six.iteritems(results):
+        for _, val in results.items():
             gotval = converter(val)
             # for now use string conversion to try and work around
             # floating-point differences
@@ -756,14 +753,14 @@ class TestModule(unittest.TestCase):
                              msg="val='{}'".format(val))
 
     def _test_invalid_string(self, converter, expected, ignore):
-        for fmt, val in six.iteritems(expected):
+        for fmt, val in expected.items():
             if fmt in ignore:
                 continue
 
             self.assertRaises(ValueError, converter, val)
 
     def _test_partial(self, converter, expected):
-        for strval, numval in six.iteritems(expected):
+        for strval, numval in expected.items():
             gotval = converter(strval)
             self.assertEqual(str(gotval), str(numval),
                              msg="converting '{}'".format(strval))
@@ -840,6 +837,7 @@ class TestModule(unittest.TestCase):
         self._test_invalid_string(dec2deg,
                                   self._test_expected_ra,
                                   [' ', ':'])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/coords/resolver.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/coords/resolver.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2013, 2015, 2016, 2018
+#  Copyright (C) 2011, 2013, 2015, 2016, 2018, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -38,8 +38,9 @@ the one provided by the CADC at
 http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver/
 """
 
-from six.moves import urllib
-import six
+from urllib.parse import quote_plus
+from urllib.request import urlopen
+from urllib.error import HTTPError, URLError
 
 import ciao_contrib.logger_wrapper as lw
 
@@ -108,7 +109,7 @@ def identify_name(name):
 
     """
 
-    tname = urllib.parse.quote_plus(name)
+    tname = quote_plus(name)
     url = "http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver/find?format=ascii&service=all&cached=true&target=" + tname
 
     # We get a 425 response code when there's no match, so catch this to make
@@ -116,10 +117,10 @@ def identify_name(name):
     #
     try:
         v5("Name query: {0}".format(url))
-        rsp = urllib.request.urlopen(url)
+        rsp = urlopen(url)
 
-    except urllib.error.HTTPError as he:
-        # HTTPError is a subclass if URLError (in Pythohn 2.7 and 3.5)
+    except HTTPError as he:
+        # HTTPError is a subclass of URLError (in Pythohn 2.7 and 3.5)
         # so process first
         code = he.getcode()
         v5("Error from CADC name resolver - status = {0}".format(code))
@@ -130,7 +131,7 @@ def identify_name(name):
             v5(str(he))
             raise he
 
-    except urllib.error.URLError as ue:
+    except URLError as ue:
         # Is this a sufficient check?
         v5("Error opening URL: {0}".format(ue))
         v5("error.reason = {0}".format(ue.reason))
@@ -141,19 +142,13 @@ def identify_name(name):
 
     v5("Response from query:")
     out = [None, None, None]
-    data = rsp.read()
-
-    # There must be a neater Python 2.7/3.3+ way to do this
-    if not isinstance(data, six.string_types):
-        # I would imagine the response is limited to ASCII but the
-        # response shouldn't be too large, so use UTF-8 as a
-        # precaution.
-        data = data.decode('utf8')
+    data = rsp.read().decode('utf8')
 
     for l in data.split('\n'):
         l = l.strip()
         v5(l)
-        if l == "": continue
+        if l == "":
+            continue
 
         toks = l.split("=", 1)
         if len(toks) != 2:

--- a/mk_runtool.header
+++ b/mk_runtool.header
@@ -459,8 +459,6 @@ import shutil
 import glob
 import re
 
-import six
-
 from collections import namedtuple
 from contextlib import contextmanager
 
@@ -478,7 +476,7 @@ from ciao_contrib.logger_wrapper import initialize_module_logger
 # (e.g. since we know the first digit of month must be 0 or 1) but
 # leave that for now.
 #
-dtime = re.compile("_\d{8}\.\d{2}:\d{2}:\d{2}\.par$")
+dtime = re.compile(r"_\d{8}\.\d{2}:\d{2}:\d{2}\.par$")
 
 logger = initialize_module_logger("runtool")
 
@@ -489,8 +487,8 @@ v5 = logger.verbose5
 
 ParValue = namedtuple("ParValue",
                       ["name", "type", "help", "default"])
-ParSet   = namedtuple("ParSet",
-                      ["name", "type", "help", "default", "options"])
+ParSet = namedtuple("ParSet",
+                    ["name", "type", "help", "default", "options"])
 ParRange = namedtuple("ParRange",
                       ["name", "type", "help", "default", "lo", "hi"])
 
@@ -729,10 +727,12 @@ def is_an_iterable(val):
     conversion, since in 2.7 strings did not have an __iter__
     method but they do now. Ideally the code would be rewritten
     to avoid this logic.
+
+    Currently unclear what needs to be changed now we have dropped
+    Python 2.7 support, so leave in.
     """
 
-    return not isinstance(val, six.string_types) \
-        and hasattr(val, "__iter__")
+    return not isinstance(val, str) and hasattr(val, "__iter__")
 
 
 # See
@@ -809,19 +809,19 @@ class CIAOParameter(object):
         self._optional = [p.name.replace('-', '_') for p in opts]
         self._parnames = self._required + self._optional
 
-        z1 = list(six.moves.zip(self._required, reqs))
-        z2 = list(six.moves.zip(self._optional, opts))
+        z1 = list(zip(self._required, reqs))
+        z2 = list(zip(self._optional, opts))
         self._store = dict(z1 + z2)
 
         # we include names that are not mapped just to make it easier
-        z1 = list(six.moves.zip(self._required,
-                                [p.name for p in reqs]))
-        z2 = list(six.moves.zip(self._optional,
-                                [p.name for p in opts]))
+        z1 = list(zip(self._required,
+                      [p.name for p in reqs]))
+        z2 = list(zip(self._optional,
+                      [p.name for p in opts]))
         self._orig_parnames = dict(z1 + z2)
 
-        self._defaults = dict([(pname, self._store[pname].default)
-                               for pname in self._parnames])
+        self._defaults = {pname: self._store[pname].default
+                          for pname in self._parnames}
         # should only be accessed via _set/get_param_value
         self._settings = {}
         self._index = 0
@@ -1149,7 +1149,7 @@ class CIAOParameter(object):
 
             pfh.close()
 
-        except:
+        except Exception:
             v5("Deleting par file due to error: {0}".format(parfile))
             os.unlink(parfile)
             raise
@@ -1364,10 +1364,10 @@ class CIAOParameter(object):
             self._update_parfile_write(parfile, stackfiles)
             self._update_parfile_verify(parfile, stackfiles)
 
-        except:
+        except Exception:
 
             # ensure any temporary stack files are cleaned up
-            for sname in six.itervalues(stackfiles):
+            for sname in stackfiles.values():
                 try:
                     v5("Deleting temporary stack file due to error: {0}".format(sname))
                     os.unlink(sname)
@@ -1504,8 +1504,7 @@ class CIAOParameter(object):
             return None
         else:
             v3("Parameters contain temporary stacks:")
-            for (k, v) in six.iteritems(stackfiles):
-                # v3("   {0}.{1} -> @{2}".format(self._toolname, k, v))
+            for (k, v) in stackfiles.items():
                 v3("   {0}.{1} -> @-{2}".format(self._toolname, k, v))
 
             return stackfiles
@@ -1695,7 +1694,7 @@ class CIAOTool(CIAOParameter):
         store.update(kwargs)
 
         nstore = {}
-        for (pname, pval) in six.iteritems(store):
+        for (pname, pval) in store.items():
             parname = self._expand_parname(pname)
             nstore[parname] = pval
 
@@ -1734,7 +1733,7 @@ class CIAOTool(CIAOParameter):
 
         rval = {}
         if self._runtimes is not None:
-            for (k, v) in six.iteritems(self._runtimes):
+            for (k, v) in self._runtimes.items():
                 rval[k] = v
 
         return rval
@@ -1786,14 +1785,7 @@ class CIAOToolParFile(CIAOTool):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
         out = proc.communicate()
-        sout = out[0]
-
-        # Python 2.7 returns a string for sout, Python 3.5 returns
-        # bytes.
-        #
-        # Question: is this the best approach?
-        if not six.PY2:
-            sout = sout.decode()
+        sout = out[0].decode()
 
         etime = time.localtime()
         rval = proc.returncode
@@ -1827,7 +1819,9 @@ class CIAOToolParFile(CIAOTool):
                     oval = self._get_param_value(pname)
                     v5("Replacing {0}.{1} = {2}".format(self._toolname, pname, oval))
                     nval = stk.build(oval)
-                    if len(nval) == 1: nval = nval[0]
+                    if len(nval) == 1:
+                        nval = nval[0]
+
                     v5("  by {0}".format(nval))
                     self._set_param_value(pname, nval)
 
@@ -1898,14 +1892,7 @@ class CIAOToolDirect(CIAOTool):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
         out = proc.communicate()
-        sout = out[0]
-
-        # Python 2.7 returns a string for sout, Python 3.5 returns
-        # bytes.
-        #
-        # Question: is this the best approach?
-        if not six.PY2:
-            sout = sout.decode()
+        sout = out[0].decode()
 
         etime = time.localtime()
         rval = proc.returncode
@@ -2335,7 +2322,7 @@ def add_comment_lines(infile, comments):
     but comments=[""] will add a blank comment line)
     """
 
-    if isinstance(comments, six.string_types):
+    if isinstance(comments, str):
         cs = [comments]
     else:
         cs = comments
@@ -2381,7 +2368,7 @@ def add_tool_history(infiles, toolname, params,
     v3("Params: {}".format(params))
 
     # special case a single file
-    if isinstance(infiles, six.string_types):
+    if isinstance(infiles, str):
         infiles = [infiles]
 
     tool = make_tool('dmhistory')
@@ -2392,7 +2379,7 @@ def add_tool_history(infiles, toolname, params,
         #
         pio.punlearn(toolname)
         fp = pio.paramopen(toolname, "wL")
-        for (k, v) in six.iteritems(params):
+        for (k, v) in params.items():
             v3("Checking parameter <{}> value <{}> type={}".format(k, v,
                                                                    type(v)))
             if isinstance(v, bool):
@@ -2445,7 +2432,7 @@ def list_tools(tools=True, params=True):
     if params:
         allowed.append(False)
 
-    out = [pname for (pname, pi) in six.iteritems(parinfo)
+    out = [pname for (pname, pi) in parinfo.items()
            if pi["istool"] in allowed]
     out.sort()
     return out

--- a/mk_runtool.py
+++ b/mk_runtool.py
@@ -53,13 +53,15 @@ def _find_pathname():
     else:
         raise IOError("Found {} matches to ciao-*.*/!".format(nmatches))
 
+
 # A lot of this code should probably go in the 'if __name__' section below!
 
 ciao_head = _find_pathname()
 
 ascds_install = os.getenv("ASCDS_INSTALL")
 if ascds_install is None:
-    raise IOError("ASCDS_INSTALL environment variable is not set; has CIAO been started?")
+    raise IOError("ASCDS_INSTALL environment variable is not set; " +
+                  "has CIAO been started?")
 
 ascds_contrib = "{}contrib".format(ciao_head)
 
@@ -169,14 +171,14 @@ class Param:
         elif nt < 7:
             toks.extend(["" for i in range(nt, 7)])
 
-        self.name   = toks[0]
-        self.type   = toks[1]
+        self.name = toks[0]
+        self.type = toks[1]
         self.python_type = self.python_type_map[self.type]
-        self.mode   = toks[2]
-        self.value  = toks[3]
+        self.mode = toks[2]
+        self.value = toks[3]
         self.minval = toks[4]
         self.maxval = toks[5]
-        self.info   = toks[6].strip()
+        self.info = toks[6].strip()
 
         # Use a case-insensitive check
         if self.name.lower() in language_keywords_lower:
@@ -360,7 +362,7 @@ def create_output(dirname, toolname, istool=True):
     (req_params, opt_params) = get_param_list(dirname, toolname)
 
     # create the parameter object
-    out  = "parinfo['{}'] = {{\n".format(toolname)
+    out = "parinfo['{}'] = {{\n".format(toolname)
     out += "\t'istool': {},\n".format(istool)
 
     rpars = [p.describe("") for p in req_params]


### PR DESCRIPTION
This removes the use of the six module from most of the support code. It doesn't change the ChIPS code (`chips_contrib.xxx`) as this is going to be removed for CIAO 4.12, and leaves out some files as they are the subject of other PRs (lightcurves in #240, ecf_calc is in #235)

There has been some linting changes (addition and removal of spaces in most cases, but explicit error catching is the other major change) based on the report from `pycodestyle` (not all warnings and errors have been implemented). 