### PR TITLE
merge_obs: fix sort order when dealing with interleaved mode

### DIFF
--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -1076,9 +1076,8 @@ def validate_obsinfo(infiles, colcheck=True):
         # Sort primary second, secondary (longer) first, HRC is None.
         sort_order = { 'P' : 2, 'S' : 1, None: 0 } 
 
-        # leading zero pad to preserve numeric sort order.
         sort_tag = sort_order[obs.obsid.cycle]
-        time_tag= "{:020.3f}_{}".format(obs.tstart,sort_tag)
+        time_tag= (obs.tstart,sort_tag) # tuples sort too
         obsinfos.append((time_tag, obs))
 
     ninfiles = len(obsinfos)

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -1073,7 +1073,13 @@ def validate_obsinfo(infiles, colcheck=True):
             blank_line = True
             continue
 
-        obsinfos.append((obs.tstart, obs))
+        # Sort primary second, secondary (longer) first, HRC is None.
+        sort_order = { 'P' : 2, 'S' : 1, None: 0 } 
+
+        # leading zero pad to preserve numeric sort order.
+        sort_tag = sort_order[obs.obsid.cycle]
+        time_tag= "{:020.3f}_{}".format(obs.tstart,sort_tag)
+        obsinfos.append((time_tag, obs))
 
     ninfiles = len(obsinfos)
     if ninfiles == 0:


### PR DESCRIPTION
`merge_obs` (and I guess `reproject_obs`?) sorts the input list of event files based on `TSTART` .

But interleaved mode datasets have the same `TSTART` so the e1 and e2 files can end up in a random order.  This affects things like DTCOR, LIVETIME, etc keywords, and which events show up first in the merged event file.

This change adds appends a sortable token (string) to the end of the TSTART to ensure a deterministic order.

I've chosen to sort so that the e2 file comes first since it is the longer of the two -- that is most events come from the e2 dataset so it's DTCOR/etc are appropriate for more of the events.


## TODO

- Review whether we should actually `dmsort` the event file on `TIME` if it contains both `e1` and `e2`.


