### PR TITLE
Ensure instmap weights can be plotted

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -10,14 +10,14 @@ Updated scripts
     "shadow" caused by the frame-store cover.
 
   combine_grating_spectra
-  
+
     Remove the TG_M and SPEC_NUM keywords from the output file.
     Previously the values were taken from 1st file in the merge.
 
   combine_spectra
-  
-    Remove any TG_M filter from the output file subspace. This 
-    cleans up the final output file to remove extraneous 
+
+    Remove any TG_M filter from the output file subspace. This
+    cleans up the final output file to remove extraneous
     subspace components.
 
   dax
@@ -28,7 +28,7 @@ Updated scripts
 
   deflare
 
-    The script has been updated to work with matplotlib 3.1.    
+    The script has been updated to work with matplotlib 3.1.
 
   tgsplit
 
@@ -54,9 +54,9 @@ Updated Python modules
   sherpa_contrib.utils
 
     The plot_instmap_weights routine has been updated to use matplotlib
-    preference settings (linecolor and linestyle) rather than ChIPS ones
-    (linecolor and linethickness) from get_data_plot_prefs when displaying
-    data.
+    preference settings (color) rather than ChIPS ones (linecolor and
+    linethickness) from get_data_plot_prefs. The preferences can also
+    be over-ridden when the plot is created.
 
   sherpa_contrib.xspec.xsconvolve
 

--- a/share/doc/xml/plot_instmap_weights.xml
+++ b/share/doc/xml/plot_instmap_weights.xml
@@ -12,7 +12,7 @@
     </SYNOPSIS>
 
     <SYNTAX>
-      <LINE>plot_instmap_weights(id=None, fluxtype="photon", overplot=False, clearwindow=True)</LINE>
+      <LINE>plot_instmap_weights(id=None, fluxtype="photon", overplot=False, clearwindow=True, **kwargs)</LINE>
     </SYNTAX>
 
     <DESC>
@@ -20,7 +20,7 @@
 	The plot_instmap_weights() command creates a plot of the current model
 	values in the form expected by the CIAO mkinstmap tool.
 	Please see the
-	<HREF link="https://cxc.harvard.edu/ciao/threads/spectral_weights/">Calculating Spectral Weights</HREF>
+	<HREF link="https://cxc.cfa.harvard.edu/ciao/threads/spectral_weights/">Calculating Spectral Weights</HREF>
 	thread for further information on how to use this routine.
       </PARA>
 
@@ -65,6 +65,14 @@ from sherpa_contrib.utils import *
             existing plots. This is not used if overplot is set.
 	  </DATA>
 	</ROW>
+	<ROW>
+	  <DATA>**kwargs</DATA>
+	  <DATA/>
+	  <DATA>
+	    The plot preferences can be over-ridden (e.g. xlog, ylog,
+	    color).
+	  </DATA>
+	</ROW>
       </TABLE>
 
     </DESC>
@@ -77,6 +85,19 @@ from sherpa_contrib.utils import *
 	<DESC>
           <PARA>
 	    Create a plot of the model weights for the default dataset.
+	  </PARA>
+        </DESC>
+      </QEXAMPLE>
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>&pr; plot_instmap_weights(ylog=True)</LINE>
+          <LINE>&pr; plot_instmap_weights(2, overplot=True, linestyle='dotted')</LINE>
+	</SYNTAX>
+	<DESC>
+          <PARA>
+	    Plot the weights for datasets 1 and 2, using a log scale for
+	    the Y axis and drawing the second curve with a dotted line.
 	  </PARA>
         </DESC>
       </QEXAMPLE>
@@ -99,8 +120,8 @@ from sherpa_contrib.utils import *
 
     <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
       <PARA>
