### PR TITLE
Remove or replace mention of ChIPS in the documentation

### DIFF
--- a/ciao-4.11/contrib/lib/python3.5/site-packages/crates_contrib/images.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/crates_contrib/images.py
@@ -1,8 +1,5 @@
-
-# Python35Support
-
 #
-#  Copyright (C) 2012, 2015, 2016
+#  Copyright (C) 2012, 2015, 2016, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -75,19 +72,13 @@ def imextent(img, xmin, xmax, ymin, ymax, limits='center'):
 
     The following example creates a 40 pixel wide by 20 pixel high
     image, zi, where the X axis goes from 40 to 60 and the Y
-    axis 10 to 20. The imextent call creates a transform object
-    that can be passed to ChIPS' add_image command to set the
-    image axes. Since the image is not square the aspect ratio of
-    the plot is changed to fit the data (and window):
+    axis 10 to 20. The imextent call creates a transform object.
 
     >>> yi, xi = np.mgrid[10:20:20j, 40:60:40j]
-    >>> zi = 100.0 / np.sqrt((xi - 45.62)**2 + (yi - 14.7)**2)
+    >>> zi = 100.0 / np.sqrt((xi - 45.62) ** 2 + (yi - 14.7) ** 2)
     >>> tr = imextent(zi, 40, 60, 10, 20)
-    >>> add_image(np.log10(zi), tr)
-    >>> set_image(['depth', 50])
-    >>> set_plot_aspect_ratio('fit')
 
-    The transform object can also be used to convert between logical
+    The transform object can be used to convert between logical
     coordinates (where 1,1 refers to the center of the lower-left
     pixel) and the data coordinates:
 
@@ -122,39 +113,10 @@ def imextent(img, xmin, xmax, ymin, ymax, limits='center'):
     >>> print(tr_edge.apply([[1.0, 1.0]]))
     [[ 10.375       -9.33333333]]
 
-    >>> add_window()
-    >>> add_image(img, tr_cen, ['depth', 50])
-    >>> set_plot_aspect_ratio('fit')
-    >>> print(get_plot_xrange())
-    [9.5, 13.5]
-    >>> print(get_plot_yrange())
-    [-11.0, -5.0]
-
-    >>> add_window()
-    >>> add_image(img, tr_edge, ['depth', 50])
-    >>> set_plot_aspect_ratio('fit')
-    >>> print(get_plot_xrange())
-    [10.0, 13.0]
-    >>> print(get_plot_yrange())
-    [-10.0, -6.0]
-
-    In the limits=center case, the pixels are centered at x=10,11,12
-    and y=-10,-8,-6 and so have widths of 1 and heights of 2. The
-    plot limits therefere cover x=10-0.5 to 12+0.5 and
-    y=-10-1 to -6+1.
-
-    In the limits=edge case, the x axis covers x=10 to 13 and so
-    the pixels have widths of 3.0/4 and heights of 4.0/3. The
-    x and y centers of the pixels are therefore:
-
-        x=10 + 3.0/8, 10 + 9.0/8, 10 + 15.0/8, 10 + 21./8
-        y=-10 + 2.0/3, -10 + 6.0/3, -10 + 10.0/3
-
     """
 
     try:
         (ny, nx) = img.shape
-
     except AttributeError:
         raise ValueError("First argument has no shape attribute.")
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/crates_contrib/utils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/crates_contrib/utils.py
@@ -1,6 +1,5 @@
-
 #
-#  Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018
+#  Copyright (C) 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2018, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -388,7 +387,7 @@ def make_image_crate(pixvals):
     -----
     The semantics of whether the input array is copied or
     just referenced in the crate are currently not specified.
-    Changing the original array after thecrate has been created
+    Changing the original array after the crate has been created
     *may* change the value in the Crate, but this behavior should
     not be taken advantage of.
 
@@ -651,13 +650,8 @@ def scale_image_crate(cr, scaling="arcsinh"):
     Examples
     --------
 
-    Use the ChIPS add_image routine to display the logarithm
-    (base 10) of the pixel values. Any WCS from the input file
-    is retained, and will be used by the 'add_image' call:
-
     >>> cr = read_file('img.fits')
     >>> scale_image_crate(cr, 'log10')
-    >>> add_image(cr)
 
     """
 
@@ -997,10 +991,6 @@ def read_ds9_contours(fname, coords=None, fromsys=None, tosys=None):
         each element refers to a single contour (so the coordinates of
         the first component are given by xcoords[0] and ycoords[0]).
 
-    See Also
-    --------
-    chips_contrib.ds9.add_ds9_contours
-
     Notes
     -----
     The only supported format is that of DS9 prior to release 7.5,
@@ -1012,9 +1002,6 @@ def read_ds9_contours(fname, coords=None, fromsys=None, tosys=None):
 
     >>> xall, yall = read_ds9_contours("ds9.con")
     >>> print("Number of segments: {}".format(len(xall)))
-    >>> add_axis(XY_AXIS, 0, 2000, 6000)
-    >>> for x, y in zip(xall, yall):
-    ...    add_line(x, y, ["color", "green"])
 
     The contours have been saved in SKY coordinates and are to
     be converted to celestial coordinates using the WCS transformation

