### PR TITLE
Handle numpy div by zero, missing ASCDS_CONTRIB env variable, MJD-OBS/MJD_OBS in fileio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *.gz
 *.pyc
+build/

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -2728,7 +2728,7 @@ def expmap_weight(infiles, expmaps, outfile, lookupTable,
     # It should not be needed here (only in the exptime weight) but
     # left in just to make sure.
     #
-    res = np.seterr(invalid='ignore')
+    res = np.seterr(invalid='ignore', divide='ignore')
     try:
         newvals = numerator / denominator
         newvals = newvals.astype(np.float32)


### PR DESCRIPTION
- fix #257 for `ciao_contrib._tools.fileio`

The following only address the merge/flux suite of scripts.

- fix #304 - `ASCDS_CONTRIB` is not guaranteed to be defined (make ASCDS_CALIB optional too for "safety")

- fix #296 - hide divide-by-zero warnings seen with recent NumPy versions.
