### PR TITLE
Add kyconv XSPEC convolution model

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -30,7 +30,6 @@ Updated scripts
 
     The script has been updated to work with matplotlib 3.1.    
 
-
   tgsplit
 
     Fixes a bug when trying to work with TYPE:II pha files created
@@ -59,6 +58,12 @@ Updated Python modules
     (linecolor and linethickness) from get_data_plot_prefs when displaying
     data.
 
+  sherpa_contrib.xspec.xsconvolve
+
+    Added the load_xskyconv routine to support the kyconv convolution model.
+    Please note that support for XSPEC convolution models is considered
+    experimental and there are known problems, so use carefully.
+
 Removed
 
   chips_contrib modules
@@ -66,4 +71,8 @@ Removed
     The chip_contrib.decorators, chips_contrib.helix,
     chips_contrib.images, chips_contrib.regions, chips_contrib.scatter,
     and chips_contrib.utils modules have been removed, as ChIPS is
-    no longer distributed as part of CIAO.
+    no longer distributed as part of CIAO. The Matplotlib plotting package
+    should be used instead.
+
+    Please contact the CXC helpdesk at https://cxc.cfa.harvard.edu/helpdesk
+    if you need help in converting existing scripts to use Matplotlib.

--- a/share/doc/xml/load_xskyconv.xml
+++ b/share/doc/xml/load_xskyconv.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
+ <!ENTITY pr "sherpa>">
+]>
+<cxchelptopics>
+  <ENTRY pkg="sherpa" key="load_xskyconv"
+	 refkeywords="xskyconv kyconv load_kyconv
+		      x-spec xspec convolution model experimental
+		      "
+	 seealsogroups="sh.models "
+	 displayseealsogroups="" context="models">
+
+    <SYNOPSIS>
+      convolution using a relativistic line from axisymmetric accretion disk.
+      XSpec convolution model
+      *Experimental*.
+    </SYNOPSIS>
+
+    <DESC>
+      <PARA>
+	Convolution using as a kernel the relativistic line from an
+	axisymmetic accretion disk.
+	See
+	<HREF link="https://ui.adsabs.harvard.edu/abs/2004ApJS..153..205D/abstract">Dovciak et al. (2004)</HREF>.
+      </PARA>
+
+      <TABLE>
+	<CAPTION>xskyconv Parameters</CAPTION>
+	<ROW>
+	  <DATA>Number</DATA>
+	  <DATA>Name</DATA>
+	  <DATA>Description</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>1</DATA> <DATA>a</DATA>
+	  <DATA>a/M; BH angular momentum (GM/c)</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>2</DATA> <DATA>theta_o</DATA>
+	  <DATA>observer inclination (0 = pole on, degrees)</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>3</DATA> <DATA>rin</DATA>
+	  <DATA>inner radius (GM/c^2)</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>4</DATA> <DATA>ms</DATA>
+	  <DATA>0 means integrate from rin, 1 means integrate emission from above the marginally stable orbit only</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>5</DATA> <DATA>rout</DATA>
+	  <DATA>outer radius (GM/c^2)</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>6</DATA> <DATA>alpha</DATA>
+	  <DATA>accretion disk emissivity scales as r^-alpha for r&lt;rb</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>7</DATA> <DATA>beta</DATA>
+	  <DATA>accretion disk emissivity scales as r^-beta for r>rb</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>8</DATA> <DATA>rb</DATA>
+	  <DATA>boundary radius between inner and outer emissivity laws (GM/c^2)</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>9</DATA> <DATA>zshift</DATA>
+	  <DATA>overall Doppler shift</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>10</DATA> <DATA>limb</DATA>
+	  <DATA>0 means isotropic emission, 1 means Laor's limb darkening (1+0.26\mu), 2 means Haardt's limb brightening (ln{1 + 1/\mu})</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>11</DATA> <DATA>ne_loc</DATA>
+	  <DATA>number of grid points in local energy (energy resolution of local flux, the grid is equidistant in logarithmic scale)</DATA>
+	</ROW>
+	<ROW>
+	  <DATA>12</DATA> <DATA>normal</DATA>
+	  <DATA>0 means normalize total flux to unity, +ve value means normalize to unity at the energy given by the parametervalue, -ve value means unnormalized.</DATA>
+	</ROW>
+      </TABLE>
+
+      <PARA title="Loading the X-Spec convolution models">
+	Please see
+	<HREF link="https://cxc.cfa.harvard.edu/ciao/ahelp/xsconvolve.html">ahelp xsconvolve</HREF>
+	for information on how to load the model.
+      </PARA>
+
+      <LIST>
+	<CAPTION>Notes</CAPTION>
+	<ITEM>
+	  This is an experimental release of the convolution models;
+	  please take care when using this model.
+	</ITEM>
+      </LIST>
+
+      <PARA title="XSpec version">
+	This information is taken from the
+	<HREF link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/manual.html">XSpec
+	User's Guide</HREF>.
+	Version 12.10.1n of the XSpec
+	models is supplied with CIAO 4.12.
+      </PARA>
+
+    </DESC>
+
+    <QEXAMPLELIST>
+      <QEXAMPLE>
+	<SYNTAX>
+	  <LINE>&pr; from sherpa_contrib.xspec.xsconvolve import load_xskyconv</LINE>
+	  <LINE>&pr; load_xskyconv("kdb")</LINE>
+	  <LINE>&pr; set_source(kdb(xspowerlaw.pl + xsgaussian.gs))</LINE>
+	  <LINE>&pr; kdb.theta_o = 45</LINE>
+	</SYNTAX>
+	<DESC>
+	  <PARA>
+	    The powerlaw and gaussian components are convolved by the kyconv model, whose
+	    inclination angle is set at 45 degrees.
+	  </PARA>
+	</DESC>
+      </QEXAMPLE>
+
+    </QEXAMPLELIST>
+
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions - such as how to
+        ensure that the parameter file is available.
+      </PARA>
+    </ADESC>
+
+    <BUGS>
+      <PARA>
+	For a list of known bugs and issues with the XSPEC models, please visit
+	the <HREF link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/bugs.html">XSPEC bugs page</HREF>.
+      </PARA>
+    </BUGS>
+
+    <LASTMODIFIED>December 2019</LASTMODIFIED>
+  </ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/xsconvolve.xml
+++ b/share/doc/xml/xsconvolve.xml
@@ -4,7 +4,7 @@
 ]>
 <cxchelptopics>
   <ENTRY pkg="sherpa" key="xsconvolve"