--- a/ciao-4.11/contrib/share/doc/xml/add_colvals.xml
+++ b/ciao-4.11/contrib/share/doc/xml/add_colvals.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="add_colvals" context="contrib"
@@ -25,7 +25,7 @@
 	None then it is used as the description of the column.
       </PARA>
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS or Sherpa session by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
       <PARA>
 	<SYNTAX>
@@ -62,7 +62,7 @@
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>December 2013</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/cda_data.xml
+++ b/ciao-4.11/contrib/share/doc/xml/cda_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="cda_data" context="contrib"
@@ -314,7 +314,7 @@ from ciao_contrib.cda.data import download_chandra_obsids
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>August 2013</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/cda_search.xml
+++ b/ciao-4.11/contrib/share/doc/xml/cda_search.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="cda_search" context="contrib"
@@ -221,7 +221,7 @@ from ciao_contrib.cda.search import *
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>August 2013</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/check_caldb_version.xml
+++ b/ciao-4.11/contrib/share/doc/xml/check_caldb_version.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="check_caldb_version" context="contrib"
@@ -58,7 +58,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-	The routine can be loaded into Sherpa by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
 
 <VERBATIM>
@@ -119,7 +119,7 @@ else:
       </QEXAMPLE>
     </QEXAMPLELIST>
 
-    <LASTMODIFIED>June 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/ciao_caldb.xml
+++ b/ciao-4.11/contrib/share/doc/xml/ciao_caldb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="ciao_caldb" context="contrib"
@@ -24,7 +24,7 @@
       </PARA>
 
       <PARA title="Loading the routines">
-        The module can be loaded into ChIPS or Sherpa by saying:
+        The module can be loaded into a Python session by saying:
       </PARA>
 
 <VERBATIM>
@@ -79,6 +79,6 @@ from ciao_contrib.caldb import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>June 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/ciao_contrib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/ciao_contrib.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="ciao_contrib" context="contrib"
@@ -8,14 +8,12 @@
 	 seealsogroups="">
 
     <SYNOPSIS>
-      Contributed Crates, ChIPS, and Sherpa routines for CIAO.
+      Useful Python routines for CIAO.
     </SYNOPSIS>
 
     <SYNTAX>
       <LINE>import ciao_contrib.all</LINE>
       <LINE>from ciao_contrib.all import *</LINE>
-      <LINE/>
-      <LINE>Note: in CIAO 4.2 the module was called ciao_contrib</LINE>
     </SYNTAX>
 
     <DESC>
@@ -27,7 +25,8 @@
       </PARA>
 
       <PARA title="Loading the routines">
-        The module can be loaded into ChIPS or Sherpa by saying:
+        The module can be loaded into Python (either a script or
+	an interactive envrionment like Sherpa or IPython) with:
       </PARA>
 
 <VERBATIM>
@@ -153,6 +152,6 @@ from ciao_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>October 2011</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/ciao_proptools.xml
+++ b/ciao-4.11/contrib/share/doc/xml/ciao_proptools.xml
@@ -30,7 +30,7 @@
       </PARA>
 
       <PARA title="Loading the routines">
-        The module can be loaded into ChIPS or Sherpa by saying:
+        The module can be loaded into Python by saying:
       </PARA>
 
 <VERBATIM>
@@ -167,7 +167,7 @@ help(proptools.colden)
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>February 2014</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/ciao_stacklib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/ciao_stacklib.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="ciao_stacklib" context="contrib"
@@ -27,7 +27,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-        The module can be loaded into ChIPS or Sherpa by saying:
+        The module can be loaded into Python by saying:
       </PARA>
 
 <VERBATIM>
@@ -223,6 +223,6 @@ src2/b.fits
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>May 2019</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/ciao_utils.xml
+++ b/ciao-4.11/contrib/share/doc/xml/ciao_utils.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="ciao_utils" context="contrib"
@@ -24,7 +24,7 @@
       </PARA>
 
       <PARA title="Loading the routines">
-        The module can be loaded into ChIPS or Sherpa by saying:
+        The module can be loaded into Python by saying:
       </PARA>
 
 <VERBATIM>
@@ -65,7 +65,7 @@ from ciao_contrib.utils import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>June 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/coords_utils.xml
+++ b/ciao-4.11/contrib/share/doc/xml/coords_utils.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="coords_utils" context="contrib"
@@ -88,7 +88,7 @@ from coords.utils import point_separation
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>August 2013</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/crates_contrib.xml
+++ b/ciao-4.11/contrib/share/doc/xml/crates_contrib.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="crates_contrib" context="contrib"
@@ -25,7 +25,8 @@
       </PARA>
 
       <PARA title="Loading the routines">
-        The module can be loaded into ChIPS, Sherpa or Python scripts
+        The module can be loaded into a Python session (such as
+	Sherpa, IPython, or Python script)
         by saying one of the following:
       </PARA>
 
@@ -75,6 +76,6 @@ import crates_contrib.all
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>November 2012</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/crates_images.xml
+++ b/ciao-4.11/contrib/share/doc/xml/crates_images.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="crates_images" context="contrib"
@@ -29,8 +29,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-        The module can be loaded into ChIPS, Sherpa, or Python
-	scripts by saying one of the following:
+        The module can be loaded into Python with one of the following:
       </PARA>
 
 <VERBATIM>