-	The plot styles can be changed using the linecolor and
-	linestyle settings returned by get_data_plot_prefs (in
+	The plot styles can be changed using the color
+	settings returned by get_data_plot_prefs (in
 	earlier releases the linecolor and linewidth settings
 	were used, which were used by the ChIPS plotting system).
       </PARA>

--- a/sherpa_contrib/utils.py
+++ b/sherpa_contrib/utils.py
@@ -281,7 +281,7 @@ class InstMapWeights:
 
         info("Created: {}".format(filename))
 
-    def plot(self, overplot=False, clearwindow=True):
+    def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the weights values.
 
         Parameters
@@ -293,6 +293,9 @@ class InstMapWeights:
             If ``True`` then clear out the current plot area of
             all existing plots. This is not used if ``overplot`` is
             set.
+        **kwargs
+            Assumed to be plot preferences that override the
+            HistogramPlot.histo_plot preferences.
 
         Notes
         -----
@@ -302,8 +305,14 @@ class InstMapWeights:
 
             ``xlog``
             ``ylog``
-            ``linestyle``
-            ``linecolor``
+            ``color``
+
+        Examples
+        --------
+
+        >>> hplot.plot()
+
+        >>> hplot.plot(ylog=True, color='orange', linestyle='dotted')
 
         """
 
@@ -333,15 +342,22 @@ class InstMapWeights:
         hplot.title = 'Weights for {}: '.format(self.id) + \
                       ' {}'.format(self.modelexpr)
 
-        # There is no validation of the preference values
+        # There is no validation of the preference values.
         #
+        # I have removed linestyle from this list since the pylab
+        # backend default is 'None', which ends up meaning nothing
+        # appears to get drawn. Which is less-than helpful.
+        # linecolor also doen't appear to be used, but color is.
+        #
+        # names = ['xlog', 'ylog', 'linestyle', 'linecolor']
+        names = ['xlog', 'ylog', 'color']
         prefs = ui.get_data_plot_prefs()
-        for name in ['xlog', 'ylog', 'linestyle', 'linecolor']:
+        for name in names:
             value = prefs.get(name, None)
             if value is not None:
                 hplot.histo_prefs[name] = value
 
-        hplot.plot(overplot=overplot, clearwindow=clearwindow)
+        hplot.plot(overplot=overplot, clearwindow=clearwindow, **kwargs)
 
     def _estimate_expmap(self, *args):
         """Estimate the exposure map given an ARF.
@@ -720,7 +736,7 @@ def save_instmap_weights(*args, **kwargs):
 
 
 def plot_instmap_weights(id=None, fluxtype="photon",
-                         overplot=False, clearwindow=True):
+                         overplot=False, clearwindow=True, **kwargs):
     """Plot the weights values.
 
     Parameters
@@ -737,6 +753,8 @@ def plot_instmap_weights(id=None, fluxtype="photon",
     clearwindow: bool, optional
         If ``True`` then clear out the current plot area of all
         existing plots. This is not used if ``overplot`` is set.
+    **kwargs
+        Override the histogram plot preferences
 
     See Also
     --------
@@ -752,8 +770,7 @@ def plot_instmap_weights(id=None, fluxtype="photon",
 
         ``xlog``
         ``ylog``
-        ``linestyle``
-        ``linecolor``
+        ``color``
 
     Examples
     --------
@@ -778,13 +795,19 @@ def plot_instmap_weights(id=None, fluxtype="photon",
     >>> plot_instmap_weights()
     >>> plot_instmap_weights(fluxtype='erg')
 
+    Plot the weights with a log scale on the y axis, and then overplot
+    the weights using erg weighting and drawn with a dotted line:
+
+    >>> plot_instmap_weights(ylog=True)
+    >>> plot_instmap_weights(fluxtype='erg', overplot=True, linestyle='dotted')
+
     """
 
     if id is None:
         id = ui.get_default_id()
 
     wgts = get_instmap_weights(id, fluxtype=fluxtype)
-    wgts.plot(overplot=overplot, clearwindow=clearwindow)
+    wgts.plot(overplot=overplot, clearwindow=clearwindow, **kwargs)
 
 
 def estimate_weighted_expmap(id=None, arf=None, elo=None, ehi=None,


### PR DESCRIPTION
The problem is that there is a disconnect between the data plot
preferences (a "curve") and the histogram plot style used here.
This lead to the "histogram" being plotted with a linestyle of
'None' - so nothing was displayed. This fixes #325 

Add in support for allowing keyword arguments to be given to
plot_instmap_weights - e.g.

    plot_instmap_weights(ylog=True, color='gray')

This matches behavior added in Sherpa in CIAO 4.12.