-	 refkeywords="convolve operator python 
+	 refkeywords="convolve operator python
 		      sherpa_contrib.xspec.xsconvolve module
 		      x-spec xspec convolution model experimental
 		      "
@@ -21,8 +21,8 @@
 	The sherpa_contrib.xspec.xsconvolve module
 	provides an *experimental* interface to the
 	X-Spec convolution models.
-	Please contact the 
-	<HREF link="https://cxc.harvard.edu/helpdesk/">CXC HelpDesk</HREF>
+	Please contact the
+	<HREF link="https://cxc.cfa.harvard.edu/helpdesk/">CXC HelpDesk</HREF>
 	if you have problems with these models.
       </PARA>
 
@@ -37,87 +37,91 @@
 
       <TABLE>
 	<CAPTION>Commands to create convolution models</CAPTION>
-	<ROW> 
+	<ROW>
 	  <DATA>Name</DATA>
-	  <DATA>Description</DATA> 
+	  <DATA>Description</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xscflux</DATA>
 	  <DATA>calculate flux</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xslumin</DATA>
 	  <DATA>calculate luminosity</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xscpflux</DATA>
 	  <DATA>calculate photon flux</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsgsmooth</DATA>
 	  <DATA>gaussian smoothing</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsireflect</DATA>
 	  <DATA>reflection from ionized material</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xskdblur</DATA>
 	  <DATA>convolve with the laor model shape</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xskdblur2</DATA>
 	  <DATA>convolve with the laor2 model shape</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xskerrconv</DATA>
 	  <DATA>accretion disk line shape with BH spin as free parameter</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
+	  <DATA>load_xskyconv</DATA>
+	  <DATA>convolution using a relativistic line from axisymmetric accretion disk</DATA>
+	</ROW>
+	<ROW>
 	  <DATA>load_xslsmooth</DATA>
 	  <DATA>lorentzian smoothing</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xspartcov</DATA>
 	  <DATA>partial covering</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsrdblur</DATA>
 	  <DATA>convolve with the diskline model shape</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsreflect</DATA>
 	  <DATA>reflection from neutral material</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsrfxconv</DATA>
 	  <DATA>reflection from an ionized disk</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsrgsxsrc</DATA>
 	  <DATA>convolve an RGS spectrum for extended emission</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xssimpl</DATA>
 	  <DATA>comptonization of a seed spectrum</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsvashift</DATA>
 	  <DATA>Velocity shift an additive model</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsvmshift</DATA>
 	  <DATA>Velocity shift a multiplicative model</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xsxilconv</DATA>
 	  <DATA>reflection from an ionized disk</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xszashift</DATA>
 	  <DATA>Redshift an additive model</DATA>
 	</ROW>