@@ -54,8 +53,8 @@ from crates_contrib.all import *
         <ROW>
 	  <DATA>imextent()</DATA>
 	  <DATA>Scale image axes from pixel coordinates to a physical scale.
-	  See "ahelp imextent" for more information.
-	  This routine is also exported by the chips_contrib.images module.</DATA>
+	  See "help(imextent)" from Python for more information.
+	  </DATA>
 	</ROW>
       </TABLE>
 
@@ -75,6 +74,6 @@ from crates_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>June 2012</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/crates_utils.xml
+++ b/ciao-4.11/contrib/share/doc/xml/crates_utils.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="crates_utils" context="contrib"
@@ -29,8 +29,9 @@
       </PARA>
 
       <PARA title="Loading the routines">
-        The module can be loaded into ChIPS, Sherpa, or Python
-	scripts by saying one of the following:
+        The module can be loaded into a Python session (such as
+	Sherpa, IPython, or Python script)
+	by saying one of the following:
       </PARA>
 
 <VERBATIM>
@@ -121,6 +122,6 @@ from crates_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>April 2014</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_caldb.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_caldb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="get_caldb" context="contrib"
@@ -75,7 +75,7 @@
       </PARA>
 
       <PARA title="Loading the routines">
-	The routines can be loaded into Sherpa by saying:
+	The routines can be loaded into Python by saying:
       </PARA>
 
 <VERBATIM>
@@ -104,8 +104,7 @@ from ciao_contrib.caldb import *
 	    given directory (in this case the top-level CALDB directory).
 	    The os.path.walk() routine can be used to recursively scan through
 	    the directory contents; see
-	    <HREF link="http://docs.python.org/library/os.path.html#os.path.walk">'help
-	    os.path.walk'</HREF> for more information.
+	    <HREF link="http://docs.python.org/library/os.path.html#os.path.walk">'help(os.path.walk)'</HREF> for more information.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -179,7 +178,7 @@ The latest version is 4.2.2, released on Mon Apr 19 19:00:00 2010
 
     </QEXAMPLELIST>
 
-    <LASTMODIFIED>September 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/get_instmap_weights.xml
+++ b/ciao-4.11/contrib/share/doc/xml/get_instmap_weights.xml
@@ -100,17 +100,25 @@ from sherpa_contrib.utils import *
 	  <LINE>xmid      = Float32[47]</LINE>
 	  <LINE>weight    = Float32[47]</LINE>
 	  <LINE>fluxtype  = photon</LINE>
-          <LINE>&pr; add_curve(w.xmid, w.weight, ["symbol.style", "none"])</LINE>
 	</SYNTAX>
 	<DESC>
 
           <PARA>
-	    Get the weights for the model values of the default dataset and
-	    then plot them up as a curve using ChIPS. The weights are appropriate
+	    Get the weights for the model values of the default dataset.
+	    The weights are appropriate
 	    for creating an instrument map in units of cm^2 count / photon
 	    and will sum to 1.
 	  </PARA>
 
+	  <PARA>
+	    The weights can be plotted with Matplotlib, here as a curve:
+	  </PARA>
+	  <PARA>
+	    <SYNTAX>
+	      <LINE>&pr; import matplotlib.pyplot as plt</LINE>
+	      <LINE>&pr; plt.plot(w.xmid, w.weight)</LINE>
+	    </SYNTAX>
+	  </PARA>
         </DESC>
       </QEXAMPLE>
 
@@ -137,6 +145,6 @@ from sherpa_contrib.utils import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>April 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/identify_name.xml
+++ b/ciao-4.11/contrib/share/doc/xml/identify_name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="identify_name" context="contrib"
@@ -91,7 +91,7 @@ from coords.resolver import identify_name
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>October 2018</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/imextent.xml
+++ b/ciao-4.11/contrib/share/doc/xml/imextent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="imextent" context="contrib"
@@ -20,45 +20,27 @@
     <SYNTAX>
       <LINE>tr = imextent(img, xlo, xhi, ylo, yhi, limits='center')</LINE>
       <LINE/>
-      <LINE>The limits argument canbe either 'center' or 'edge'.</LINE>
-      <LINE>
-	The image is available from both the crates_contrib.images and chips_contrib.images modules, so
-	either of the following will load in the routine:
-      </LINE>
+      <LINE>The limits argument can be either 'center' or 'edge'.</LINE>
       <LINE/>
       <LINE>from crates_contrib.images import imextent</LINE>
-      <LINE>from chips_contrib.images import imextent</LINE>
     </SYNTAX>
 
     <DESC>
       <PARA>
 	The imextent routine creates a 2D linear transform object
-	- offset and scale changes only - that can be used to:
+	- offset and scale changes only - that can be used to
+	convert between logical and physical coordinate systems
+	(the SimpleCoordTransform class in the crates_contrib.utils
+	module may also be of use for this).
       </PARA>
 
