### PR TITLE
check_ciao_version: handle contrib installed manually

### DIFF
--- a/bin/check_ciao_version
+++ b/bin/check_ciao_version
@@ -50,13 +50,11 @@ Aim:
 
 import os
 import sys
-import glob
+
 from optparse import OptionParser
 
-import socket
-
 toolname = "check_ciao_version"
-version = "16 June 2020"
+version = "07 December 2020"
 
 try:
     from ciao_contrib import logger_wrapper as lw
@@ -65,7 +63,7 @@ try:
         get_caldb_installed, check_caldb_version
 
 except ImportError:
-    sys.stderr.write("# {} ({}): ERROR ".format(toolname, version) +
+    sys.stderr.write(f"# {toolname} ({version}): ERROR " +
                      "Unable to load a CIAO module. Has CIAO " +
                      "been started?\n")
     sys.exit(1)
@@ -131,9 +129,9 @@ def compare_versions(ciao, latest, installed):
 
     # automatically error out if this fails
     if vlatest != vinstalled:
-        print("The CIAO installation at {}".format(ciao))
-        print("   has version             {}".format(vinstalled))
-        print("   the released version is {}".format(vlatest))
+        print(f"The CIAO installation at {ciao}")
+        print(f"   has version             {vinstalled}")
+        print(f"   the released version is {vlatest}")
         report_update_info()
         sys.exit(1)
 
@@ -146,32 +144,31 @@ def compare_versions(ciao, latest, installed):
             updates.append((ik, iv, lv))
 
     if updates == []:
-        print("The CIAO  installation at {0} is up to date.".format(ciao))
+        print(f"The CIAO  installation at {ciao} is up to date.")
         return True
 
+    print(f"Using the CIAO installation at {ciao}\n")
+
+    nu = len(updates)
+    if nu == 1:
+        print("The following package:")
     else:
-        print("Using the CIAO installation at {0}\n".format(ciao))
+        print("The following packages:")
 
-        nu = len(updates)
-        if nu == 1:
-            print("The following package:")
-        else:
-            print("The following packages:")
+    fmt = "    {0:10s}:  {1}"
+    for (pname, iver, _) in updates:
+        print(fmt.format(pname, iver))
 
-        fmt = "    {0:10s}:  {1}"
-        for (pname, iver, _) in updates:
-            print(fmt.format(pname, iver))
+    if nu == 1:
+        print("\nneeds updating to:")
+    else:
+        print("\nneed updating to:")
 
-        if nu == 1:
-            print("\nneeds updating to:")
-        else:
-            print("\nneed updating to:")
+    for (pname, _, lver) in updates:
+        print(fmt.format(pname, lver))
 
-        for (pname, _, lver) in updates:
-            print(fmt.format(pname, lver))
-
-        print("")
-        return False
+    print("")
+    return False
 
 
 # Logic also in check_ciao_caldb: should re-factor
@@ -181,23 +178,23 @@ def compare_caldb():
 
     caldb = get_caldb_dir()
 
-    (cver, cdat) = get_caldb_installed(caldb)
+    inst = get_caldb_installed(caldb)
+    cver = inst[0]
     rval = check_caldb_version(cver)
 
-    cinfo = "The CALDB installation at {0}".format(caldb)
+    cinfo = f"The CALDB installation at {caldb}"
     if os.path.islink(caldb):
         lname = os.path.realpath(caldb)
-        cinfo += " (link to {0})".format(lname)
+        cinfo += f" (link to {lname})"
 
     if rval is None:
-        print("{0} is up to date.".format(cinfo))
+        print(f"{ciao} is up to date.")
         return True
 
-    else:
-        print(cinfo)
-        print("  has version: {0}".format(cver))
-        print("  latest is:   {0}".format(rval[1]))
-        return False
+    print(cinfo)
+    print(f"  has version: {cver}")
+    print(f"  latest is:   {rval[1]}")
+    return False
 
 
 @lw.handle_ciao_errors(toolname, version)

--- a/share/doc/xml/check_ciao_version.xml
+++ b/share/doc/xml/check_ciao_version.xml
@@ -71,6 +71,16 @@
 <VERBATIM>
 CIAO (installed via conda) is up to date.
 </VERBATIM>
+
+	  <PARA title="Out of date">
+	    If there is an out of date component then you will see
+	    something like:
+	  </PARA>
+<VERBATIM>
+There is one package that need updating:
+  sherpa : 4.12.0 -> 4.12.1
+</VERBATIM>
+
 	</DESC>
       </QEXAMPLE>
 

--- a/share/doc/xml/check_ciao_version.xml
+++ b/share/doc/xml/check_ciao_version.xml
@@ -31,16 +31,16 @@
 	of 0 when everything is up to date or non-zero when
 	something needs updating.
       </PARA>
+      <PARA title="How do I upgrade my system: conda">
+	The 'conda update' command can be used to update a conda-installed
+	version of CIAO.
+      </PARA>
       <PARA title="How do I upgrade my system: ciao-install">
 	If the tool finds that your CIAO or CALDB installations are out
 	of date then it will point you to the
 	<HREF link="https://cxc.harvard.edu/ciao/download/">download CIAO
 	page</HREF>, from which the ciao-install script can be
 	downloaded. This script will perform the necessary updates.
-      </PARA>
-      <PARA title="How do I upgrade my system: conda">
-	The 'conda update' command can be used to update a conda-installed
-	version of CIAO.
       </PARA>
       <PARA title="Limitations">
 	The tool does not
@@ -59,6 +59,21 @@
     </DESC>
 
     <QEXAMPLELIST>
+      <QEXAMPLE>
+	<SYNTAX>
+	  <LINE>&pr; check_ciao_version</LINE>
+	</SYNTAX>
+	<DESC>
+	  <PARA title="Up to date: conda">
+	    If the installations are up to date then you will see
+	    something like the following:
+	  </PARA>
+<VERBATIM>
+CIAO (installed via conda) is up to date.
+</VERBATIM>
+	</DESC>
+      </QEXAMPLE>
+
       <QEXAMPLE>
 	<SYNTAX>
 	  <LINE>&pr; check_ciao_version</LINE>
@@ -112,22 +127,13 @@ to update your CIAO installation.
 	</DESC>
       </QEXAMPLE>
 
-      <QEXAMPLE>
-	<SYNTAX>
-	  <LINE>&pr; check_ciao_version</LINE>
-	</SYNTAX>
-	<DESC>
-	  <PARA title="Up to date: conda">
-	    If the installations are up to date then you will see
-	    something like the following:
-	  </PARA>
-<VERBATIM>
-CIAO (installed via conda) is up to date.
-</VERBATIM>
-	</DESC>
-      </QEXAMPLE>
-
     </QEXAMPLELIST>
+
+    <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
+      <PARA>
+	The script has improved handling of the conda installation path.
+      </PARA>
+    </ADESC>
 
     <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
       <PARA>
@@ -175,7 +181,7 @@ CIAO (installed via conda) is up to date.
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2019</LASTMODIFIED>
+    <LASTMODIFIED>December 2020</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This avoids the unhelpful failure message that check_ciao_version
returned if the contrib code has been installed via 'python
setup.py install' (which is only expected to be found for internal
testing).

The code had been written to handle the error case, but I had not
taken advantage of this before. So there's two fixes:

  a) correct handling of the error case [this was from an old version of the code; it has been subsumed by other changes]
  b) skip checking for any CIAO packages installed via pypi

The ahelp file has been updated to make conda the "primary" installation method (i.e.mentioned first) and ciao-install second.

I've also taken advantage of f-strings.