-	<ROW> 
+	<ROW>
 	  <DATA>load_xszmshift</DATA>
 	  <DATA>Redshift a multiplicative model</DATA>
 	</ROW>
@@ -126,8 +130,8 @@
       <PARA title="Loading the X-Spec convolution models">
 	To use these model, the xsconvolve module from the
 	<HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO
-	contributed package</HREF> 
-	must be installed. The relevant load routine can then 
+	contributed package</HREF>
+	must be installed. The relevant load routine can then
 	be loaded with a command like
       </PARA>
 
@@ -136,7 +140,7 @@
 	  <LINE>&pr; from sherpa_contrib.xspec.xsconvolve import load_xscflux</LINE>
 	</SYNTAX>
       </PARA>
-	
+
       <PARA>
 	or all models loaded by saying
       </PARA>
@@ -178,8 +182,9 @@
 	  not just the X-Spec models.
 	</ITEM>
 	<ITEM>
-	  Sherpa does not have an equivalent of the extend command
-	  in X-Spec.
+	  Sherpa now has support for evaluating a model on a different
+	  grid to the data - so similar to XSPECs extend command - but
+	  it has not yet been tried with these models.
 	</ITEM>
       </LIST>
 
@@ -187,11 +192,19 @@
 	This information is taken from the
 	<HREF link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/manual.html">XSpec
 	User's Guide</HREF>.
-	Version 12.10.0e of the XSpec
-	models is supplied with CIAO 4.11.
+	Version 12.10.1n of the XSpec
+	models is supplied with CIAO 4.12.
       </PARA>
 
     </DESC>
+
+    <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
+      <PARA>
+	The kyconv model from XSPEC 12.10.1 has been added (note that the
+	relconv set of models are not supported since they were removed
+	in XSPEC 12.10.1m and CIAO includes XSPEC 12.10.1n).
+      </PARA>
+    </ADESC>
 
     <ADESC title="Changes in the scripts 4.11.1 (December 2018) release">
       <PARA>
@@ -199,14 +212,14 @@
         XSPEC 12.10.0.
       </PARA>
     </ADESC>
-    
+
     <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
       <PARA>
         The XSPEC convolution models now work again (an update in CIAO 4.8
         had broken them).
       </PARA>
     </ADESC>
-    
+
     <ADESC title="Changes in the scripts 4.6.6 (September 2014) release">
       <PARA>
 	The sherpa_contrib.xspec.xsconvolve module is new in this
@@ -218,7 +231,7 @@
       <PARA>
         This script is not an official part of the CIAO release but is
         made available as "contributed" software via the
-        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        <HREF link="https://cxc.cfa.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
         Please see this page for installation instructions - such as how to
         ensure that the parameter file is available.
       </PARA>
@@ -230,7 +243,7 @@
 	the <HREF link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/bugs.html">XSPEC bugs page</HREF>.
       </PARA>
     </BUGS>
-    
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+
+    <LASTMODIFIED>December 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/sherpa_contrib/xspec/tests/test_xsconvolve_ui.py
+++ b/sherpa_contrib/xspec/tests/test_xsconvolve_ui.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017
+#  Copyright (C) 2017, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -20,14 +20,17 @@
 
 """Test the integration of the XSPEC convolution models with the ui layer.
 
-There's no testing of model evaluation, as that is done for the lower
+There's limited testing of model evaluation, as that is done for the lower
 level. The assumption here is that if a XSConvolutionKernel is created
 then we can rely on the evaluation tests in test_xsconvolve.py.
 
 """
 
+import numpy as np
+
 from sherpa.astro import ui
 from sherpa.utils.err import IdentifierErr
+from sherpa.astro.xspec import XSpowerlaw
 
 from sherpa_contrib.xspec import xsconvolve
 from sherpa_contrib.xspec.xsmodels import XSConvolutionKernel
@@ -37,16 +40,24 @@ from sherpa_contrib.xspec.xsmodels import XSConvolutionKernel
 #
 _models = [
     ('cflux', 1, 2),
+    ('clumin', 1, 3),
+    ('cpflux', 1, 2),
     ('gsmooth', 1, 1),
     ('ireflect', 1, 6),
     ('kdblur', 1, 3),
     ('kdblur2', 1, 5),
     ('kerrconv', 2, 5),
+    ('kyconv', 2, 10),
     ('lsmooth', 1, 1),
     ('partcov', 1, 0),
     ('rdblur', 1, 3),
     ('reflect', 1, 4),
+    ('rfxconv', 2, 3),
+    ('rgsxsrc', 0, 1),
     ('simpl', 2, 1),
+    ('vashift', 0, 1),
+    ('vmshift', 0, 1),
+    ('xilconv', 2, 4),
     ('zashift', 0, 1),
     ('zmshift', 0, 1)]
 