-      <LIST>
-	<ITEM>
-	  label an image axes with the physical rather than
-	  pixel coordinates (analagous to the extent argument of matplotlib's
-	  imshow command).
-	</ITEM>
-	<ITEM>
-	  convert between logical and physical coordinate systems
-	  (the SimpleCoordTransform class in the crates_contrib.utils
-	  module may also be of use for this).
-	</ITEM>
-      </LIST>
-
-      <PARA title="Loading the routine">
-	Since the routine is useful to both Crates and ChIPS users it
-	is exported by both the crates_contrib and chips_contrib modules;
-	so either of the following commands will load the routine:
+      <PARA>
+	It is similar to the extent argument of Matplotlib's
+	<HREF link="https://matplotlib.org/2.2.3/api/_as_gen/matplotlib.pyplot.imshow.html">imshow</HREF>
+	function, in that it defines the physical extent of an
+	image, but returns a transform object that can be used
+	to calculate coordinates.
       </PARA>
-
-<VERBATIM>
-from crates_contrib.images import imextent
-from chips_contrib.images import imextent
-</VERBATIM>
 
       <PARA title="Arguments">
 	The imextent routine has 5 required arguments - img, xlo,
@@ -111,10 +93,7 @@ from chips_contrib.images import imextent
 	<SYNTAX>
 	  <LINE>&pr; yi, xi = np.mgrid[10:20:20j, 40:60:40j]</LINE>
 	  <LINE>&pr; zi = 100.0 / np.sqrt((xi-45.62)**2 + (yi- 14.7)**2)</LINE>
-	  <LINE>&pr; add_image(np.log10(zi), imextent(zi, 40, 60, 10, 20))</LINE>
-	  <LINE>&pr; set_image(['depth', 50])</LINE>
-	  <LINE>&pr; set_plot_aspect_ratio('fit')</LINE>
-	  <LINE>&pr; add_point(45.62, 14.7, ['color', 'red'])</LINE>
+	  <LINE>&pr; tr = imextent(zi, 40, 60, 10, 20)</LINE>
 	</SYNTAX>
 
 	<DESC>
@@ -125,41 +104,8 @@ from chips_contrib.images import imextent
 	    along y=10 to 20 (see
 	    <HREF link="http://docs.scipy.org/doc/numpy-1.7.0/reference/generated/numpy.mgrid.html">the NumPy documentation
 	    for mgrid</HREF> for more information).
-	    We use imextent in the add_image call to
-	    ensure that the axes are displayed using the
-	    physical scale of the data (i.e. x=40 to 60)
-	    rather than the pixel scale (i.e. x=1 to 40).
-	    The set_plot_aspect_ratio() call ensures that the
-	    plot just covers the image data and no more.
-	    We decorate the image with a point located at the
-	    peak coordinate of the image.
 	  </PARA>
-	  <PARA>
-	    The output can be compared to the version without the
-	    imextent call, namely:
-	  </PARA>
-	  <PARA>
-	    <SYNTAX>
-	      <LINE>&pr; add_window()</LINE>
-	      <LINE>&pr; add_image(np.log10(zi))</LINE>
-	      <LINE>&pr; set_image(['depth', 50])</LINE>
-	      <LINE>&pr; set_plot_aspect_ratio('fit')</LINE>
-	    </SYNTAX>
-	  </PARA>
-	</DESC>
-      </QEXAMPLE>
 
-      <QEXAMPLE>
-	<SYNTAX>
-	  <LINE>&pr; tr = imextent(zi, 40, 60, 10, 20)</LINE>
-	  <LINE>&pr; print(tr.apply([[1,1], [40,20]]))</LINE>
-	  <LINE>[[40 10]</LINE>
-	  <LINE>[60 20]]</LINE>
-	  <LINE>&pr; pix = tr.invert([[45.62, 14.7]])</LINE>
-	  <LINE>&pr; print(pix[0])</LINE>
-	  <LINE>[ 11.959   9.93 ]</LINE>
-	</SYNTAX>
-	<DESC>
 	  <PARA>
 	    Here we use the transform object returned by imextent to
 	    convert between physical and logical (i.e. pixel) coordinates.
@@ -172,87 +118,37 @@ from chips_contrib.images import imextent
 	    coordinate system: (1,1) refers to the center of the
 	    bottom-left pixel.
 	  </PARA>
+<VERBATIM>
+&pr; print(tr.apply([[1,1], [40,20]]))
+[[40 10]
+ [60 20]]
+</VERBATIM>
+
 	  <PARA>
 	    We can also use the transform object to convert from
 	    physical to pixel coortinates by using the invert() method;
 	    here we use it to find the pixel location of the
 	    peak of the image, which has physical coordinates of
 	    (45.62,14.7).
-	    Given these limits we can mark the peak position on the
-	    image when using logical coordinates:
 	  </PARA>
+	  
 	  <PARA>
 	    <SYNTAX>
-	      <LINE>&pr; add_window()</LINE>
-	      <LINE>&pr; add_image(np.log10(zi), ['depth', 50])</LINE>
-	      <LINE>&pr; set_plot_aspect_ratio('fit')</LINE>
-	      <LINE>&pr; add_point(pix[0][0], pix[0][1], ['color', 'red'])</LINE>
+	      <LINE>&pr; pix = tr.invert([[45.62, 14.7]])</LINE>
+	      <LINE>&pr; print(pix[0])</LINE>
+	      <LINE>[ 11.959   9.93 ]</LINE>
 	    </SYNTAX>
 	  </PARA>
-	  <PARA>
+
+	  <PARA title="Lists of lists">
 	    Note that the transform object expects a list of lists as input,
 	    and returns the same, hence the use of "[[45.62, 14.7]]" and
 	    pix[0][0]/pix[0][1] above.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
