### PR TITLE
Add regrid support to xsconvolve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.gz
 *.pyc
 build/
+ciao_contrib.egg-info/


### PR DESCRIPTION
This updates the XSPEC convolution support to allow models to be evaluated ona different grid using the `regrid` method.