### PR TITLE
Remove expand stack

### DIFF
--- a/bin/blanksky
+++ b/bin/blanksky
@@ -18,37 +18,17 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-__version__ = "CIAO 4.11"
 toolname = "blanksky"
-__revision__  = "01 May 2019"
+__revision__  = "13 November 2019"
 
 import os, sys, paramio, tempfile, shutil, stat
+
+import stk
 import pycrates as pcr
-
-# This is only needed for development.
-try:
-    if not __file__.startswith(os.environ['ASCDS_INSTALL']):
-        _thisdir = os.path.dirname(__file__)
-        _libname = "python{}.{}".format(sys.version_info.major,
-                                        sys.version_info.minor)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
-        if os.path.isdir(_pathdir):
-            os.sys.path.insert(1, _pathdir)
-        else:
-            print("*** WARNING: no {}".format(_pathdir))
-
-        del _libname
-        del _pathdir
-        del _thisdir
-
-except KeyError:
-    raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
-########################################################
 
 from crates_contrib.utils import *
 from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
 from ciao_contrib.param_wrapper import open_param_file
-from ciao_contrib.stacklib import expand_stack
 
 from ciao_contrib._tools import fluximage, utils, fileio, obsinfo, bands
 
@@ -318,7 +298,7 @@ def get_par(argv):
     elif params["evtfile"].startswith("@"):
         error_out("Input event stacks not supported.")
     else:
-        #params["evtfile"] = expand_stack(params["evtfile"])
+        #params["evtfile"] = stk.build(params["evtfile"])
         params["infile_filter"] = fileio.get_filter(params["evtfile"])
         params["evtfile"] = fileio.get_file(params["evtfile"])
 
@@ -341,7 +321,7 @@ def get_par(argv):
         if params["asol"].lower() == "none":
             error_out("Aspect solutions are required to run {}.".format(toolname))
         else:
-            params["asol"] = ",".join(expand_stack(params["asol"]))
+            params["asol"] = ",".join(stk.build(params["asol"]))
     else:
         fobs = obsinfo.ObsInfo(params["evtfile"])
 
@@ -490,7 +470,7 @@ def blanksky(infile,filters,asols,tmpdir,keywords,verbose,clobber):
             ccds.remove(9)
 
         if [0 in ccds, set([4,5,6,7,8,9]).isdisjoint(set(ccds))] == [True,False]:
-            # check location of aimpoint with dmcoords using the 
+            # check location of aimpoint with dmcoords using the
             # time-averaged optical-axis coordinates
             ra_pnt = keywords["RA_PNT"]
             dec_pnt = keywords["DEC_PNT"]

--- a/bin/blanksky_image
+++ b/bin/blanksky_image
@@ -22,35 +22,17 @@
 # 02110-1301 USA.
 #
 
-__version__ = "CIAO 4.11"
 toolname = "blanksky_image"
-__revision__  = "23 April 2019"
+__revision__  = "13 November 2019"
 
 
 import os, sys, paramio, tempfile, numpy
+
 import pycrates as pcr
-
-# This is only needed for development.
-# try:
-#     if not __file__.startswith(os.environ['ASCDS_INSTALL']):
-#         _thisdir = os.path.dirname(__file__)
-#         _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib/python2.7/site-packages'))
-#         if os.path.isdir(_pathdir):
-#             os.sys.path.insert(1, _pathdir)
-#         else:
-#             print("*** WARNING: no {}".format(_pathdir))
-
-#         del _pathdir
-#         del _thisdir
-
-# except KeyError:
-#     raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
-########################################################
 
 from crates_contrib.utils import *
 from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
 from ciao_contrib.param_wrapper import open_param_file
-from ciao_contrib.stacklib import expand_stack
 
 from ciao_contrib._tools import utils, fileio
 

--- a/bin/blanksky_sample
+++ b/bin/blanksky_sample
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2017, 2018
+# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -22,38 +22,16 @@
 # 02110-1301 USA.
 #
 
-__version__ = "CIAO 4.10"
 toolname = "blanksky_sample"