-
-      <QEXAMPLE>
-	<SYNTAX>
-	  <LINE>&pr; img = np.arange(0, 12).reshape(3, 4)</LINE>
-	  <LINE>&pr; print(img)</LINE>
-	  <LINE>[[ 0  1  2  3]</LINE>
-	  <LINE> [ 4  5  6  7]</LINE>
-	  <LINE> [ 8  9 10 11]]</LINE>
-	  <LINE>&pr; add_window()</LINE>
-	  <LINE>&pr; add_image(img, imextent(img, 10, 13, -10, -6))</LINE>
-	  <LINE>&pr; set_image(['depth', 50])</LINE>
-	  <LINE>&pr; set_plot_aspect_ratio('fit')</LINE>
-	  <LINE>&pr; print(get_plot_xrange())</LINE>
-	  <LINE>[9.5, 13.5]</LINE>
-	  <LINE>&pr; print(get_plot_yrange())</LINE>
-	  <LINE>[-11.0, -5.0]</LINE>
-	</SYNTAX>
-	<DESC>
-	  <PARA>
-	    Here we create a 4 by 3 pixel image (4 pixels along the
-	    x direction) and display it so that the centers of the
-	    pixels have
-	    <EQUATION>x = 10, 11, 12, 13</EQUATION>
-	    and
-	    <EQUATION>y = -10, -8, -6</EQUATION>
-	    Since the width of each pixel is 1 and it's height is 2
-	    then the axes span from x=10-0.5 to 13+0.5
-	    and y=-10-1 to -6+1.
-	  </PARA>
-	</DESC>
-      </QEXAMPLE>
-
-      <QEXAMPLE>
-	<SYNTAX>
-	  <LINE>&pr; add_window()</LINE>
-	  <LINE>&pr; add_image(img, imextent(img, 10, 13, -10, -6, limits='edge'))</LINE>
-	  <LINE>&pr; set_image(['depth', 50])</LINE>
-	  <LINE>&pr; set_plot_aspect_ratio('fit')</LINE>
-	  <LINE>&pr; print(get_plot_xrange())</LINE>
-	  <LINE>[10.0, 13.0]</LINE>
-	  <LINE>&pr; print(get_plot_yrange())</LINE>
-	  <LINE>[-10.0, -6.0]</LINE>
-	</SYNTAX>
-	<DESC>
-	  <PARA>
-	    Here we repeat the previous example but this time set the limits
-	    option of imextent to 'edge', which means that this time the
-	    axes span from x=10 to 13 and x=-10 to -6, so that 
-	    the pixel width is 3/4 and height is 4/3.
-	    The pixel centers are therefore located at
-	    <EQUATION>x = 10 + 3.0/8, 10 + 9.0/8, 10 + 15.0/8, 10 + 21.0/8</EQUATION>
-	    <EQUATION>y = -10 + 2.0/3, -10 + 6.0/3, -10 + 10.0/3</EQUATION>
-	  </PARA>
-	</DESC>
-      </QEXAMPLE>
     </QEXAMPLELIST>
-
+    
     <ADESC title="Changes in the June 2012 Release">
       <PARA>
 	The imextent routine is new in this release.
@@ -267,6 +163,6 @@ from chips_contrib.images import imextent
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>June 2012</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/make_image_crate.xml
+++ b/ciao-4.11/contrib/share/doc/xml/make_image_crate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="make_image_crate" context="contrib"
@@ -24,7 +24,7 @@
 	an array of values.
       </PARA>
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS or Sherpa session by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
       <PARA>
 	<SYNTAX>
@@ -177,6 +177,6 @@ Block    2: TABLE                          Table         2 cols x 4        rows
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>December 2013</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/make_table_crate.xml
+++ b/ciao-4.11/contrib/share/doc/xml/make_table_crate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="make_table_crate" context="contrib"
@@ -27,7 +27,7 @@
 	a set of arrays, a dictionary, or a NumPy structured array.
       </PARA>
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS or Sherpa session by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
       <PARA>
 	<SYNTAX>
@@ -296,6 +296,6 @@ Block    3: IMAGE                          Image      Int4(4x3)
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>December 2013</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/read_ds9_contours.xml
+++ b/ciao-4.11/contrib/share/doc/xml/read_ds9_contours.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="read_ds9_contours" context="contrib"
@@ -12,7 +12,7 @@
     </SYNOPSIS>
 
     <SYNTAX>
-      <LINE>(xs, ys) = read_ds9_contours(filename [, coords=None, fromsys=None, tosys=None])</LINE>
+      <LINE>(xs, ys) = read_ds9_contours(filename, coords=None, fromsys=None, tosys=None)</LINE>
     </SYNTAX>
 
     <DESC>
@@ -25,15 +25,17 @@
 	in WCS but you wish to use the sky system).
       </PARA>
 
+      <!-- is this going to be updated for Matplotlib?
       <PARA>
 	The 
 	<HREF link="http://cxc.harvard.edu/ciao/ahelp/add_ds9_contours.html">add_ds9_contours routine</HREF>
 	from the chips_contrib.utils
 	module can be used to display a DS9 contour file in ChIPS.
       </PARA>
