### PR TITLE
Update instrument-map weight code to make more use of public interfaces

### DIFF
--- a/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/sherpa_contrib/utils.py
@@ -189,7 +189,7 @@ class InstMapWeights:
 
         # Apply the filter if necessary.
         #
-        m = data._get_mask()
+        m = data.mask
         if _is_boolean(m):
             if not m:
                 raise RuntimeError("filter excludes all data")
@@ -476,7 +476,7 @@ class InstMapWeights1DInt(InstMapWeights):
 
         # Handle a case when dataspace1d in CIAO 4.1.2 can produce
         # different length bins. If this has happened then we know
-        # that d._get_mask() will be True since ignore/notice will
+        # that d.mask will be True since ignore/notice will
         # fail to work on such a dataset. We do not take advantage of
         # this knowledge since it doesn't really help.
         #


### PR DESCRIPTION
CIAO 4.12 removes the _get_mask method from the Data hierarchy, but prior
to that we can use the mask attribute to get at the values. This change
should not break CIAO 4.11 or 4.12 behavior, but there's a lot of needed
changes to the Sherpa data hierarchy in CIAO 4.12 so there may be other
problems.

This is to fix #258