-__revision__  = "23 October 2018"
+__revision__  = "13 November 2019"
 
 import os, sys, paramio, tempfile
+
+import stk
 import pycrates as pcr
-
-#######################################################################
-# This is only needed for development.
-try:
-    if not __file__.startswith(os.environ['ASCDS_INSTALL']):
-        _thisdir = os.path.dirname(__file__)
-        _libname = "python{}.{}".format(sys.version_info.major,sys.version_info.minor)
-
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib',_libname, 'site-packages'))
-        
-        if os.path.isdir(_pathdir):
-            os.sys.path.insert(1, _pathdir)
-        else:
-            print("*** WARNING: no {}".format(_pathdir))
-            
-        del _libname
-        del _pathdir
-        del _thisdir
-
-except KeyError:
-    raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
-#######################################################################
 
 from ciao_contrib.param_wrapper import open_param_file
 from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
-from ciao_contrib.stacklib import expand_stack
 
 from ciao_contrib._tools import fileio, utils
 
@@ -146,7 +124,7 @@ def get_par(argv):
     if params["regionfile"] != "":
         if params["fill_out"] == "":
             error_out("input 'regionfile' specified, an output 'fill_out' file must be specified")
-            
+
     else:
         if params["fill_out"] != "":
             error_out("'fill_out' output file specified, an input 'regionfile' must also be specified")
@@ -168,13 +146,13 @@ def get_par(argv):
     else:
         params["bkgfile_filter"] = fileio.get_filter(params["bkgfile"])
         params["bkgfile"] = fileio.get_file(params["bkgfile"])
-    
+
     # output blanksky sampled file name
     if params["bkgout"] == "":
         error_out("Please specify an output background file name.")
     else:
         params["bkgoutdir"],bkgoutfile = utils.split_outroot(params["bkgout"])
-        
+
         if params["bkgout"].endswith("_"):
             params["bkgout"] = bkgoutfile
         else:
@@ -186,7 +164,7 @@ def get_par(argv):
     # output PSF+bkg file name
     if params["psf_bkg_out"] != "":
         psf_bkg_outdir,psf_bkg_outfile = utils.split_outroot(params["psf_bkg_out"])
-        
+
         if params["psf_bkg_out"].endswith("_"):
             params["psf_bkg_out"] = psf_bkg_outfile
         else:
@@ -199,11 +177,11 @@ def get_par(argv):
     # input region file
     if params["regionfile"] != "":
         params["regionfile"] = fileio.get_file(params["regionfile"])
-    
+
     # output fill_out file name
     if params["fill_out"] != "":
         params["fill_outdir"],fill_outfile = utils.split_outroot(params["fill_out"])
-        
+
         if params["fill_out"].endswith("_"):
             params["fill_out"] = fill_outfile
         else:
@@ -212,9 +190,9 @@ def get_par(argv):
         # check if output directory is writable
         fileio.validate_outdir(params["fill_outdir"])
 
-    # aspect solution files, listed in quotes.    
+    # aspect solution files, listed in quotes.
     if params["asol"] != "":
-        params["asol"] = ",".join(expand_stack(params["asol"]))
+        params["asol"] = ",".join(stk.build(params["asol"]))
 
 
     # close parameters block after validation
@@ -227,9 +205,9 @@ def get_par(argv):
 
 def _get_nevt(fn):
     """get number of events"""
-    
+
     cr = pcr.read_file(fn)
-    
+
     nevt = cr.get_nrows()
 
     cr.__del__()
@@ -272,7 +250,7 @@ def _cols2int4(fn,tmpdir):
                 tmpcol_del = "[cols -tmppha]"
 
         dmtcalc.punlearn()
-        dmtcalc.infile = fn 
+        dmtcalc.infile = fn
         dmtcalc.outfile = tmp1.name
         dmtcalc.expression = convert_col
         dmtcalc.verbose = "0"
@@ -294,7 +272,7 @@ def _cols2int4(fn,tmpdir):
         dmcopy.outfile = fn
         dmcopy.verbose = "0"
         dmcopy.clobber = "yes"
