### PR TITLE
Tweak instmap plotting docs and code for matplotlib transition

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -40,6 +40,13 @@ Updated Python modules
 
     This module no-longer imports the chips_contrib module.
 
+  sherpa_contrib.utils
+
+    The plot_instmap_weights routine has been updated to use matplotlib
+    preference settings (linecolor and linestyle) rather than ChIPS ones
+    (linecolor and linethickness) from get_data_plot_prefs when displaying
+    data.
+
 Removed
 
   chips_contrib modules

--- a/share/doc/xml/plot_instmap_weights.xml
+++ b/share/doc/xml/plot_instmap_weights.xml
@@ -12,7 +12,7 @@
     </SYNOPSIS>
 
     <SYNTAX>
-      <LINE>plot_instmap_weights( [id=None, fluxtype="photon"] )</LINE>
+      <LINE>plot_instmap_weights(id=None, fluxtype="photon", overplot=False, clearwindow=True)</LINE>
     </SYNTAX>
 
     <DESC>
@@ -45,7 +45,7 @@ from sherpa_contrib.utils import *
 	<ROW>
 	  <DATA>fluxtype</DATA>
 	  <DATA>"photon"</DATA>
-	  <DATA>The units for the instrument map are cm^2 count / &lt;fluxtype>. The 
+	  <DATA>The units for the instrument map are cm^2 count / &lt;fluxtype>. The
 	  valid options for this argument are "photon" (the default) or "erg".
 	  </DATA>
 	</ROW>
@@ -97,6 +97,15 @@ from sherpa_contrib.utils import *
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
+      <PARA>
+	The plot styles can be changed using the linecolor and
+	linestyle settings returned by get_data_plot_prefs (in
+	earlier releases the linecolor and linewidth settings
+	were used, which were used by the ChIPS plotting system).
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.11.4 (2019) release">
       <PARA title="Plotting can now use matplotlib">
 	The plot_instmap_weights() routine now uses the
@@ -117,6 +126,6 @@ from sherpa_contrib.utils import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>June 2019</LASTMODIFIED>
+    <LASTMODIFIED>December 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/sherpa_contrib/utils.py
+++ b/sherpa_contrib/utils.py
@@ -302,11 +302,9 @@ class InstMapWeights:
 
             ``xlog``
             ``ylog``
-            ``linethickness``  (ChIPS only)
-            ``linecolor``      (ChIPS only)
+            ``linestyle``
+            ``linecolor``
 
-        This has *not* been updated to support the Matplotlib
-        backend yet.
         """
 
         # Create a Sherpa histogram plot. Unlike other plot
@@ -338,7 +336,7 @@ class InstMapWeights:
         # There is no validation of the preference values
         #
         prefs = ui.get_data_plot_prefs()
-        for name in ['xlog', 'ylog', 'linethickness', 'linecolor']:
+        for name in ['xlog', 'ylog', 'linestyle', 'linecolor']:
             value = prefs.get(name, None)
             if value is not None:
                 hplot.histo_prefs[name] = value
@@ -754,8 +752,8 @@ def plot_instmap_weights(id=None, fluxtype="photon",
 
         ``xlog``
         ``ylog``
-        ``linethickness``  (ChIPS only)
-        ``linecolor``      (ChIPS only)
+        ``linestyle``
+        ``linecolor``
 
     Examples
     --------
@@ -768,13 +766,11 @@ def plot_instmap_weights(id=None, fluxtype="photon",
     >>> pl.phoindex = 1.7
     >>> plot_instmap_weights()
 
-    Change the model to an absorbed APEC model and overplot it
-    (in orange).
+    Change the model to an absorbed APEC model and overplot it.
 
     >>> set_source(gal * xsapec.gal)
     >>> gal.kt = 1.2
     >>> plot_instmap_weights(overplot=True)
-    >>> set_histogram(['*.color', 'orange'])
 
     Compare the weights when using the photon and erg weighting
     schemes (the normalization is significantly different).

--- a/sherpa_contrib/utils.py
+++ b/sherpa_contrib/utils.py
@@ -118,7 +118,7 @@ class InstMapWeights:
 
         names = ["id", "modelexpr", "xlo", "xhi", "xmid", "weight",
                  "fluxtype"]
-        vals  = [getattr(self, n) for n in names]
+        vals = [getattr(self, n) for n in names]
         return print_fields(names, dict(zip(names, vals)))
 
     def __init__(self, id=None, fluxtype="photon"):
@@ -175,9 +175,9 @@ class InstMapWeights:
         self.weight = src / norm
 
         self.weight = self.weight.astype(dtype)
-        self.xlo    = self.xlo.astype(dtype)
-        self.xhi    = self.xhi.astype(dtype)
-        self.xmid   = self.xmid.astype(dtype)
+        self.xlo = self.xlo.astype(dtype)
+        self.xhi = self.xhi.astype(dtype)
+        self.xmid = self.xmid.astype(dtype)
 
     def _calc_bins(self, data):
         "Calculate the bin edges"
@@ -304,6 +304,9 @@ class InstMapWeights:
             ``ylog``
             ``linethickness``  (ChIPS only)
             ``linecolor``      (ChIPS only)
+
+        This has *not* been updated to support the Matplotlib
+        backend yet.
         """
 
         # Create a Sherpa histogram plot. Unlike other plot
@@ -684,13 +687,13 @@ def save_instmap_weights(*args, **kwargs):
         user["filename"] = args[0]
 
     elif nargs == 3:
-        user["id"]       = args[0]
+        user["id"] = args[0]
         user["filename"] = args[1]
-        user["clobber"]  = args[2]
+        user["clobber"] = args[2]
 
     elif _is_boolean(args[1]):
         user["filename"] = args[0]
-        user["clobber"]  = args[1]
+        user["clobber"] = args[1]
 
     elif isinstance(args[1], int):
         # This was needed in CIAO 4.2 and earlier since S-Lang would
@@ -701,10 +704,10 @@ def save_instmap_weights(*args, **kwargs):
         # clobber=2 will not map to True).
         #
         user["filename"] = args[0]
-        user["clobber"]  = args[1] == 1
+        user["clobber"] = args[1] == 1
 
     else:
-        user["id"]       = args[0]
+        user["id"] = args[0]
         user["filename"] = args[1]
 
     for (n, v) in kwargs.items():


### PR DESCRIPTION
Use the matplotlib preferences (`linecolor` and `linestyle`) rather than ChIPS (`linecolor` and `linethickness`).

Note that due to sherpa/sherpa#654 users with matplotlib 3 will see a warning message when calling `plot_instmap_weights` which will look like

```
In [7]: utils.plot_instmap_weights()                                                                                                                                                  
/home/dburke/anaconda3/envs/ciao412-py37/lib/python3.7/site-packages/sherpa/plot/pylab_backend.py:251: MatplotlibDeprecationWarning: Passing the drawstyle with the linestyle as a single string is deprecated since Matplotlib 3.1 and support will be removed in 3.3; please pass the drawstyle separately using the drawstyle keyword argument to Line2D or set_drawstyle() method (or ds/set_ds()).
  getattr(line, 'set_' + var)(val)

```