### PR TITLE
chandra_repro update bitflag for framestore shadow

### DIFF
--- a/ciao-4.11/contrib/bin/chandra_repro
+++ b/ciao-4.11/contrib/bin/chandra_repro
@@ -1149,7 +1149,7 @@ def create_acis_badpix(params):
         acis_build_badpix.procbias='no'
 
         # reset the bitflag to the default
-        acis_build_badpix.bitflag='00000000000000022221100020022222'
+        acis_build_badpix.bitflag='00000000000000122221100020022222'
 
         out = acis_build_badpix()
         v5("acis_build_badpix returned")

--- a/ciao-4.11/contrib/bin/chandra_repro
+++ b/ciao-4.11/contrib/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "24 September 2019"
+version = "30 October 2019"
 
 # import standard python modules as required
 #
@@ -1122,7 +1122,7 @@ def create_acis_badpix(params):
         acis_build_badpix.berrfile='none'
         acis_build_badpix.calibfile='CALDB'
         acis_build_badpix.biasfile='@'+bias0
-        acis_build_badpix.bitflag='00000000000000020021100020022222'
+        acis_build_badpix.bitflag='00000000000000120021100020022222'
         acis_build_badpix.obsfile=obspar
         out = acis_build_badpix()
         v5("acis_build_badpix returned")

--- a/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
+++ b/ciao-4.11/contrib/share/doc/xml/chandra_repro.xml
@@ -751,6 +751,14 @@ acisf084244478N003_2_bias0.fits.gz
     </PARAMLIST>
 
 
+<ADESC title="Changes in script 4.12.1 (December 2019) release">
+  <PARA>
+    Updated to support new badpixels associated with bottom rows
+    of each CCD due to 'shadow' cast by frame-store cover.  
+  </PARA>
+</ADESC>
+
+
 <ADESC title="Change in script 4.11.5 (October 2019) release">
   <PARA>
     Internal only changes to correct verbose handling in newer versions


### PR DESCRIPTION
This must wait for CIAO 4.12 to be released.  

I expect other chandra_repro updates to deal with ASPSOL to ASPOBI (or whatever) changes ... maybe?