### PR TITLE
Update runtool to add catalog parameter for [obsid_]search_csc

### DIFF
--- a/ciao-4.11/contrib/Changes.CIAO_scripts
+++ b/ciao-4.11/contrib/Changes.CIAO_scripts
@@ -1,6 +1,11 @@
-## 4.11.x - ? ##
+## 4.11.5 - October 2019 ##
 
 Updated scripts
+
+  search_csc, obsid_search_csc
+
+    These scripts now default to the Chandra Source Catalog 2.0 release.
+    Use version=csc1 if you need to search version 1.1 of the CSC.  
 
   deflare
 
@@ -23,9 +28,16 @@ Updated scripts
 
 Python modules
 
+  ciao_contrib.runtool
+
+    The module has been updated to add the catalog parameter to the
+    search_csc and obsid_search_csc functions. The default is to
+    use version 2.0 of the Chandra Source Catalog.
+
   lightcurves
 
     The same fix for the plotting routines as seen with deflare.
+
 
 ## 4.11.4 - August 2019 ##
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/runtool.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/ciao_contrib/runtool.py
@@ -3346,7 +3346,7 @@ parinfo['multi_chip_gti'] = {
 parinfo['obsid_search_csc'] = {
     'istool': True,
     'req': [ParValue("obsid","s","Chandra Observation ID",None),ParValue("outfile","f","Name of output table (TSV format)",None)],
-    'opt': [ParValue("columns","s","List of columns to include",'INDEF'),ParSet("download","s","Download data products for which sources?",'none',["none","ask","all"]),ParValue("root","f","Output root for data products",'./'),ParValue("bands","s","Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all",'broad,wide'),ParValue("filetypes","s","Comma separated list of CSC filetypes.  Blank retrieves all",'regevt,pha,arf,rmf,lc,psf,regexp'),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove existing outfile if it exists?",False)],
+    'opt': [ParValue("columns","s","List of columns to include",'INDEF'),ParSet("download","s","Download data products for which sources?",'none',["none","ask","all"]),ParValue("root","f","Output root for data products",'./'),ParValue("bands","s","Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all",'broad,wide'),ParValue("filetypes","s","Comma separated list of CSC filetypes.  Blank retrieves all",'regevt,pha,arf,rmf,lc,psf,regexp'),ParSet("catalog","s","Version of catalog",'csc2',["csc2","csc1"]),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove existing outfile if it exists?",False)],
     }
 
 
@@ -3451,7 +3451,7 @@ parinfo['roi'] = {
 parinfo['search_csc'] = {
     'istool': True,
     'req': [ParValue("pos","s","Input position.  RA, Dec, eg: 246.59955,-24.415158 or name, M81",None),ParRange("radius","r","Search radius [default: arcmin]",0,0,60),ParValue("outfile","f","Name of output table (TSV format)",None)],
-    'opt': [ParSet("radunit","s","Units of search radius",'arcmin',["arcmin","arcsec","deg"]),ParValue("columns","s","List of columns to return",'INDEF'),ParValue("sensitivity","b","Retrieve Limiting sensitivity for each energy band?",False),ParSet("download","s","Download data products for which sources?",'none',["none","ask","all"]),ParValue("root","f","Output root for data products",'./'),ParValue("bands","s","Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all",'broad,wide'),ParValue("filetypes","s","Comma separated list of CSC filetypes.  Blank retrieves all",'regevt,pha,arf,rmf,lc,psf,regexp'),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove existing outfile if it exists?",False)],
+    'opt': [ParSet("radunit","s","Units of search radius",'arcmin',["arcmin","arcsec","deg"]),ParValue("columns","s","List of columns to return",'INDEF'),ParValue("sensitivity","b","Retrieve Limiting sensitivity for each energy band?",False),ParSet("download","s","Download data products for which sources?",'none',["none","ask","all"]),ParValue("root","f","Output root for data products",'./'),ParValue("bands","s","Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all",'broad,wide'),ParValue("filetypes","s","Comma separated list of CSC filetypes.  Blank retrieves all",'regevt,pha,arf,rmf,lc,psf,regexp'),ParSet("catalog","s","Version of catalog",'csc2',["csc2","csc1"]),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove existing outfile if it exists?",False)],
     }
 
 


### PR DESCRIPTION
This updates the `ciao_contrib.runtool` module to support the catalog parameter for the `search_csc` and `obsid_search_csc` scripts. Previously this parameter only supported a single value and so was ignored by the parameter interface. It can now be set to `csc2` or `csc1` as of #287 and this PR updates the runtool interface to support this new behavior.