-        dmcopy()   
+        dmcopy()
 
         tmp2.close()
 
@@ -307,7 +285,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     dmtcalc.punlearn()
     dmtcalc.infile = infile
     dmtcalc.outfile = tmp1.name
-    dmtcalc.expression = "tmpx=(float)x,tmpy=(float)y,tmpdetx=(float)detx,tmpdety=(float)dety,tmpchipx=(short)chipx,tmpchipy=(short)chipy" 
+    dmtcalc.expression = "tmpx=(float)x,tmpy=(float)y,tmpdetx=(float)detx,tmpdety=(float)dety,tmpchipx=(short)chipx,tmpchipy=(short)chipy"
     dmtcalc.verbose = "0"
     dmtcalc.clobber= "yes"
     dmtcalc()
@@ -321,7 +299,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     dmtcalc()
 
     dmhedit.punlearn()
-    dmhedit.infile = tmp2.name 
+    dmhedit.infile = tmp2.name
     dmhedit.operation = "add"
     dmhedit.key = "MTYPE1"
     dmhedit.value = "chip"
@@ -329,7 +307,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     dmhedit()
 
     dmhedit.punlearn()
-    dmhedit.infile = tmp2.name 
+    dmhedit.infile = tmp2.name
     dmhedit.operation = "add"
     dmhedit.key = "MFORM1"
     dmhedit.value = "chipx,chipy"
@@ -337,7 +315,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     dmhedit()
 
     dmhedit.punlearn()
-    dmhedit.infile = tmp2.name 
+    dmhedit.infile = tmp2.name
     dmhedit.operation = "add"
     dmhedit.key = "MTYPE2"
     dmhedit.value = "det"
@@ -345,7 +323,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     dmhedit()
 
     dmhedit.punlearn()
-    dmhedit.infile = tmp2.name 
+    dmhedit.infile = tmp2.name
     dmhedit.operation = "add"
     dmhedit.key = "MFORM2"
     dmhedit.value = "detx,dety"
@@ -353,7 +331,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     dmhedit()
 
     dmhedit.punlearn()
-    dmhedit.infile = tmp2.name 
+    dmhedit.infile = tmp2.name
     dmhedit.operation = "add"
     dmhedit.key = "MTYPE3"
     dmhedit.value = "sky"
@@ -361,7 +339,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     dmhedit()
 
     dmhedit.punlearn()
-    dmhedit.infile = tmp2.name 
+    dmhedit.infile = tmp2.name
     dmhedit.operation = "add"
     dmhedit.key = "MFORM3"
     dmhedit.value = "x,y"
@@ -373,7 +351,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
 
         if keynum != None:
             dmhedit.punlearn()
-            dmhedit.infile = tmp2.name 
+            dmhedit.infile = tmp2.name
             dmhedit.operation = "add"
             dmhedit.key = "TLMIN{}".format(keynum)
             dmhedit.value = "0.5"
@@ -381,7 +359,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
             dmhedit()
 
             dmhedit.punlearn()
-            dmhedit.infile = tmp2.name 
+            dmhedit.infile = tmp2.name
             dmhedit.operation = "add"
             dmhedit.key = "TLMAX{}".format(keynum)
             dmhedit.value = "8192.5"
@@ -402,7 +380,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
 
         dmcopy.punlearn()
         dmcopy.infile = "{}[cols -ccd_id]".format(tmp1.name)
-        dmcopy.outfile = outfile 
+        dmcopy.outfile = outfile
         dmcopy.verbose = "0"
         dmcopy.clobber = "yes"
         dmcopy()
@@ -410,7 +388,7 @@ def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
     else:
         dmcopy.punlearn()
         dmcopy.infile = "{}".format(tmp2.name)
-        dmcopy.outfile = outfile 
+        dmcopy.outfile = outfile
         dmcopy.verbose = "0"
         dmcopy.clobber = "yes"
         dmcopy()
@@ -443,7 +421,7 @@ def _structural_kw(fn,keyval,tmpdir):
     #             shutil.copyfileobj(fd,wfd)
 
     # tmp1.close()
