### PR TITLE
check_ciao_version/caldb - work with https site and conda installation

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -9,6 +9,10 @@ Updated scripts
     rows of each ACIS CCD to the bad-pixel maps to account for the
     "shadow" caused by the frame-store cover.
 
+  check_ciao_version, check_ciao_caldb
+
+    Updated to work with the new https location for the CXC site.
+
   combine_grating_spectra
 
     Remove the TG_M and SPEC_NUM keywords from the output file.

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -11,7 +11,9 @@ Updated scripts
 
   check_ciao_version, check_ciao_caldb
 
-    Updated to work with the new https location for the CXC site.
+    Updated to work with the new https location for the CXC site. The
+    check_ciao_version has been updated to work with CIAO installations
+    using the conda package manner.
 
   combine_grating_spectra
 

--- a/bin/check_ciao_caldb
+++ b/bin/check_ciao_caldb
@@ -43,7 +43,7 @@ Aim:
 """
 
 toolname = "check_ciao_caldb"
-version = "12 November 2015"
+version = "21 November 2019"
 
 import os
 import time
@@ -53,10 +53,13 @@ from optparse import OptionParser
 import pycrates
 import caldb4
 
-from ciao_contrib.logger_wrapper import handle_ciao_errors
+from ciao_contrib import logger_wrapper as lw
 from ciao_contrib.cxcdm_wrapper import convert_block_number
 from ciao_contrib.caldb import get_caldb_dir, get_caldb_installed, \
     check_caldb_version
+
+
+lw.initialize_logger(toolname)
 
 
 help_str = """
@@ -160,7 +163,7 @@ def check_caldb_query(caldb, caldbver):
     print("CALDB query completed successfully.")
 
 
-@handle_ciao_errors(toolname, version)
+@lw.handle_ciao_errors(toolname, version)
 def doit():
     """Run the code."""
 
@@ -175,13 +178,19 @@ def doit():
     opts.add_option("-v", "--version", dest="list_version",
                     action="store_true",
                     help="List the version of the script and exit.")
-    # opts.add_option("-d", "--debug", dest="debug", action="store_true",
-    #                 help="Display diagnostic output? [default: %default]")
+
+    opts.add_option("--debug", dest="debug", action="store_true",
+                    help="Provide debugging information.")
+
     opts.set_defaults(list_copyright=False, latest=False, list_version=False)
 
     (options, args) = opts.parse_args()
-    nargs = len(args)
 
+    if options.debug:
+        lw.set_verbosity(5)
+        lw.set_handle_ciao_errors_debug(True)
+
+    nargs = len(args)
     if nargs != 0:
         opts.print_help()
         return

--- a/bin/check_ciao_version
+++ b/bin/check_ciao_version
@@ -35,13 +35,16 @@ Aim:
   version file on the CXC web site, and so requires on-line access.
 
   If called with an argument, the check will be made against the given
-  version file. This is intended for testing purposes only.
+  version file. This is intended for testing purposes only, and is
+  *only* for CIAO installations installed via ciao-install.
 
   CIAO must have been started before running this tool, and the
-  CIAO installation *must* have been created with ciao-install.
-  The 'conda update' command can be used for conda installations.
+  CIAO installation should have been made with either ciao-install
+  or conda. Support for the conda installation is new and not
+  well tested.
 
-  If there is an error the tool will exit with a non-zero status.
+  If the system needs an update then the tool will exit with a
+  non-zero status.
 
 """
 
@@ -53,7 +56,7 @@ from optparse import OptionParser
 import socket
 
 toolname = "check_ciao_version"
-version = "20 November 2019"
+version = "21 November 2019"
 
 try:
     from ciao_contrib import logger_wrapper as lw
@@ -75,7 +78,7 @@ help_str = """
 Check that the installed CIAO is up to date.
 
 The script checks that the installed CIAO and CALDB is up to date,
-which requres that it downloads a file from the CIAO web site.
+which requres that it downloads information from the CIAO web site.
 
 """
 
@@ -126,10 +129,11 @@ def compare_versions(ciao, latest, installed):
     vlatest = latest["CIAO"]
     vinstalled = installed["CIAO"]
 
+    # automatically error out if this fails
     if vlatest != vinstalled:
-        print("The CIAO installation at {0}".format(ciao))
-        print("   has version   {0}".format(vinstalled))
-        print("   the latest is {0}".format(vlatest))
+        print("The CIAO installation at {}".format(ciao))
+        print("   has version             {}".format(vinstalled))
+        print("   the released version is {}".format(vlatest))
         report_update_info()
         sys.exit(1)
 
@@ -240,6 +244,10 @@ def doit():
         raise IOError("$ASCDS_INSTALL is not defined; has CIAO been started?")
 
     installed = versioninfo.get_installed_versions(ciao)
+    if installed is None:
+        flag = versioninfo.check_conda_versions(ciao)
+        sys.exit(0 if flag else 1)
+
     if nargs == 1:
         latest = versioninfo.read_latest_versions(args[0])
     else:
@@ -248,7 +256,6 @@ def doit():
     # Check versions
     flag = compare_versions(ciao, latest, installed)
     flag &= compare_caldb()
-
     if not flag:
         report_update_info()
 

--- a/bin/check_ciao_version
+++ b/bin/check_ciao_version
@@ -37,7 +37,9 @@ Aim:
   If called with an argument, the check will be made against the given
   version file. This is intended for testing purposes only.
 
-  CIAO must have been started before running this tool.
+  CIAO must have been started before running this tool, and the
+  CIAO installation *must* have been created with ciao-install.
+  The 'conda update' command can be used for conda installations.
 
   If there is an error the tool will exit with a non-zero status.
 
@@ -51,11 +53,10 @@ from optparse import OptionParser
 import socket
 
 toolname = "check_ciao_version"
-version = "11 June 2019"
+version = "20 November 2019"
 
 try:
-    from ciao_contrib.logger_wrapper import handle_ciao_errors, \
-        set_handle_ciao_errors_debug
+    from ciao_contrib import logger_wrapper as lw
     from ciao_contrib._tools import versioninfo
     from ciao_contrib.caldb import get_caldb_dir, \
         get_caldb_installed, check_caldb_version
@@ -65,6 +66,9 @@ except ImportError:
                      "Unable to load a CIAO module. Has CIAO " +
                      "been started?\n")
     sys.exit(1)
+
+
+lgr = lw.initialize_logger(toolname)
 
 
 help_str = """