-
+      -->
+      
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS or Sherpa session by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
 <VERBATIM>
 from crates_contrib.utils import *
@@ -56,9 +58,16 @@ from crates_contrib.utils import *
 
     <QEXAMPLELIST>
       <QEXAMPLE>
+	<SYNTAX>
+	  <LINE>&pr; (xs, ys) = read_ds9_contours('ds9.con')</LINE>
+	</SYNTAX>
 	<DESC>
+	  <PARA>
+	    The contours from the file "ds9.con" are read into xs and ys
+	    arrays.
+	  </PARA>
+	  <!--
 <VERBATIM>
-(xs, ys) = read_ds9_contours("ds9.con")
 add_image("image.fits")
 for i in range(0, len(xs))
     add_line(xs[i], ys[i], ["color", "green"])
@@ -70,7 +79,8 @@ for i in range(0, len(xs))
 	    add them onto a ChIPS image as green lines. See the
 	    add_ds9_contours() routine from chips_contrib.utils for a
 	    way to automate this.
-	  </PARA>
+	    </PARA>
+	    -->
 	</DESC>
       </QEXAMPLE>
 
@@ -116,7 +126,7 @@ for i in range(0, len(xs))
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>April 2013</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/scale_image_crate.xml
+++ b/ciao-4.11/contrib/share/doc/xml/scale_image_crate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
   <!ENTITY keys ' '>
 ]>
 <cxchelptopics>
@@ -9,7 +9,7 @@
          seealsogroups="cr.io">
 
     <SYNOPSIS>
-      Scale the pixel values in an IMAGE crate (useful for the ChIPS add_image command)
+      Scale the pixel values in an IMAGE crate.
     </SYNOPSIS>
 
     <SYNTAX>
@@ -19,9 +19,7 @@
     <DESC>
       <PARA>
 	This routines applies a scaling function to the pixel values stored in 
-	an image crate. It is useful if you want to display the Crate using
-	add_crate or make_figure and want to change the scaling of the data
-	(since, in CIAO 4.4, images are only displayed using a linear scaling).
+	an image crate.
       </PARA>
 
       <TABLE>
@@ -65,7 +63,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS or Sherpa session by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
 <VERBATIM>
 from crates_contrib.utils import *
@@ -82,14 +80,15 @@ from crates_contrib.utils import *
 	<SYNTAX>
 	  <LINE>&pr; cr = read_file("img.fits")</LINE>
 	  <LINE>&pr; scale_image_crate(cr)</LINE>
+	  <!--
 	  <LINE>&pr; add_image(cr)</LINE>
 	  <LINE>&pr; set_plot_title("arcsinh scaling")</LINE>
 	  <LINE>&pr; set_image(["interpolation", "bilinear"])</LINE>
+	  -->
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    Here we use the default scaling method (arcsinh) to scale the data
-	    before displaying it using the ChIPS add_image() command.
+	    Here we use the default scaling method (arcsinh) to scale the data.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -98,16 +97,19 @@ from crates_contrib.utils import *
 	<SYNTAX>
 	  <LINE>&pr; r = read_file("evt2.fits[energy=500:1500][bin sky=::4]")</LINE>
 	  <LINE>&pr; g = read_file("evt2.fits[energy=1500:3500][bin sky=::4]")</LINE>
-	  <LINE>&pr; b = read_file("evt2.fits[energy=3500:700][bin sky=::4]")</LINE>
+	  <LINE>&pr; b = read_file("evt2.fits[energy=3500:7000][bin sky=::4]")</LINE>
 	  <LINE>&pr; scale_image_crate(r)</LINE>
 	  <LINE>&pr; scale_image_crate(g)</LINE>
 	  <LINE>&pr; scale_image_crate(b)</LINE>
-	  <LINE>&pr; add_image(r, g, b)</LINE>
+	  <!--
+	      <LINE>&pr; add_image(r, g, b)</LINE>
+	  -->
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    Here we use the default scaling method (arcsinh) to scale the three
-	    channels used to create a "true color" image.
+	    Here we use the default scaling method (arcsinh) to scale
+	    the "soft", "medium", and "hard" bands (these energy
+	    ranges are aribtrarily chosen for this example).
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -123,12 +125,6 @@ from crates_contrib.utils import *
 	    A new file is created - called img.scaled.fits - which contains the
 	    natural logarithm of the pixel values.
 	  </PARA>
-	  <!-- TODO: this needs to be checked to see if it is still valid -->
-	  <PARA title="Note">
-	    The dmimgcalc routine is the
-	    preferred method to modify image files since using the Crates routines
-	    in CIAO 4.4 can lead to the loss of some metadata.
-	  </PARA>
 	</DESC>
       </QEXAMPLE>
 
@@ -143,7 +139,7 @@ from crates_contrib.utils import *
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>September 2011</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/simple_hist.xml
+++ b/ciao-4.11/contrib/share/doc/xml/simple_hist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="simple_hist" context="contrib"
@@ -23,7 +23,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-	The routine can be loaded into Sherpa by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
 
 <VERBATIM>
@@ -113,26 +113,36 @@ from ciao_contrib.utils import *
 	<SYNTAX>
 	  <LINE>&pr; x = [0, 1, 2, 3, 2, 3, 4, 2, 1]</LINE>
 	  <LINE>&pr; h = simple_hist(x)</LINE>
