### PR TITLE
updated lightcurves.py and deflare to handle matplotlib 3 deprecations

### DIFF
--- a/ciao-4.11/contrib/bin/deflare
+++ b/ciao-4.11/contrib/bin/deflare
@@ -71,7 +71,7 @@ from ciao_contrib.param_wrapper import open_param_file
 
 
 toolname = "deflare"
-__revision__ = "11 June 2019"
+__revision__ = "05 November 2019"
 
 initialize_logger(toolname)
 
@@ -160,16 +160,15 @@ def wrapup(params, plot_stat):
             format = "ps"
         elif oplot.lower().endswith(".eps"):
             format = "eps"
-        elif oplot.lower().endswith("png"):
+        elif oplot.lower().endswith(".png"):
             format = "png"
+        elif oplot.lower().endswith(".svg"):
+            format = "svg"
         else:
             oplot += ".pdf"
             format = "pdf"
 
-#        if not oplot.endswith(".pdf"):
-#            oplot += ".pdf"
-
-        plt.savefig(oplot, format=format, frameon=True)
+        plt.savefig(oplot, format=format)
 
         v1("Created: {0}".format(oplot))
 

--- a/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
+++ b/ciao-4.11/contrib/lib/python3.5/site-packages/lightcurves.py
@@ -57,7 +57,7 @@ import matplotlib.pyplot as plt
 # __all__ = ("lc_sigma_clip", "lc_sigma_uclip", "lc_clean")
 __all__ = ("lc_sigma_clip", "lc_clean")
 
-__revision = "June 2019"
+__revision = "04 November 2019"
 
 
 def _write_gti_text(outfile, tstart, tend):
@@ -566,7 +566,17 @@ class LightCurve:
         # setup figure
 
         if rateaxis == "y":
-            fig, axs = plt.subplots(2, 1, tight_layout=True)
+            from matplotlib import tight_layout
+
+            fig, axs = plt.subplots(2, 1, tight_layout=False)
+            hpad = tight_layout.get_tight_layout_figure(fig, 
+                                                        axs, 
+                                                        tight_layout.get_subplotspec_list(axs),
+                                                        tight_layout.get_renderer(fig))["hspace"]
+
+            #fig.set_figheight(fig.get_figheight()+2*hpad)
+            fig.subplots_adjust(hspace=2*hpad)
+
         else:
             fig, axs = plt.subplots(2, 1, sharex=True)
             fig.subplots_adjust(hspace=0)
@@ -729,7 +739,7 @@ class LightCurve:
 
             axs[1].set_xlim(auto=True)
             axs[1].set_ylim(bottom=0, auto=True)
-
+            
             if rateaxis == "x":
                 y_minor_ticks = axs[1].yaxis.get_minorticklocs()
                 dytick = y_minor_ticks[1] - y_minor_ticks[0]
@@ -768,10 +778,11 @@ class LightCurve:
 
                 y_minor_ticks = mplaxs[0].yaxis.get_minorticklocs()
                 dytick = y_minor_ticks[1] - y_minor_ticks[0]
-                yrs = [yr[0], yr[1] + dytick]
+                yrs = [yr[0] - dytick, yr[1] + dytick]
 
-                mplaxs[0].set_ylim(bottom=min(y_minor_ticks),
-                                   top=max(y_minor_ticks) + dytick)
+                mplaxs[0].set_ylim(bottom=min(yrs),
+                                   top=max(yrs))
+
             else:
                 start = np.append(startvals, yr[1])
                 end = np.append(yr[0], stopvals)


### PR DESCRIPTION
these changes should address the deprecation warnings and drastically different plots reported in #293 and #295 with matplotlib 3.