### PR TITLE
Support for VFAINT/no PHA cleaning and particle rate scaling method

### DIFF
--- a/bin/blanksky
+++ b/bin/blanksky
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2018, 2019
+#  Copyright (C) 2018, 2019, 2020
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 #
 
 toolname = "blanksky"
-__revision__  = "18 November 2019"
+__revision__  = "25 June 2020"
 
 import os, sys, paramio, tempfile, shutil, stat
 
@@ -112,7 +112,10 @@ def caldb_blanksky(detector):
     else:
         error_out("Check that CalDB has been installed.")
 
-    if len(os.listdir(bkg_path)) > 1:
+    if len(os.listdir(bkg_path)) > 2:
+        # the CALDB 'main' tarball only	contains a readme and manifest text
+        # file in the 'bkgrnd' sub-directory
+
         return True
     else:
         return False

--- a/bin/blanksky
+++ b/bin/blanksky
@@ -19,7 +19,7 @@
 #
 
 toolname = "blanksky"
-__revision__  = "13 November 2019"
+__revision__  = "18 November 2019"
 
 import os, sys, paramio, tempfile, shutil, stat
 
@@ -174,6 +174,42 @@ def e_norm(evtfile,bkgfile,chip,bkgparams,instrument):
     return obs_counts/bkg_counts
 
 
+def he_rate_norm(evtfile,bkgfile,chip,bkgparams,instrument,evt_keywords,bkg_keywords):
+    he = e_norm(evtfile,bkgfile,chip,bkgparams,instrument)
+    t = t_norm(evtfile,bkgfile,chip,evt_keywords,bkg_keywords)
+    
+    return he/t
+
+
+def check_tool_par(evt,tool,param):
+    
+    dmhistory.punlearn()
+    dmhistory.infile = evt
+    dmhistory.tool = tool
+    dmhistory.verbose = "1"
+
+    try:
+        hist = dmhistory()
+    except OSError:
+        raise ValueError("{0} was not used to generate {1}".format(tool,evt))
+   
+    hist = [t for t in hist.split("\n") if t.startswith(tool)]
+
+    par_instance = []
+
+    for h in hist:
+        for par in h.split(" "):
+            if par.startswith(param):
+                par_instance.append(par)
+
+    par_instance = [par.replace("\"","") for par in par_instance]
+
+    if "{}=yes".format(param) in par_instance:
+        return True
+    else:
+        return False
+
+
 def apply_gain(infile,outfile,kw,tmpdir,verbose):
     # The two gain files should have the same date and version number in the filename.
     # If they do not match, reprocess the background file with the event file gain file.
@@ -183,33 +219,43 @@ def apply_gain(infile,outfile,kw,tmpdir,verbose):
     bkg_gain = fileio.get_keys_from_file(infile)["GAINFILE"]
 
     if gainfile != bkg_gain:
-        # grab eventdef and remove time def
-        # change status bits to match infile
-        dmhistory.punlearn()
 
-        dmhistory.infile = infile
-        dmhistory.outfile = "stdout"
-        dmhistory.tool = "acis_process_events"
-        dmhistory.action = "get"
-        dmhistory.clobber = "yes"
-        dmhistory.verbose = "0"
+        ## grab eventdef and remove time def
+        ## change status bits of background events to match infile w/a_p_e
 
-        eventdef = dmhistory()
-        eventdef = eventdef.split("\n")
-        eventdef = [edef for edef in eventdef if edef!=""][-1]
-        eventdef = eventdef.split(" ")
+        def _get_edef(evt,removecol=None):
+            cr = pcr.read_file("{}[#row=1]".format(evt))
+            colnames = cr.get_colnames(vector=False)
 
-        for edef in eventdef:
-            if edef.startswith("eventdef"):
-                eventdef = edef.lstrip("eventdef=").replace("\"","")
+            # The data types recognized by acis_process_events include 
+            # d (double-precision real), f (single-precision real), i (integer), 
+            # l (long integer), s (short integer), and x (logical)
 
-        eventdef = eventdef[1:-1].split(",")
+            edef_type = { "float64" : "d", 
+                          "float32" : "f",
+                          "int64" : "l",
+                          "int32" : "i",
+                          "int16" : "s",
+                          "uint8" : "x" }
 
-        for edef in eventdef:
-            if edef.endswith(":time"):
-                eventdef.remove(edef)
+            edef = {}
+    
+            for col in colnames:
+                edef[col] = edef_type[cr.get_column(col).values.dtype.name]
 
