### PR TITLE
dax: fix hard coded xpa "ds9" in plotting calls

### DIFF
--- a/bin/ds9_radial_fit
+++ b/bin/ds9_radial_fit
@@ -64,8 +64,8 @@ def blt_plot_fit(sherpa_plot_fit_obj, xpa="ds9",
         """Plot the residuals""" 
 
         # This requires ds9 v8.1    
-        xpa_plot_cmd( "ds9", "add graph line")
-        xpa_plot_cmd( "ds9", "layout strip")
+        xpa_plot_cmd( access_point, "add graph line")
+        xpa_plot_cmd( access_point, "layout strip")
         
         cmd = ["xpaset", access_point, "plot", "data", "xyey"]    
 

--- a/bin/ds9_specfit.sh
+++ b/bin/ds9_specfit.sh
@@ -321,8 +321,8 @@ def blt_plot_delchisqr(access_point,xx, ex, yy, ey, y_label):
     """Plot the residuals""" 
 
     # This requires ds9 v8.1    
-    xpa_plot_cmd( "ds9", "add graph line")
-    xpa_plot_cmd( "ds9", "layout strip")
+    xpa_plot_cmd( "${ds9}", "add graph line")
+    xpa_plot_cmd( "${ds9}", "layout strip")
     
     cmd = ["xpaset", access_point, "plot", "data", "xyey"]    
 
@@ -381,7 +381,7 @@ blt_plot_model( "${ds9}", _m.x, _m.y)
 delta = (_d.y-_m.y)/_d.yerr
 ones = _d.yerr*0.0+1.0
 
-blt_plot_delchisqr( "ds9", _d.x, _d.x, delta, ones, "")
+blt_plot_delchisqr( "${ds9}", _d.x, _d.x, delta, ones, "")
 
 
 EOF


### PR DESCRIPTION
The new residual plots have some hard-coded `ds9` xpa access points instead of using the appropriate variables.  This only affect users who start ds9 with a `-title` 