### PR TITLE
added catch on ValueError 

### DIFF
--- a/ciao-4.11/contrib/bin/ecf_calc
+++ b/ciao-4.11/contrib/bin/ecf_calc
@@ -20,7 +20,7 @@ Usage:
 
 __version__ = "CIAO 4.11"
 toolname = "ecf_calc"
-__revision__ = "12 June 2019"
+__revision__ = "05 September 2019"
 
 import numpy, tempfile, sys, os, paramio
 
@@ -217,7 +217,7 @@ def get_ecf(infile,reg,outfile,x,y,radius,binsize,fraction,clobber):
         try:
             file.delete_column(col)
             break
-        except AttributeError:
+        except (ValueError,AttributeError):
             continue
 
     r_mid = [numpy.mean(bin) for bin in rad]


### PR DESCRIPTION
a change to cr.delete_column throws a ValueError in CIAOX 09092019 build rather than AttributeError like in prior versions.