### PR TITLE
dax: psffrac hanging problem

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -11,9 +11,10 @@ Updated scripts
 
   dax
   
-    Updated the Regions -> PSF Fraction task to be sure to request 
-    regions in ds9 format. If user have changed default to 'ciao' 
-    format, this task will hang.
+    Updated the Regions -> PSF Fraction task to force regions in
+    ds9 format.  This update prevents dax from hanging when 
+    users have modified their preferences to save regions in 
+    ciao format.
     
 
 ## 4.12.1 - December 2019 ##

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -9,7 +9,12 @@ Updated scripts
     tool.  The background BACKSCAL column was incorrectly copied
     from the source region.
 
-
+  dax
+  
+    Updated the Regions -> PSF Fraction task to be sure to request 
+    regions in ds9 format. If user have changed default to 'ciao' 
+    format, this task will hang.
+    
 
 ## 4.12.1 - December 2019 ##
 

--- a/bin/ds9_get_psffrac.sh
+++ b/bin/ds9_get_psffrac.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 # 
-#  Copyright (C) 2004-2008,2015  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2004-2008,2015,2020  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -52,7 +52,7 @@ then
 fi
 
 
-myreg=`xpaget ${ds9} regions selected -system wcs -skyformat degrees -strip | tr ";" "\012" | egrep "circle|ellipse|box|annulus" | tail -1 | tr "(),"'"'  " " `
+myreg=`xpaget ${ds9} regions selected -format ds9 -system wcs -skyformat degrees -strip | tr ";" "\012" | egrep "circle|ellipse|box|annulus" | tail -1 | tr "(),"'"'  " " `
 
 
 if test "x$myreg" = x

--- a/share/doc/xml/dax.xml
+++ b/share/doc/xml/dax.xml
@@ -90,9 +90,10 @@ unix% ds9 -analysis $ASCDS_INSTALL/contrib/config/ciao.ds9 ...
 <ADESC title="Changes in the 4.12.2 (March 2020) release">
 
   <PARA>
-    Updated the Regions -> PSF Fraction task to be sure to request 
-    regions in ds9 format. If user have changed default to 'ciao' 
-    format, this task will hang.
+    Updated the Regions -> PSF Fraction task to force regions in
+    ds9 format.  This update prevents dax from hanging when 
+    users have modified their preferences to save regions in 
+    ciao format.
   </PARA>
 
 </ADESC>

--- a/share/doc/xml/dax.xml
+++ b/share/doc/xml/dax.xml
@@ -87,6 +87,19 @@ unix% ds9 -analysis $ASCDS_INSTALL/contrib/config/ciao.ds9 ...
 </DESC>
 
 
+<ADESC title="Changes in the 4.12.2 (March 2020) release">
+
+  <PARA>
+    Updated the Regions -> PSF Fraction task to be sure to request 
+    regions in ds9 format. If user have changed default to 'ciao' 
+    format, this task will hang.
+  </PARA>
+
+</ADESC>
+
+
+
+
 <ADESC title="Changes in the 4.11.3 (May 2019) release">
   <PARA>
   This release includes major changes to dax affecting most of the 
@@ -217,6 +230,8 @@ unix% ds9 -analysis $ASCDS_INSTALL/contrib/config/ciao.ds9 ...
 
 
 
+
+
 <ADESC title="Changes in the 4.11.1 (December 2018) release">
   <PARA>
     Clarified error messages to indicate that users must have regions
@@ -294,6 +309,6 @@ clear which task is being run.
       </PARA>
    </BUGS>
 
-   <LASTMODIFIED>May 2019</LASTMODIFIED>
+   <LASTMODIFIED>January 2020</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #255 

Originally I thought it was a problem with preferences on units but now realize it was a diff in pref in format (ciao vs. ds9 region format).  Dax should ask for format it wants instead of relying on defaults.