-	  <LINE>&pr; add_histogram(h.xlow, h.xhigh, h.y)</LINE>
         </SYNTAX>
         <DESC>
 
           <PARA>
-	    The return value of h is an object with the fields "xlow", "xhigh", and "y",
-	    which contain the lower and upper bin edges and the histogram values respectively.
-	    These fields are used to plot up the histogram using the ChIPS
-	    add_histogram() routine.
+	    The return value of h is an object with the fields "xlow",
+	    "xhigh", and "y", which contain the lower and upper bin
+	    edges and the histogram values respectively.
           </PARA>
 
 <VERBATIM>
-&pr; print (h)
+&pr; print(h)
 xlow  = Float64[10]
 xhigh = Float64[10]
 y     = Int32[10]
 &pr; print (h.y)
 [1 0 2 0 0 3 0 2 0 1]
 </VERBATIM>
-        </DESC>
+
+          <PARA>
+	    This can be displayed with the Matplotlib
+	    <HREF link="https://matplotlib.org/2.2.3/api/_as_gen/matplotlib.pyplot.bar.html">bar</HREF>
+	    function:
+	  </PARA>
+	  <PARA>
+	    <SYNTAX>
+	      <LINE>&pr; import matplotlib.pyplot as plt</LINE>
+	      <LINE>&pr; plt.bar(h.xlow, h.y, h.xhigh - h.xlow, align='edge')</LINE>
+	    </SYNTAX>
+	  </PARA>
+	</DESC>
       </QEXAMPLE>
 
       <QEXAMPLE>
@@ -147,11 +157,11 @@ y     = Int32[10]
           </PARA>
 
 <VERBATIM>
-&pr; print (h)
+&pr; print(h)
 xlow  = Float64[4]
 xhigh = Float64[4]
 y     = Int32[4]
-&pr; print (h.y)
+&pr; print(h.y)
 [1 2 3 3]
 </VERBATIM>
 
@@ -177,7 +187,7 @@ y     = Int32[4]
 
     </QEXAMPLELIST>
 
-    <LASTMODIFIED>June 2010</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
  </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/simple_stats.xml
+++ b/ciao-4.11/contrib/share/doc/xml/simple_stats.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="simple_stats" context="contrib"
@@ -25,7 +25,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-	The routine can be loaded into Sherpa by saying:
+	The routine can be loaded into a Python session by saying:
       </PARA>
 
 <VERBATIM>
@@ -91,7 +91,7 @@ from ciao_contrib.utils import *
           </PARA>
 
 <VERBATIM>
-&pr; print (s)
+&pr; print(s)
 npts   = 10
 min    = 0
 max    = 5
@@ -99,8 +99,8 @@ total  = 23
 mean   = 2.3
 median = 2.0
 stddev = 1.41774468788
-&pr; print ("The mean is {0} +- {1}".format(s.mean, s.stddev))
-The mean is 2.3 +- 1.41774
+&pr; print("The mean is {0} +- {1}".format(s.mean, s.stddev))
+The mean is 2.3 +- 1.4177446878757827
 </VERBATIM>
 
         </DESC>

--- a/ciao-4.11/contrib/share/doc/xml/simplecoordtransform.xml
+++ b/ciao-4.11/contrib/share/doc/xml/simplecoordtransform.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="simplecoordtransform" context="contrib"
@@ -24,7 +24,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS or Sherpa session by saying:
+	The routine can be loaded into a Python session by saying:
       </PARA>
 <VERBATIM>
 from crates_contrib.utils import *
@@ -71,21 +71,29 @@ from crates_contrib.utils import *
 
       <QEXAMPLE>
 	<SYNTAX>
-	  <LINE>&pr; tcr = read_file("sources.fits[cols ra,dec]")</LINE>
-	  <LINE>&pr; ra = copy_colvals(tcr, "ra")</LINE>
-	  <LINE>&pr; dec = copy_colvals(tcr, "dec")</LINE>
-	  <LINE>&pr; icr = read_file("img.fits")</LINE>
-	  <LINE>&pr; tr = SimpleCoordTransform("img.fits")</LINE>
-	  <LINE>&pr; (x, y) = tr.convert("world", "image", ra, dec)</LINE>
-	  <LINE>&pr; add_image(icr, ["wcs", "logical"])</LINE>
-	  <LINE>&pr; add_points(x, y, ["symbol", "square", "fill", False])</LINE>
+	  <LINE>&pr; tcr = read_file('sources.fits[cols ra,dec]')</LINE>
+	  <LINE>&pr; ra = tcr.get_column('ra').values</LINE>
+	  <LINE>&pr; dec = tcr.get_column('dec').values</LINE>
+	  <LINE>&pr; icr = read_file('img.fits')</LINE>
+	  <LINE>&pr; tr = SimpleCoordTransform('img.fits')</LINE>
+	  <LINE>&pr; (x, y) = tr.convert('world', 'image', ra, dec)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Here Ra and Dec coordiantes from the file "sources.fits" are
 	    converted into image (a.k.a. logical) coordinates of the
