### PR TITLE
Fix example in XML helpfile for coords_chandra

### DIFF
--- a/share/doc/xml/coords_chandra.xml
+++ b/share/doc/xml/coords_chandra.xml
@@ -77,7 +77,7 @@
 	<LINE>&pr; from coords.chandra import cel_to_chandra</LINE>
 	<LINE>&pr; from pycrates import read_file</LINE>
 	<LINE>&pr; srclist = read_file("wavedetect.src")</LINE>
-	<LINE>&pr; keywords = {srclist: cr.get_key_value(n) for n in srclist.get_keynames()}</LINE>
+	<LINE>&pr; keywords = {n: cr.get_key_value(n) for n in srclist.get_keynames()}</LINE>
 	<LINE>&pr; ra = srclist.get_column("RA").values</LINE>
 	<LINE>&pr; dec = srclist.get_column("DEC").values</LINE>
 	<LINE>&pr; coords = cel_to_chandra(keywords, ra, dec)</LINE>


### PR DESCRIPTION
As given, the dictionary created in the example would not be `{header_key: header_value}`, but `{crates_file_object: header_value}` which is clearly a typo in the example.