-        eventdef = "{"+",".join(eventdef)+"}"
+            cr.__del__()
+
+            if removecol != None:
+                try:
+                    colnames.remove(removecol)
+                except ValueError:
+                    pass
+
+            edefstr = ["{0}:{1}".format(edef[col],col) for col in colnames]
+    
+            return  "{" + ",".join(edefstr) + "}"
+
+        eventdef = _get_edef(infile,remove="time")
 
         ## CTI and TGAIN Calibration Files
         #
@@ -607,11 +653,15 @@ def blanksky(infile,filters,asols,tmpdir,keywords,verbose,clobber):
 
             bkg = tempfile.NamedTemporaryFile(suffix=".bkg",dir=tmpdir)
 
-            # if datamode is VFAINT, set status to 0
-            if keywords["DATAMODE"] == "VFAINT":
+            # if datamode is VFAINT and ran a_p_e with check_vf_pha=yes, 
+            # remove background events with non-0 status
+            if False not in (keywords["DATAMODE"] == "VFAINT",
+                             check_tool_par(evt=infile,tool="acis_process_events",
+                                            param="check_vf_pha")):
+
                 dmcopy.punlearn()
 
-                dmcopy.infile = bkg_repro.name+"[status=0]"
+                dmcopy.infile = "{}[status=0]".format(bkg_repro.name)
                 dmcopy.outfile = bkg.name
                 dmcopy.verbose = "0"
                 dmcopy.clobber = "yes"
@@ -667,7 +717,7 @@ def doit():
     dmcopy.verbose = "0"
     dmcopy()
 
-    if method == "particle":
+    if method != "time":
         if instrument == "ACIS":
             if bkgparams.lower() == "default":
                 e_particle = "[energy=9000:12000]"
@@ -733,11 +783,15 @@ def doit():
     # calculate scaling factor, add as keyword
     scale = []
     for ccd in sorted(ccds):
-        if method == "time":
-            bkg_kw = fileio.get_keys_from_file(outdir+outfile)
-            scalefactor = t_norm(check_evt.name,outdir+outfile,ccd,kw,bkg_kw)
-        else:
+        if method == "particle":
             scalefactor = e_norm(check_evt.name,outdir+outfile,ccd,e_particle,instrument)
+        else:
+            bkg_kw = fileio.get_keys_from_file(outdir+outfile)
+
+            if method == "time":
+                scalefactor = t_norm(check_evt.name,outdir+outfile,ccd,kw,bkg_kw)
+            else:
+                scalefactor = he_rate_norm(check_evt.name,outdir+outfile,ccd,e_particle,instrument,kw,bkg_kw)
 
         if instrument == "HRC":
             dmhedit.key = "BKGSCALE"

--- a/bin/blanksky_sample
+++ b/bin/blanksky_sample
@@ -23,9 +23,9 @@
 #
 
 toolname = "blanksky_sample"
-__revision__  = "13 November 2019"
+__revision__  = "18 November 2019"
 
-import os, sys, paramio, tempfile
+import os, sys, paramio, tempfile, numpy
 
 import stk
 import pycrates as pcr
@@ -35,7 +35,7 @@ from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, s
 
 from ciao_contrib._tools import fileio, utils
 
-from ciao_contrib.runtool import dmcopy, dmhedit, dmlist, dmmerge, dmsort, dmtcalc, reproject_events, add_tool_history
+from ciao_contrib.runtool import dmcopy, dmhedit, dmlist, dmmerge, dmsort, dmtcalc, reproject_events, add_tool_history, dmhistory
 
 from sherpa.utils import parallel_map
 from ciao_contrib.parallel_wrapper import parallel_pool
@@ -492,7 +492,7 @@ def _evt_type(fn):
 def _num_pick(args): # P3
     """Pick number of photons to add to the simulation"""
 
-    (bkg,outfile,bkgscale,randomseed,tmpdir,verbose) = args # P3
+    (bkg,outfile,bkgscale,bkgmeth,tobs,tbsky,randomseed,tmpdir,verbose) = args # P3
 
     with new_pfiles_environment(ardlib=True):
 
@@ -513,15 +513,36 @@ def _num_pick(args): # P3
         dmtcalc.punlearn()
         dmtcalc.infile = bkg
         dmtcalc.outfile = def_rand.name
-        #dmtcalc.expression = "randnum={0}/{1}*#trand".format(n,cts)
-        dmtcalc.expression = "randnum={0}/{1}".format(randseed,bkgscale)
         dmtcalc.verbose = verbose
         dmtcalc.clobber = "yes"
