### PR TITLE
Relax keyword requirements for lightcurve (fix regression)

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -2,11 +2,23 @@
 
 Updated scripts
 
-  merge_obs, flux_obs
+  deflare
+
+    The script can now be used to create plots for XMM data fiels
+    again (or any file without some of the keywords that are only
+    used to label the plots).
+
+  flux_obs, merge_obs
 
     Observations with different ACIS chip arrangements can now be
     handled when using the exptime and expmap options for the
     psfmerge parameter.
+
+Python modules
+
+  lightcurves
+
+    The same fix for the plotting routines as seen with deflare.
 
 ## 4.11.4 - August 2019 ##
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
@@ -279,12 +279,17 @@ class LightCurve:
 
     def add_label(self, crate, name, protect=True):
         """If there is a keyword of the given name in the crate, add
-        it to the store.
+        it to the store. If the keyword does not exist do
+        nothing.
 
         The protect argument is now ignored.
         """
 
-        val = pcr.get_keyval(crate, name)
+        # crate.get_key_value returns None on a missing lookup,
+        # pycrates.get_keyval raises a LookupError when the key is
+        # not found.
+        #
+        val = crate.get_key_value(name)
         if val is None:
             return
 


### PR DESCRIPTION
The update to using matplotlib removed a necessary test for accessing
a keyword value, which meant that if the input file didn't have the
necessary keywords the code would now fall over. The code has been
changed to a method that returns None (which was being checked for)
rather than throwing an error.

This should allow light-curve code (deflare and the lc_clean/_sigma_clip
routines) to work with non-Chandra data.

Should fix #270 