@@ -192,7 +196,7 @@ def compare_caldb():
         return False
 
 
-@handle_ciao_errors(toolname, version)
+@lw.handle_ciao_errors(toolname, version)
 def doit():
     """Run the code."""
 
@@ -207,14 +211,15 @@ def doit():
 
     opts.add_option("--debug", dest="debug",
                     action="store_true",
-                    help="Provide debugging information on error.")
+                    help="Provide debugging information.")
 
     opts.set_defaults(list_copyright=False, list_version=False)
 
     (options, args) = opts.parse_args()
 
     if options.debug:
-        set_handle_ciao_errors_debug(True)
+        lw.set_verbosity(5)
+        lw.set_handle_ciao_errors_debug(True)
 
     nargs = len(args)
     if nargs > 1:

--- a/share/doc/xml/check_ciao_version.xml
+++ b/share/doc/xml/check_ciao_version.xml
@@ -17,26 +17,30 @@
     <DESC>
       <PARA>
 	The check_ciao_version tool allows users to easily
-	check that the CIAO and 
+	check that the CIAO and
 	CIAO Calibration Database (CALDB) installations are up
 	to date. It compares the dates of the installed components
 	against the latest-released versions and prints out those
 	elements that need upgrading.
 	The script requires internet access
-	since it has to download the version information from the
-	CIAO and CALDB web sites.
+	since it has to download information from the
+	CXC web site.
       </PARA>
       <PARA title="Tool behavior">
 	The tool prints messages to the screen and exits with a status
-	of 0 when everything is up to date or non-zero when 
+	of 0 when everything is up to date or non-zero when
 	something needs updating.
       </PARA>
-      <PARA title="How do I upgrade my system">
+      <PARA title="How do I upgrade my system: ciao-install">
 	If the tool finds that your CIAO or CALDB installations are out
 	of date then it will point you to the
 	<HREF link="https://cxc.harvard.ed/ciao/download/">download CIAO
 	page</HREF>, from which the ciao-install script can be
 	downloaded. This script will perform the necessary updates.
+      </PARA>
+      <PARA title="How do I upgrade my system: conda">
+	The 'conda update' command can be used to update a conda-installed
+	version of CIAO.
       </PARA>
       <PARA title="Limitations">
 	The tool does not
@@ -44,7 +48,8 @@
       <LIST>
 	<ITEM>check that the components are installed correctly;</ITEM>
 	<ITEM>check for any optional CALDB components, such as the ACIS
-	background files or the PSF library files.</ITEM>
+	background files (for the ciao-install case, it does with
+	the conda install).</ITEM>
       </LIST>
       <PARA>
 	The CALDB check matches that done by the "--latest" flag of
@@ -59,7 +64,7 @@
 	  <LINE>&pr; check_ciao_version</LINE>
 	</SYNTAX>
 	<DESC>
-	  <PARA title="Up to date">
+	  <PARA title="Up to date: ciao-install">
 	    If the installations are up to date then you will see
 	    something like the following:
 	  </PARA>
@@ -107,8 +112,31 @@ to update your CIAO installation.
 	</DESC>
       </QEXAMPLE>
 
+      <QEXAMPLE>
+	<SYNTAX>
+	  <LINE>&pr; check_ciao_version</LINE>
+	</SYNTAX>
+	<DESC>
+	  <PARA title="Up to date: conda">
+	    If the installations are up to date then you will see
+	    something like the following:
+	  </PARA>
+<VERBATIM>
+CIAO (installed via conda) is up to date.
+</VERBATIM>
+	</DESC>
+      </QEXAMPLE>
+
     </QEXAMPLELIST>
-    
+
+    <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
+      <PARA>
+	The script has been updated to work with CIAO installations
+	made with the conda package manner as well as with ciao-install,
+	although support should be considered experimental.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
       <PARA>
         The code has been updated to avoid warning messages from
@@ -147,7 +175,7 @@ to update your CIAO installation.
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+    <LASTMODIFIED>December 2019</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Clean up the download code for check_ciao_version and check_ciao_caldb
so that it works with the new https location for the CXC. The problem
for these scripts is that the Python urlopen command can fail in
certain platform/system combinations (e.g. ciao-install + Ubuntu)
because the correct certificates can not be found. This was
compounded in the check_ciao_version case by the need to check
multiple URLs, with fall-through behavior on missing files:
this interacted badly with the fall-through-to-wget/curl approach,
resulting in bad results.

The approach now is to use Python only requests - which should be
okay now we can 'import ssl' on the platforms - but to turn off
the TLS validation. This is not ideal, but it is only for
these URL downloads, and they are to cxc.fa.harvard.edu (so no
less safe than it was prior to CIAO 4.12).

This should fix #321

check_ciao_version has been updated so that it will work with conda install
(relying on 'conda list' and 'conda update' to do the heavy lifting). This has
seen limited testing.

This should fix #267 (check_ciao_caldb has not been updated to use 'conda'
in this case as the existing code should still work in the conda environment).