+
+        if bkgmeth.lower() == "particle-rate":
+            # # get HE filter
+            # dmhistory.punlearn()
+            # dmhistory.infile = bkg
+            # dmhistory.tool = "blanksky"
+            # bsky_output = dmhistory().split("\n")[-1].split(" ")[1:]
+            #
+            # bsky_kw = {}
+            # for d in bsky_output:
+            #     bsky_kw[d.split("=")[0]] = d.split("=")[-1].replace("\"","")
+            #
+            # if bsky_kw["bkgparams"] == "default":
+            #     efilt = "[energy=9000:12000]"
+            # else:
+            #     efilt = bsky_kw["bkgparams"]
+            #
+            # ntot = _get_nevt(bkg)          
+            # nhe = _get_nevt("{0}{1}".format(bkg,efilt))
+
+            dmtcalc.expression = "randnum={0}*({1}/({2}*{3}))".format(randseed,tbsky,tobs,bkgscale)
+        else:
+            dmtcalc.expression = "randnum={0}/{1}".format(randseed,bkgscale)
 
         dmtcalc()
 
         dmcopy.punlearn()
-        dmcopy.infile = "{}[randnum=0:1]".format(def_rand.name)
+        dmcopy.infile = "{}[randnum=0:1]".format(def_rand.name) 
         dmcopy.outfile = outfile # sampled event will have RANDNUM value less than 1
         dmcopy.clobber = "yes"
 
@@ -592,14 +613,18 @@ def assign_time(bkg_rand,time_sorted_outfile,kw,randomseed,tmpdir,verbose):
             dmhedit()
 
 
-def sample_chip(bkg,outfile,kw,randomseed,tmpdir,verbose):
+def sample_chip(bkg,infile,outfile,kw,randomseed,tmpdir,verbose):
     instrument = kw["INSTRUME"]
+    bkgmeth = kw["BKGMETH"]
 
     # determine chips to be used for the image
     if instrument == "HRC":
         bkgscale = kw["BKGSCALE"]
 
-        _num_pick((bkg,outfile,bkgscale,randomseed,tmpdir,verbose))
+        tobs = fileio.get_keys_from_file(infile)["LIVETIME"]
+        tbsky = kw["LIVETIME"]
+
+        _num_pick((bkg,outfile,bkgscale,bkgmeth,tobs,tbsky,randomseed,tmpdir,verbose))
 
     else:
         chips = fileio.get_ccds(bkg)
@@ -613,7 +638,11 @@ def sample_chip(bkg,outfile,kw,randomseed,tmpdir,verbose):
                 bkgscale = kw["BKGSCAL{}".format(chip)]
                 bkgchipstr = "{0}[ccd_id={1}]".format(bkg,chip)
 
-                bkg_sample.append((bkgchipstr,bkgtmp.name,bkgscale,randomseed,tmpdir,verbose))
+                tobs = fileio.get_keys_from_file(infile)["LIVTIME{}".format(chip)]
+                tbsky = kw["LIVTIME{}".format(chip)]
+
+                bkg_sample.append((bkgchipstr,bkgtmp.name,bkgscale,bkgmeth,tobs,tbsky,randomseed,tmpdir,verbose))
+
                 bkg_tmp.append(bkgtmp)
 
             #parallel_map(_num_pick,bkg_sample)
@@ -711,7 +740,7 @@ def doit():
     cr_bkg.__del__()
 
     # sample background file and assign times to each event
-    sample_chip(bkgfile,get_rand.name,kw_bkg,seed,tmpdir,verbose)
+    sample_chip(bkgfile,infile,get_rand.name,kw_bkg,seed,tmpdir,verbose)
     assign_time(get_rand.name,time_sorted.name,kw_psf,seed,tmpdir,verbose)
 
     get_rand.close()

