### PR TITLE
fix tgsplit backscale for tge2 files

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,3 +1,16 @@
+
+## 4.12.2 - March 2020 ##
+
+Updated scripts
+
+  tgsplit
+  
+    Fix problem with TYPE:II PHA files created with the tgextract2
+    tool.  The background BACKSCAL column was incorrectly copied
+    from the source region.
+
+
+
 ## 4.12.1 - December 2019 ##
 
 Updated scripts

--- a/bin/tgsplit
+++ b/bin/tgsplit
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2014,2016 Smithsonian Astrophysical Observatory
+# Copyright (C) 2014,2016,2019,2020 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 from __future__ import print_function
 
 toolname = "tgsplit"
-__revision__ = "04 November 2019"
+__revision__ = "21 Jan 2020"
 
 from ciao_contrib.runtool import make_tool
 from pycrates import read_file, write_file
@@ -216,7 +216,7 @@ def split_bkg_tge2( infile, clobber ):
 
     # save values
     tab.get_column("counts").values = bgcts
-    tab.get_column("backscal").value = bgscl
+    tab.get_column("backscal").values = bgscl
     tab.get_key("POISSERR").value = True
 
     # delete bkg colums/keys

--- a/share/doc/xml/tgsplit.xml
+++ b/share/doc/xml/tgsplit.xml
@@ -374,6 +374,20 @@ Created background spectrum: tgcat_obs7435_heg_p1_bkg.pha
      </PARA>
    </ADESC>
 
+
+
+
+  <ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+    <PARA>
+    Fix problem with TYPE:II PHA files created with the tgextract2
+    tool.  The background BACKSCAL column was incorrectly copied
+    from the source region.
+    </PARA>
+  
+  </ADESC>
+
+
+
     <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
       <PARA>
         A bug fix to work with TYPE:II PHA files created with the
@@ -435,7 +449,7 @@ Created background spectrum: tgcat_obs7435_heg_p1_bkg.pha
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>December 2019</LASTMODIFIED>
+    <LASTMODIFIED>January 2020</LASTMODIFIED>
 
   </ENTRY>    
 </cxchelptopics>


### PR DESCRIPTION
This fixes #337 

stupid typo:  `value` vs. `values` 