-    # tmp2.close()  
+    # tmp2.close()
 
     # ## strip empty lines
     # #open(filename_out, "w").write(open(filename_in).read().strip())
@@ -485,14 +463,14 @@ def _structural_kw(fn,keyval,tmpdir):
 
 def _evt_type(fn):
     """
-    ID infile input type. 
+    ID infile input type.
     # MARX: HDUNAME=EVENTS, DATACLAS=SIMULATED
     # PPR: HDUNAME=RAYEVENTS, DATACLAS=OBSERVED
     # Obs: HDUNAME=EVENTS, DATACLAS=OBSERVED
     """
-    
+
     kw = fileio.get_keys_from_file(fn)
-    
+
     hduclass = kw["HDUNAME"]
     dataclass = kw["DATACLAS"]
 
@@ -515,10 +493,10 @@ def _num_pick(args): # P3
     """Pick number of photons to add to the simulation"""
 
     (bkg,outfile,bkgscale,randomseed,tmpdir,verbose) = args # P3
-    
+
     with new_pfiles_environment(ardlib=True):
-    
-        ## get total number of events; the NAXIS2/__NROWS keyword aren't updated if 
+
+        ## get total number of events; the NAXIS2/__NROWS keyword aren't updated if
         ## evt file is filtered
         # n = kw["__NROWS"]
         # n = _get_nevt(bkg)
@@ -535,7 +513,7 @@ def _num_pick(args): # P3
         dmtcalc.punlearn()
         dmtcalc.infile = bkg
         dmtcalc.outfile = def_rand.name
-        #dmtcalc.expression = "randnum={0}/{1}*#trand".format(n,cts) 
+        #dmtcalc.expression = "randnum={0}/{1}*#trand".format(n,cts)
         dmtcalc.expression = "randnum={0}/{1}".format(randseed,bkgscale)
         dmtcalc.verbose = verbose
         dmtcalc.clobber = "yes"
@@ -550,7 +528,7 @@ def _num_pick(args): # P3
         dmcopy()
 
         def_rand.close()
-    
+
 
 def assign_time(bkg_rand,time_sorted_outfile,kw,randomseed,tmpdir,verbose):
     """Assign some random time during the observation to each photon"""
@@ -577,7 +555,7 @@ def assign_time(bkg_rand,time_sorted_outfile,kw,randomseed,tmpdir,verbose):
 
     dmsort.punlearn()
 
-    dmsort.infile = time_rand.name 
+    dmsort.infile = time_rand.name
     dmsort.outfile = time_sorted_outfile
     dmsort.keys = "TIME"
     dmsort.clobber = "yes"
@@ -595,24 +573,24 @@ def assign_time(bkg_rand,time_sorted_outfile,kw,randomseed,tmpdir,verbose):
     for tkey in ["ONTIME","LIVETIME","EXPOSURE","TSTART","TSTOP"]:
         dmhedit.key = tkey
         dmhedit.value = kw[tkey]
-        dmhedit()    
+        dmhedit()
 
     if kw["INSTRUME"] == "ACIS":
         chips = fileio.get_ccds(bkg_rand)
-   
+
         for chip in chips:
             dmhedit.key = "ONTIME{}".format(chip)
             dmhedit.value = kw["ONTIME{}".format(chip)]
-            dmhedit()                
+            dmhedit()
 
             dmhedit.key = "LIVTIME{}".format(chip)
             dmhedit.value = kw["LIVTIME{}".format(chip)]
-            dmhedit()                
+            dmhedit()
 
             dmhedit.key = "EXPOSUR{}".format(chip)
             dmhedit.value = kw["EXPOSUR{}".format(chip)]
-            dmhedit()     
-    
+            dmhedit()
+
 
 def sample_chip(bkg,outfile,kw,randomseed,tmpdir,verbose):
     instrument = kw["INSTRUME"]
@@ -627,7 +605,7 @@ def sample_chip(bkg,outfile,kw,randomseed,tmpdir,verbose):
         chips = fileio.get_ccds(bkg)
 
         bkg_sample = []