--- a/ciao_contrib/runtool.py
+++ b/ciao_contrib/runtool.py
@@ -2611,7 +2611,7 @@ parinfo['axbary'] = {
 parinfo['blanksky'] = {
     'istool': True,
     'req': [ParValue("evtfile","f","Source event file",None),ParValue("outfile","f","Output directory path + file name for output files",None)],
-    'opt': [ParValue("asolfile","f","Source aspect solution file(s)",None),ParSet("weight_method","s","Method to calculate background scale factor",'particle',["particle","time"]),ParValue("bkgparams","s","Optional argument for background scaling, default is [pi=300:500] for HRC and [energy=9000:12000] for ACIS",'default'),ParValue("tmpdir","s","Directory for temporary files",'${ASCDS_WORK_PATH}'),ParRange("random","i","Random seed, 0=clock time",0,0,None),ParValue("clobber","b","OK to overwrite existing output file?",False),ParRange("verbose","i","Debug Level(0-5)",1,0,5)],
+    'opt': [ParValue("asolfile","f","Source aspect solution file(s)",None),ParSet("weight_method","s","Method to calculate background scale factor",'particle',["particle","time","particle-rate"]),ParValue("bkgparams","s","Optional argument for background scaling, default is [pi=300:500] for HRC and [energy=9000:12000] for ACIS",'default'),ParValue("tmpdir","s","Directory for temporary files",'${ASCDS_WORK_PATH}'),ParRange("random","i","Random seed, 0=clock time",0,0,None),ParValue("clobber","b","OK to overwrite existing output file?",False),ParRange("verbose","i","Debug Level(0-5)",1,0,5)],
     }
 
 

--- a/param/blanksky.par
+++ b/param/blanksky.par
@@ -1,7 +1,7 @@
 evtfile,f,a,"",,,"Source event file"
 outfile,f,a,"",,,"Output directory path + file name for output files"
 asolfile,f,h,"",,,"Source aspect solution file(s)"
-weight_method,s,h,"particle",particle|time,,"Method to calculate background scale factor"
+weight_method,s,h,"particle",particle|time|particle-rate,,"Method to calculate background scale factor"
 bkgparams,s,h,"default",,,"Optional argument for background scaling, default is [pi=300:500] for HRC and [energy=9000:12000] for ACIS"
 tmpdir,s,h,"${ASCDS_WORK_PATH}",,,"Directory for temporary files"
 random,i,h,0,0,,"Random seed, 0=clock time"

--- a/share/doc/xml/blanksky.xml
+++ b/share/doc/xml/blanksky.xml
@@ -171,6 +171,11 @@
 	    ratio of the observation to background exposure
 	    times. 
 	  </PARA>
+	  <PARA title="method=particle-rate">
+	    This setting scales the background file by the
+	    ratio of the observation to background high-energy
+	    particle count rates. 
+	  </PARA>
           <PARA title="Header keywords">
 	    The scaling method and factor are added to the tailored
 	    blanksky background file using the BKGMETH and BKGSCALE
@@ -187,7 +192,7 @@
         
         <DESC>
           <PARA>
-	    This parameter is only used if "weight_method=particle"
+	    This parameter is only used if "weight_method" is set to "particle" or "weight_method=particle-rate"
 	    and otherwise ignored.  The default is [pi=300:500] for
 	    HRC and [energy=9000:12000] for ACIS. 
           </PARA>
@@ -274,7 +279,7 @@
 
       <PARA>
 	The basis for scaling by the high-energy particle background is described
-	in <HREF link="http://adsabs.harvard.edu/abs/2006ApJ...645...95H">"Absolute
+	in <HREF link="https://ui.adsabs.harvard.edu/abs/2006ApJ...645...95H/abstract">"Absolute
 	Measurement of the Unresolved Cosmic X-Ray Background in the
 	0.5-8 keV Band with Chandra" (Hickox &amp; Markevitch, ApJ 645
 	95)</HREF>.  The calculation of the factors are done by taking the
@@ -284,19 +289,30 @@
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the November 2019 revision">
+      <PARA>
+	The weight_method="particle-rate" scaling has been added which
+	is calculated using the ratio of the observed high-energy
+	event count rate, to the blanksky high-energy event count rate
+	using the band defined by the "bkgparams" parameter.
+	Additionally, support for VFAINT data where "check_vf_pha=no"
+	is set in acis_process_events added.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.11.3 (May 2019) release">
       <PARA>
-	The aimpoint chip is now calculated using the RA_PNT and DEC_PNT
-	keywords, rather than the RA_NOM and DEC_NOM, to better support
-	reprojected datasets.
+        The aimpoint chip is now calculated using the RA_PNT and DEC_PNT
+        keywords, rather than the RA_NOM and DEC_NOM, to better support
+        reprojected datasets.
       </PARA>
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA>
-	The script no-longer copies over the RA_PNT, DEC_PNT, ROLL_PNT,
-	DY_AVG, DZ_AVG, and DTH_AVG header keywords as they are now
-	provided by reproject_events.
+        The script no-longer copies over the RA_PNT, DEC_PNT, ROLL_PNT,
+        DY_AVG, DZ_AVG, and DTH_AVG header keywords as they are now
+        provided by reproject_events.
       </PARA>
     </ADESC>
 
@@ -307,7 +323,6 @@
         <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
         Please see this page for installation instructions - such as how to
         ensure that the parameter file is available.
-
       </PARA>
     </ADESC>
 
@@ -321,6 +336,6 @@
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>May 2019</LASTMODIFIED>
+    <LASTMODIFIED>November 2019</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
support for VFAINT observations without PHA filtering (acis_process_events run with check_vf_pha=no) added and new scaling method based on high-energy particle rate.

 Updated 'blanksky' ahelp for 'particle-rate' weight method and updated 'blanksky_sample' to handle 'particle-rate' scaling.