-	    image stored in img.fits. They are then drawn, as open squares, on
-	    top of the image using ChIPS.
+	    image stored in img.fits.
+	  </PARA>
+	  <PARA>
+	    The points can then be overlaid on the iage using the following
+	    Matplotlib code:
+	  </PARA>
+	  <PARA>
+	    <SYNTAX>
+	      <LINE>&pr; import matplotlib.pyplot as plt</LINE>
+	      <LINE>&pr; plt.imshow(icr.get_image().values, origin='lower')</LINE>
+	      <LINE>&pr; plt.scatter(x, y, color='orange')</LINE>
+	    </SYNTAX>
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -118,7 +126,7 @@ from crates_contrib.utils import *
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>April 2014</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/smooth_image_crate.xml
+++ b/ciao-4.11/contrib/share/doc/xml/smooth_image_crate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="smooth_image_crate" context="contrib"
@@ -8,7 +8,7 @@
          seealsogroups="cr.io ">
 
     <SYNOPSIS>
-      Smooth the pixel values in an IMAGE crate (useful for add_image)
+      Smooth the pixel values in an IMAGE crate.
     </SYNOPSIS>
 
     <SYNTAX>
@@ -18,8 +18,7 @@
     <DESC>
       <PARA>
 	This routines smoothes the pixel values stored in 
-	an image crate. It is useful if you want to display the Crate using
-	add_crate or make_figure, so that the WCS information is retained.
+	an image crate.
 	If you want to smooth an image and save it to disk it is suggested
 	that the aconvolve tool be used rather than this one.
       </PARA>
@@ -86,7 +85,7 @@
       </PARA>
 
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS, Sherpa or a Python script by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
 <VERBATIM>
 from crates_contrib.utils import *
@@ -105,13 +104,10 @@ from crates_contrib.utils import *
 	  <LINE>&pr; from crates_contrib.utils import *</LINE>
 	  <LINE>&pr; cr = read_file("img.fits")</LINE>
 	  <LINE>&pr; smooth_image_crate(cr, "gauss", 5)</LINE>
-	  <LINE>&pr; add_image(cr)</LINE>
-	  <LINE>&pr; set_plot_title(r"gaussian smoothing (\sigma=5)")</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    The gaussian-smoothed version of the data in img.fits is
-	    displayed using the ChIPS add_image() command.
+	    The data in img.fits is smoothed with a gaussian.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -120,11 +116,12 @@ from crates_contrib.utils import *
 	<SYNTAX>
 	  <LINE>&pr; cr = read_file("img.fits")</LINE>
 	  <LINE>&pr; smooth_image_crate(cr, "tophat", 3)</LINE>
-	  <LINE>&pr; add_image(cr)</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Here the image is smoothed with a 3-pixel radius top-hat kernel.
+	    Note that the data is re-loaded from the file (otherwise
+	    the previously-smoothed image would have been used).
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -166,12 +163,11 @@ from crates_contrib.utils import *
 	  <LINE>&pr; cr = read_file("img.fits")</LINE>
 	  <LINE>&pr; smooth_image_crate(cr, "gauss", 3)</LINE>
 	  <LINE>&pr; scale_image_crate(cr, "arcsinh")</LINE>
-	  <LINE>&pr; make_figure(cr, "image")</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Here we smooth an image and then apply an arcsinh transform
-	    before displaying it in ChIPS.
+	    to the smoothed data.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -192,18 +188,6 @@ from crates_contrib.utils import *
            return cr
 
 </VERBATIM>
-	  <PARA>
-	    This routine can then be used to create a three-color
-	    image using the following set of commands:
-	  </PARA>
-	  <PARA>
-	    <SYNTAX>
-	      <LINE>&pr; r = getfile("evt2.fits[energy=500:1500][bin sky=::4]")</LINE>
-	      <LINE>&pr; g = getfile("evt2.fits[energy=1500:3500][bin sky=::4]")</LINE>
-	      <LINE>&pr; b = getfile("evt2.fits[energy=3500:700][bin sky=::4]")</LINE>
-	      <LINE>&pr; add_image(r, g, b)</LINE>
-	    </SYNTAX>
-	  </PARA>
 	</DESC>
       </QEXAMPLE>
 
@@ -218,7 +202,7 @@ from crates_contrib.utils import *
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>September 2011</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/ciao-4.11/contrib/share/doc/xml/write_columns.xml
+++ b/ciao-4.11/contrib/share/doc/xml/write_columns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
-  <!ENTITY pr  'chips>'>
+  <!ENTITY pr  '>>>'>
 ]>
 <cxchelptopics>
   <ENTRY key="write_columns" context="contrib"
@@ -33,7 +33,7 @@
 	to a file as a table, in ASCII or FITS binary format.
       </PARA>
       <PARA title="Loading the routine">
-	The routine can be loaded into a ChIPS or Sherpa session by saying:
+	The routine can be loaded into Python by saying:
       </PARA>
 <VERBATIM>
 from crates_contrib.utils import *
@@ -310,7 +310,7 @@ ROW    col1       col2[2]
       </PARA>
     </BUGS>
  
-    <LASTMODIFIED>December 2011</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This is mainly ahelp files, but the docstrings in two Python modules have also been changed. It is not complete (some changes are in existing PRs, some will need to be done once the ChIPS code is fully removed, and some [*] may have been missed in this sweep).

[*] in particular, the examples may still contain chips calls