### PR TITLE
missing exposure keywords set to 0 for CalcGTI merging rule

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -1,3 +1,13 @@
+## 4.11.x - ? ##
+
+Updated scripts
+
+  merge_obs, flux_obs
+
+    Observations with different ACIS chip arrangements can now be
+    handled when using the exptime and expmap options for the
+    psfmerge parameter.
+
 ## 4.11.4 - August 2019 ##
 
 This release updates the Sherpa plotting functionality to use Matplotlib

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/headers.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/_tools/headers.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2018
+#  Copyright (C) 2018, 2019
 #    Smithsonian Astrophysical Observatory
 #
 #
@@ -81,8 +81,9 @@ class BaseMergeRule:
             values = [v if v is not None else self.default
                       for v in values]
 
+        v4("Merging {}".format(values))
         newval = self._merge(values)
-        v4("Merged {} -> {}".format(values, newval))
+        v4(" -> Merged = {}".format(newval))
         return newval
 
     def _merge(self, values):
@@ -217,6 +218,9 @@ class CalcGTIMergeRule(BaseMergeRule):
     This just sums the input values, assuming that they do not
     overlap in time. This should be okay for the "merging observation"
     workload, but is not correct in all cases.
+
+    It is expected that the default is set to 0, so that missing
+    values are essentially skipped.
     """
 
     def __init__(self, key, default=None):
@@ -466,7 +470,7 @@ def parse_merge_rule(key, rulespec):
     elif rupper == 'CALCFORCE':
         return CalcForceMergeRule(key)
     elif rupper == 'CALCGTI':
-        return CalcGTIMergeRule(key)
+        return CalcGTIMergeRule(key, default=0)
     elif rupper == 'FORCE':
         return ForceMergeRule(key, default=val1)
     elif rupper == 'WARNFIRST':


### PR DESCRIPTION
This should allow the combination of PSF maps using exposure-related
scaling when one or more chips are missing in one (or more) obsids.

This should fix the second part of the problem seen in #262