### PR TITLE
replace StringIO with BytesIO in downloadutils

### DIFF
--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/downloadutils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/downloadutils.py
@@ -31,7 +31,7 @@ at your own risk.
 """
 
 
-from io import StringIO
+from io import BytesIO
 from subprocess import check_output
 import urllib
 import urllib.request
@@ -90,7 +90,7 @@ def manual_download(url):
                    "CXC HelpDesk)."
             raise RuntimeError(emsg)
 
-    return StringIO(rsp.decode("utf-8"))
+    return BytesIO(rsp)
 
 
 def retrieve_url(url, timeout=None):


### PR DESCRIPTION
Replace `StringIO` with `BytesIO` to return the same file-like object returned by `urlopen()`