-        bkg_tmp = [] 
+        bkg_tmp = []
 
         try:
             for chip in chips:
@@ -676,7 +654,7 @@ def doit():
     seed = params["randomseed"]
     clobber = params["clobber"]
     verbose = params["verbose"]
-   
+
     ############
 
     get_rand = tempfile.NamedTemporaryFile(dir=tmpdir)
@@ -696,7 +674,7 @@ def doit():
 
             tmpin = tempfile.NamedTemporaryFile(dir=tmpdir)
             tmpbkg = tempfile.NamedTemporaryFile(dir=tmpdir)
-            
+
             ccd_psf = fileio.get_ccds(infile)
             ccd_bkg = fileio.get_ccds(bkgfile)
 
@@ -719,9 +697,9 @@ def doit():
 
             infile = tmpin.name
             bkgfile = tmpbkg.name
-            
-    # check for background CALDB version; any ACIS background before 4.7.5.1 
-    # will need to convert the PHA and PI datatype which were short integers 
+
+    # check for background CALDB version; any ACIS background before 4.7.5.1
+    # will need to convert the PHA and PI datatype which were short integers
     # (Int16/Int2) and match the event files with long integers (Int64/Int4)
     cr_bkg = pcr.read_file("{}[#row=1]".format(bkgfile))
 
@@ -751,7 +729,7 @@ def doit():
     if reproject == "yes":
         # Reproject the blank sky fields to the same position on the sky as the marx simulation.
         reproject_events.punlearn()
-        
+
         if instrument == "ACIS":
             reproject_events.infile = "{}[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]".format(time_sorted.name)
         else:
@@ -765,7 +743,7 @@ def doit():
         reproject_events.verbose = verbose
 
         reproject_events()
-        
+
     else:
         # if the blank sky file is already reprojected or if the blanksky script was used
         dmcopy.punlearn()
@@ -773,19 +751,19 @@ def doit():
         if instrument == "ACIS":
             dmcopy.infile = "{}[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]".format(time_sorted.name)
         else:
-            dmcopy.infile = "{}[cols chip_id,chip,det,sky,pha,pi,status,time]".format(time_sorted.name) 
+            dmcopy.infile = "{}[cols chip_id,chip,det,sky,pha,pi,status,time]".format(time_sorted.name)
 
         dmcopy.outfile = bkgoutdir+bkgout
         dmcopy.clobber = clobber
         dmcopy()
 
     time_sorted.close()
-    
+
     try:
         add_tool_history(bkgoutdir+bkgout,toolname,pars)
     except OSError:
         pass
-        
+
     ## Merge marx simulation and blank sky fields into a single fits table.
     if psf_bkg_out != "":
 
@@ -807,7 +785,7 @@ def doit():
                 # first need to convert data type for PI and PHA columns
                 dmcopy.punlearn()
                 dmcopy.infile = infile
-                dmcopy.outfile = tmppsf.name 
+                dmcopy.outfile = tmppsf.name
                 dmcopy.verbose = "0"
                 dmcopy.clobber = "yes"
                 dmcopy()
@@ -827,16 +805,16 @@ def doit():
 
         else:
             if instrument == "ACIS":
-                dmmerge.columnList = "time,ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status"    
+                dmmerge.columnList = "time,ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status"
             else:
-                dmmerge.columnList = "time,chip_id,chip,det,sky,pha,status"    
+                dmmerge.columnList = "time,chip_id,chip,det,sky,pha,status"
 
         dmmerge.outfile = psf_bkg_outdir+psf_bkg_out
         dmmerge.clobber = clobber
         dmmerge.verbose = verbose
 
         dmmerge()
-        
+
         try:
             add_tool_history(psf_bkg_outdir+psf_bkg_out,toolname,pars)
         except OSError:
@@ -904,6 +882,3 @@ def doit():
 
 if __name__  == "__main__":
     doit()
-
-
-

