### PR TITLE
chandra_repro: support HRC obs w/ 0 ontime

### DIFF
--- a/ciao-4.11/contrib/bin/chandra_repro
+++ b/ciao-4.11/contrib/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "13 May 2019"
+version = "11 Jun 2019"
 
 # import standard python modules as required
 #
@@ -1929,10 +1929,16 @@ def l2_hrc_events(params):
     dtfstats = os.path.join(outdir, root + '_repro_dtfstats.fits')
     # this is *not* a replacement for the dtf1 file
 
+    gtifile = evt2+"[GTI]"
+    ontime = pyc.read_file(flt1).get_key_value("ONTIME")
+    if 0 == ontime:
+        # Warning is generated elsewhere
+        gtifile = flt1+"[FILTER]"
+
     hrc_dtfstats.punlearn()
     hrc_dtfstats.infile=dtf1
     hrc_dtfstats.outfile=dtfstats
-    hrc_dtfstats.gtifile=evt2+"[GTI]"
+    hrc_dtfstats.gtifile=gtifile
     hrc_dtfstats.clobber=clobber
     out=hrc_dtfstats()
     v5("hrc_dtfstats returned")

--- a/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
+++ b/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
@@ -751,6 +751,15 @@ acisf084244478N003_2_bias0.fits.gz
     </PARAMLIST>
 
 
+<ADESC title="Changes in scripts 4.X.Y (Month Year) release">
+ <PARA>
+   Updated to support HRC observations with no Level 2 good time, ONTIME=0. 
+   Users get a recalibrated Level 1 event file when they set cleanup=no.
+ </PARA>
+
+</ADESC>
+
+
 
 <ADESC title="Changes in scripts 4.11.3 (May 2019) release">
   <PARA>
@@ -1067,6 +1076,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>May 2019</LASTMODIFIED>
+    <LASTMODIFIED>June 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixed #239 .  With 0 ontime, the L2 GTIs are missing (DM omits them) so instead we use the flt1 file.  It's still 0|NULL but it exists which is what was causing the problem.  Elsewhere in the script it issues a warning about 0 ONTIME so no need to add on here.