@@ -56,8 +67,22 @@ def test_load_exists():
 
     for mname, _, _ in _models:
         func = 'load_xs{}'.format(mname)
-        assert func in xsconvolve.__all__, func
-        
+        assert func in dir(xsconvolve), func
+
+
+def test_no_missing_models():
+    """Make sure we aren't missing tests for a kernel"""
+
+    # strip off 'load_xs' prefix before testing
+    models = set(sorted([n[7:] for n in dir(xsconvolve)
+                         if n.startswith('load_xs') and
+                         n != 'load_xsconvolve']))
+    tests = set(sorted([m[0] for m in _models]))
+
+    # test_load_exists checks the other way around
+    missing = models.difference(tests)
+    assert len(missing) == 0, missing
+
 
 def test_load_creates_kernel():
     """Do the load_xsXXX functions create a convolution kernel with npars?"""
@@ -70,28 +95,71 @@ def test_load_creates_kernel():
         assert False, 'Why does delme exist?'
     except IdentifierErr:
         pass
-    
+
     for mname, nthaw, nfrozen in _models:
         func = 'load_xs{}'.format(mname)
         f = getattr(xsconvolve, func)
-        f('delme')
+        rsp = f('delme')
 
-        mdl = ui.get_model_component('delme')
+        try:
+            mdl = ui.get_model_component('delme')
+        except IdentifierErr:
+            assert False, 'Unable to create instance for {}'.format(mname)
+
         assert isinstance(mdl, XSConvolutionKernel), \
             "{} creates XSConvolutionKernel".format(mname)
-        
-        assert len(mdl.pars) == nthaw + nfrozen, \
-            '{}: number of pars matches'.format(mname)
+
+        npars = len(mdl.pars)
+        assert npars == nthaw + nfrozen, \
+            '{}: number of pars matches {} {} {}'.format(mname,
+                                                         npars,
+                                                         nthaw,
+                                                         nfrozen)
 
         nf = sum([1 for p in mdl.pars if p.frozen])
         assert nf == nfrozen, \
-            '{}: number of frozen pars matches'.format(mname)
+            '{}: number of frozen pars matches {} {}'.format(mname,
+                                                             nf,
+                                                             nfrozen)
 
     ui.clean()
 
+
+def test_evaluate_kernels():
+    """Run each model with a simple powerlaw - check answers aren't NaN"""
+
+    ui.clean()
+
+    plaw = XSpowerlaw('pl')
+    plaw.phoindex = 1.7
+    plaw.norm = 0.025
+
+    egrid = np.arange(0.1, 10.0, 0.1)
+
+    for mname, nthaw, nfrozen in _models:
+        func = 'load_xs{}'.format(mname)
+        getattr(xsconvolve, func)('delme')
+
+        # Not guaranteed that all models will return something
+        # sensible without extra setup, although as of 12.10.1n
+        # they all do except for clumin, which needs a non-zero
+        # redshift
+        #
+        mdl = ui.get_model_component('delme')
+        cmdl = mdl(plaw)
+
+        if mname == 'clumin':
+            mdl.redshift = 0.1
+
+        y = cmdl(egrid)
+        assert np.isfinite(y).all(), mname
+
+    ui.clean()
 
 
 if __name__ == "__main__":
 
     test_load_exists()
+    test_no_missing_models()
     test_load_creates_kernel()
+    test_evaluate_kernels()

--- a/sherpa_contrib/xspec/xsmodels.py
+++ b/sherpa_contrib/xspec/xsmodels.py
@@ -136,7 +136,7 @@ class XSConvolutionModel(models.CompositeModel, models.ArithmeticModel):
             return models.ArithmeticFunctionModel(obj)
 
     def __init__(self, model, wrapper):
-        self.model  = self.wrapobj(model)
+        self.model = self.wrapobj(model)
         self.wrapper = wrapper
         models.CompositeModel.__init__(self,
                                        "{}({})".format(self.wrapper.name,


### PR DESCRIPTION
Fix #320 

Also adds some extra text to the changelog regarding ChIPS
replacement by matplotlib and updates the xsconvolve tests.