--- a/bin/ecf_calc
+++ b/bin/ecf_calc
@@ -18,17 +18,16 @@ Usage:
 
 """
 
-__version__ = "CIAO 4.11"
 toolname = "ecf_calc"
-__revision__ = "05 September 2019"
+__revision__ = "13 November 2019"
 
 import numpy, tempfile, sys, os, paramio
 
+import stk
 import pycrates as pcr
 
 from ciao_contrib.logger_wrapper import handle_ciao_errors
 from ciao_contrib.param_wrapper import open_param_file
-from ciao_contrib.stacklib import expand_stack
 from ciao_contrib.cxcdm_wrapper import get_block_info_from_file
 from ciao_contrib.runtool import dmhistory, dmellipse, new_pfiles_environment, add_tool_history
 
@@ -174,7 +173,7 @@ def get_ecf(infile,reg,outfile,x,y,radius,binsize,fraction,clobber):
     if fraction.lower() in ["","none","indef"]:
         frac = "lgrid(0.01:1.0:0.01)" #",".join([str(i*0.01) for i in range(1,100)])
     else:
-        frac = ",".join(expand_stack(fraction))
+        frac = ",".join(stk.build(fraction))
 
     # run dmellipse to obtain a radii for a given set of ECFs
     with new_pfiles_environment(ardlib=False, copyuser=False):
@@ -304,7 +303,7 @@ def plot_ecf(rad_file):
 
     matplotlib.use("TkAgg")
     matplotlib.interactive(True)
-    
+
     try:
         detector = get_detnam(rad_file)
     except KeyError:
@@ -321,7 +320,7 @@ def plot_ecf(rad_file):
              markersize=3.5,fillstyle="none")
     axs.loglog()
     axs.set_ylabel("Encircled Counts Fraction")
-    
+
     if "HRC" in detector:
         axs.set_xlabel("HRC Pixels")
     elif "ACIS" in detector:

--- a/ciao_contrib/stacklib.py
+++ b/ciao_contrib/stacklib.py
@@ -2,7 +2,7 @@
 # Python35Support
 
 #
-#  Copyright (C) 2011, 2012, 2016  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2012, 2016, 2019  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -23,9 +23,8 @@
 """Helper routines for using the stack module (see "ahelp stack"
 for information on how stacks are used in CIAO tools).
 
-The expand_stack() routine is deprecated; please use the build routine
-from the stk module instead (in fact, expand_stack just calls this
-routine for you).
+The expand_stack() routine was removed in CIAO 4.12 since it was
+just a renamed version of the build routine from the CIAO stk module.
 
 The make_stackfile() is somewhat experimental, and may be removed.
 
@@ -33,50 +32,9 @@ The make_stackfile() is somewhat experimental, and may be removed.
 
 import os
 import tempfile
-import warnings
-
-import stk
-
-__all__ = ("expand_stack", "make_stackfile")
 
 
-def expand_stack(pval):
-    """***DEPRECATED*** use stk.build() instead.
-
-    Expand out the contents of the parameter value
-    treating it as a stack. So pval="@foo.lis" will
-    examine the contents of the file foo.lis but
-    pval="foo.lis" just has a single value (i.e.
-    "foo.lis"). The input should be a string.
-
-    The return value is an array of values, even if the input is not a
-    stack.
-
-    Examples of use:
-
-        pval='foo.lis'
-        return=['foo.lis']
-
-        pval='foo.lis,bar.lis'
-        return=['foo.lis', 'bar.lis']
-
-        pval='foo.lis bar.lis'
-        return=['foo.lis', 'bar.lis']
-
-        pval='foo.lis[cols x,y]'
-        return=['foo.lis[cols x,y]']
-
-        pval='@foo.lis'
-        return=[array of the contents of foo.lis]
-
-        pval='@foo.lis[cols x,y]'
-        return=[array of the contents of foo.lis with
-                '[cols x,y]' appended to the end of each line]
-
-    """
-
-    warnings.warn("Use stk.build instead", DeprecationWarning)
-    return stk.build(pval)
+__all__ = ("make_stackfile", )
 
 
 def make_stackfile(infiles, dir="/tmp/", suffix='', delete=True):
@@ -98,7 +56,8 @@ def make_stackfile(infiles, dir="/tmp/", suffix='', delete=True):
 
     # Change the mode, since the default is 'wb+' which makes
     # Python 3.5 use byte strings. I could set the encoding, but
-    # this argument isn't available in Python 2.7
+    # this used to be used with Python 2.7 so leave as is.
+    #
     tfh = tempfile.NamedTemporaryFile(mode='w+', dir=dir,
                                       suffix=suffix,
                                       delete=delete)

--- a/share/doc/xml/ciao_stacklib.xml
+++ b/share/doc/xml/ciao_stacklib.xml
@@ -35,56 +35,9 @@ from ciao_contrib.stacklib import *
 </VERBATIM>
 
       <PARA title="Contents">
-        The module provides two routines - expand_stack() and make_stackfile() -
-	which are described below.
+        The module provides one routine - make_stackfile() -
+	which is described below.
       </PARA>
-
-      <PARA title="expand_stack">
-	This routine is now deprecated (as of CIAO 4.5) since the build() routine from
-	the CIAO stk module has the same functionality.
-      </PARA>
-      <PARA>
-	The expand_stack() routine takes a single argument - a string - and
-	expand it using the stack libeary into an array of strings. If the
-	input argument is called pval, the following table shows the value
-	returned by expand_stack() for a range of inputs, where we have
-      </PARA>
-<VERBATIM>
-&pr; cat files.lis
-src1/a.fits 
-src2/b.fits
-</VERBATIM>
-      <TABLE>
-	<ROW>
-	  <DATA>Input (pval)</DATA>
-	  <DATA>Output from expand_stack(pval)</DATA>
-	</ROW>
-	<ROW>
-	  <DATA>"src.fits"</DATA>
-	  <DATA>["src.fits"]</DATA>
-	</ROW>
-	<ROW>
-	  <DATA>"src1.fits,src2.fits"</DATA>
-	  <DATA>["src1.fits", "src2.fits"]</DATA>
-	</ROW>
-	<ROW>
-	  <DATA>"src1.fits[cols x,y] src2.fits[bin sky;energy]"</DATA>
-	  <DATA>["src1.fits[cols x,y]", "src2.fits[bin sky;energy]"]</DATA>
-	</ROW>
-	<ROW>
-	  <DATA>"@src.lis"</DATA>
-	  <DATA>["src1/a.fits", "src2/b.fits"]</DATA>
-	</ROW>
-	<ROW>
-	  <DATA>"@src.lis[cols time,energy]"</DATA>
-	  <DATA>["src1/a.fits[cols time,energy]", "src2/b.fits[cols time,energy]"]</DATA>
-	</ROW>
-	<ROW>
-	  <DATA>"evt2.fits[ccd_id=lgrid(0:3:1)]"</DATA>
-	  <DATA>["evt2.fits[ccd_id=0]", "evt2.fits[ccd_id=1]",
-	         "evt2.fits[ccd_id=2]", "evt2.fits[ccd_id=3]"]</DATA>
-	</ROW>
-      </TABLE>
 
       <PARA title="make_stackfile">
 	The routines in the ciao_contrib.runtool module
@@ -154,7 +107,7 @@ src2/b.fits
 	  <LINE>mvals = [float(m) for m in means]</LINE>
 	</SYNTAX>
 	<DESC>
-	  <PARA>
+	  <PARA title="Replacement for expand_stack">
 	    In this example we get the out_mean parameter of dmstat, which can
 	    contain multiple values as a stack, and use the build routine from
 	    the stk module to
@@ -208,6 +161,14 @@ src2/b.fits
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the December 2019 release">
+      <PARA>
+	The expand_stack routine has been removed. The build
+	routine from the stk module should be used, as it has
+	the same interface.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the December 2012 release">
       <PARA>
 	The expand_stack() routine is deprecated; please use
@@ -223,6 +184,6 @@ src2/b.fits
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>June 2019</LASTMODIFIED>
+    <LASTMODIFIED>December 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
The ciao_contrib.stacklib.expand_stack has been marked as deprecated for a while now (CIAO 4.5) so remove it, as the replacement is the stk.build routine (with the same interface).

This fixes #244