### PR TITLE
Download obsid data via http

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,37 +1,45 @@
 
 ## 4.12.2 - March 2020 ##
 
+Note that the CXC-provided FTP service has been deprecated, and will
+soon be removed. It is important to update to version 4.12.2 of the
+contributed scripts package, or later, otherwise scripts will fail
+or may hang indefinitely.
+
 Updated scripts
+
+  download_chandra_obsid
+
+    No longer accesses the archive via FTP. The file download
+    is now done in decreasing order of file size (per obsid).
 
   download_obsid_caldb
 
-    Updated to use https:// to retrieve the CALDB files
-    
+    No longer accesses the CALDB files via FTP.
+
     Updated to create standard CALDB setup scripts:
         software/tools/caldbinit.unix
         software/tools/caldbinit.sh
     Versioned editions of the scripts are in the config/ directory.
 
-
   tgsplit
-  
+
     Fix problem with TYPE:II PHA files created with the tgextract2
     tool.  The background BACKSCAL column was incorrectly copied
     from the source region.
 
   dax
-  
+
     Updated the Regions -> PSF Fraction task to force regions in
-    ds9 format.  This update prevents dax from hanging when 
-    users have modified their preferences to save regions in 
+    ds9 format.  This update prevents dax from hanging when
+    users have modified their preferences to save regions in
     ciao format.
-    
+
   simulate_psf
 
     Fixed bug that caused parameter values in the script's HISTORY 
     records to be reset to their default (blank) values.
-   
-  
+
 
 ## 4.12.1 - December 2019 ##
 

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -12,6 +12,8 @@ Updated scripts
 
     No longer accesses the archive via FTP. The file download
     is now done in decreasing order of file size (per obsid).
+    Support for grating ARFs and RMFs has been added, in preparation
+    for the next reprocessing of the Chandra archive.
 
   download_obsid_caldb
 

--- a/bin/download_chandra_obsid
+++ b/bin/download_chandra_obsid
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017
+#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2020
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -26,7 +26,7 @@ Usage:
 
 Aim:
 
-Download, via anonymous FTP, Chandra observatinoal data using the
+Download, via HTTPS, Chandra observational data using the
 ObsId value of the observation. Multiple observations can be given by
 giving a comma-separated list of obsid values (or a stack).
 
@@ -45,7 +45,7 @@ scheme: e.g.
   <obsid>/secondary/...
   ... etc ...
 
-This tool can only be used to download publicly-accessible
+This tool can *only* be used to download publicly-accessible
 data. Data that has not yet been made public has to be downloaded by
 other means.
 
@@ -55,52 +55,29 @@ argument or the CDA_MIRROR_SITE environment variable (the command-line
 argument takes precedence if both are set). The mirror name should
 point to the location of the byobsid directory - e.g.  for the Chandra
 Data Archive itself you would use
-ftp://cda.cfa.harvard.edu/pub/. The leading ftp:// is required.
-
-If you need to use a specific username and password then include it in
-the mirror setting - e.g.
-ftp://anonymous:anonymous@anonymous.com@cda.cfa.harvard.edu/pub/. See
-http://tools.ietf.org/html/rfc3986 for more information.
+https://cxc.cfa.harvard.edu/cdaftp/
 
 """
 
-toolname = "download_chandra_obsid"
-version = "15 May 2017"
-
 import sys
-import os
 import textwrap
 import argparse
 
+import subprocess as sbp
+
 import stk
-
-# This is only needed for development.
-try:
-    if not __file__.startswith(os.environ['ASCDS_INSTALL']):
-        _thisdir = os.path.dirname(__file__)
-        _libname = "python{}.{}".format(sys.version_info.major,
-                                        sys.version_info.minor)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
-        if os.path.isdir(_pathdir):
-            os.sys.path.insert(1, _pathdir)
-        else:
-            print("*** WARNING: no {}".format(_pathdir))
-
-        del _libname
-        del _pathdir
-        del _thisdir
-
-except KeyError:
-    raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
 
 import ciao_contrib.logger_wrapper as lw
 import ciao_contrib.cda.data as data
 
-lw.initialize_logger(toolname, verbose=1)
-v1 = lw.make_verbose_level(toolname, 1)
-v3 = lw.make_verbose_level(toolname, 3)
+TOOLNAME = "download_chandra_obsid"
+VERSION = "5 February 2020"
 
-help_str = """
+lw.initialize_logger(TOOLNAME, verbose=1)
+V1 = lw.make_verbose_level(TOOLNAME, 1)
+V3 = lw.make_verbose_level(TOOLNAME, 3)
+
+HELP_STR = """
 Download public Chandra observations.
 
 The observations to download are given as a comma-separated list of
@@ -121,16 +98,13 @@ A mirror site of the Chandra Data Archive can be used by setting the
 --mirror option or by setting the CDA_MIRROR_SITE envrironment
 variable; the command-line option takes precedence if both are
 set. The mirror name should point to the location of the byobsid
-directory and start with ftp:// - e.g. using the Chandra Data is
-equivalent to using a setting of ftp://cda.cfa.harvard.edu/pub/. A
-username and password can be included in this setting, following
-http://tools.ietf.org/html/rfc3986, e.g.
-ftp://anonymous:foo@bar.org@cda.cfa.harvard.edu/pub/.
+directory - e.g. using the Chandra Data is equivalent to using a
+setting of https://cxc.cfa.harvard.edu/cdaftp/
 """
 
 
-copyright_str = """
-Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015
+COPYRIGHT_STR = """
+Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2020
           Smithsonian Astrophysical Observatory
 
 This program is free software; you can redistribute it and/or modify
@@ -157,16 +131,22 @@ def get_terminal_width():
     http://stackoverflow.com/questions/566746/how-to-get-console-window-width-in-python
     """
 
-    # Should this use the processing module instead of os.popen?
+    default = 80
+
     try:
-        rows, columns = os.popen('stty size', 'r').read().split()
-    except:
-        columns = 80
+        sizes = sbp.run(['stty', 'size'], stdout=sbp.PIPE, check=True)
+    except (FileNotFoundError, sbp.CalledProcessError):
+        return default
 
-    return int(columns)
+    try:
+        columns = int(sizes.stdout.decode('utf-8').split()[1])
+    except (ValueError, IndexError):
+        return default
+
+    return columns
 
 
-def display_string(str, lwidth=3, rwidth=3):
+def display_string(strval, lwidth=3, rwidth=3):
     """Return a string which is the contents of str broken up so that
     if fits into the current display width and each line is indented:
     the left side so that there are lwidth spaces and the right side
@@ -178,14 +158,14 @@ def display_string(str, lwidth=3, rwidth=3):
     wrapper = textwrap.TextWrapper(initial_indent=indent,
                                    subsequent_indent=indent,
                                    width=nwidth)
-    return wrapper.fill(str)
+    return wrapper.fill(strval)
 
 
-@lw.handle_ciao_errors(toolname, version)
+@lw.handle_ciao_errors(TOOLNAME, VERSION)
 def download_chandra_obsid():
     "Run the code"
 
-    parser = argparse.ArgumentParser(description=help_str,
+    parser = argparse.ArgumentParser(description=HELP_STR,
                                      prog="download_chandra_obsid")
 
     parser.add_argument("obsids", nargs='?',  # for now we do not
@@ -205,7 +185,7 @@ def download_chandra_obsid():
                         action="store_true",
                         help="List the valid file types and exit.")
     parser.add_argument("--mirror", "-m", dest="mirror_site", action="store",
-                        help="Use this instead of the CDA FTP site")
+                        help="Use this instead of the CDA site")
     parser.add_argument("--debug", "-d", dest="debug", action="store_true",
                         help="Display diagnostic output? [default: %(default)s]")
 
@@ -213,17 +193,17 @@ def download_chandra_obsid():
     args = parser.parse_args(arglist)
 
     if args.list_version:
-        v1(version)
+        V1(VERSION)
         sys.exit(0)
 
     if args.list_copyright:
-        v1(copyright_str)
+        V1(COPYRIGHT_STR)
         sys.exit(0)
 
     if args.list_ft:
-        v1("The list of valid file types is:\n")
-        v1(display_string(data.known_file_types_str))
-        v1("")
+        V1("The list of valid file types is:\n")
+        V1(display_string(data.known_file_types_str))
+        V1("")
         sys.exit(0)
 
     if args.debug:
@@ -231,7 +211,7 @@ def download_chandra_obsid():
     elif args.quiet:
         lw.set_verbosity(0)
 
-    v3("{}: {}".format(toolname, version))
+    V3("{}: {}".format(TOOLNAME, VERSION))
 
     olist = args.obsids
     if olist is None:
@@ -244,9 +224,9 @@ def download_chandra_obsid():
         tlist = [t.lower() for t in stk.build(tlist)]
         for t in tlist:
             if t not in data.known_file_types:
-                raise ValueError("{0} is not a valid file type".format(t) +
+                raise ValueError("{} is not a valid file type".format(t) +
                                  " - must be one of:\n" +
-                                 "{0}".format(data.known_file_types_str))
+                                 "{}".format(data.known_file_types_str))
 
     if args.mirror_site:
         mirror = args.mirror_site

--- a/bin/download_chandra_obsid
+++ b/bin/download_chandra_obsid
@@ -71,7 +71,7 @@ import ciao_contrib.logger_wrapper as lw
 import ciao_contrib.cda.data as data
 
 TOOLNAME = "download_chandra_obsid"
-VERSION = "5 February 2020"
+VERSION = "6 February 2020"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)
@@ -186,6 +186,10 @@ def download_chandra_obsid():
                         help="List the valid file types and exit.")
     parser.add_argument("--mirror", "-m", dest="mirror_site", action="store",
                         help="Use this instead of the CDA site")
+
+    # Note: --debug is stripped out by preprocess_arglist, but leave in
+    # here as it is used in the help string.
+    #
     parser.add_argument("--debug", "-d", dest="debug", action="store_true",
                         help="Display diagnostic output? [default: %(default)s]")
 
@@ -206,7 +210,12 @@ def download_chandra_obsid():
         V1("")
         sys.exit(0)
 
-    if args.debug:
+    # We stripped out the --debug argument before sending it to the
+    # argument parser, so args.debug is only  set if -d was given,
+    # not --debug. I should remove -d (ie so it isn't a synonym for
+    # --debug), but leave in for now.
+    #
+    if args.debug or lw.get_handle_ciao_errors_debug():
         lw.set_verbosity(3)
     elif args.quiet:
         lw.set_verbosity(0)

--- a/ciao_contrib/cda/data.py
+++ b/ciao_contrib/cda/data.py
@@ -103,6 +103,7 @@ known_file_types = [
     "cntr_img", "full_img", "src_img",
     "asol", "eph0", "eph1",
     "aoff", "evt1a", "evt1", "flt", "msk", "mtl", "soff", "stat",
+    "arf", "rmf",  # assume these are the correct tokens
     "bias", "pbk",
     "osol", "aqual",
     "sum", "pha2", "dtf", "plt",

--- a/ciao_contrib/cda/data.py
+++ b/ciao_contrib/cda/data.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2019
+#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2019, 2020
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 """
 Download publically-available data from the Chandra Data Archive (CDA).
 
-Routines that wrap up FTP access to the Chandra Data Archive -
+Routines that wrap up HTTPS access to the Chandra Data Archive -
 https://cxc.harvard.edu/cda/ - supporting mirror sites under the
 assumption that they have the same directory structure and login
 support as the CDA.
@@ -30,13 +30,13 @@ stable, so there may well be API changes.
 
 Example with no screen output:
 
-  out = download_chandra_obsids([1843,1844])
+  out = download_chandra_obsids([1843, 1844])
 
 Example with screen output:
 
   import ciao_contrib.logger_wrapper as lw
   lw.initialize_logger("download", verbose=1)
-  out = download_chandra_obsids([1843,1844],
+  out = download_chandra_obsids([1843, 1844],
              ["evt1", "asol", "bpix", "mtl"])
 
 """
@@ -44,77 +44,26 @@ Example with screen output:
 import sys
 import os
 import os.path
-import time
-import socket
-import ftplib
 
-from urllib.parse import urlparse
+import urllib.parse
+import urllib.request
+
+from operator import itemgetter
 
 import ciao_contrib.logger_wrapper as lw
+from ciao_contrib import downloadutils
+
 
 __init__ = ("download_chandra_obsids", )
 
-DEFAULT_USERNAME = 'anonymous'
-DEFAULT_PASSWORD = 'anonymous@ciao_contrib.cda.data'
+BASE_URL = 'https://cxc.cfa.harvard.edu/cdaftp/'
 
-logger = lw.initialize_module_logger("cda.data")
+LOGGER = lw.initialize_module_logger("cda.data")
 
-v0 = logger.verbose0
-v1 = logger.verbose1
-v3 = logger.verbose3
+V1 = LOGGER.verbose1
+V3 = LOGGER.verbose3
 
-
-# Wrapper around a file for writing to write a hash sign every x%
-# of the file has been downloaded.
-#
-# This is based on code from the Tools/scripts/ftpmirror.py in the
-# Python distribution.
-#
-# Hashes are only output if the logging verbosity is set to >= 1,
-# although the logger is not used to write out the text.
-#
-class LoggingFile:
-
-    def __init__(self, fp, filesize, outfp, startfrom=None, nhash=20):
-        """nhash is the number of hashes to print (so 100/nhash is the
-        percentage of the file content for each #)."""
-        if nhash < 1:
-            raise ValueError("nhash must be >= 1, sent {}".format(nhash))
-        self.fp = fp
-        if startfrom is None:
-            self.bytes = 0
-        else:
-            if startfrom > filesize:
-                raise ValueError("startfrom > filesize ({} vs {})".format(startfrom, filesize))
-            self.bytes = startfrom - 1
-        self.hashes = 0
-        self.filesize = filesize
-        self.nhash = nhash
-        self.blocksize = filesize / self.nhash
-        self.outfp = outfp
-
-    def write(self, data):
-        self.bytes = self.bytes + len(data)
-        hashes = int(self.bytes) / self.blocksize
-        if logger.getEffectiveVerbose() > 0:
-            while hashes > self.hashes:
-                self.outfp.write('#')
-                self.outfp.flush()
-                self.hashes = self.hashes + 1
-
-        self.fp.write(data)
-
-    def close(self):
-        # hack around rounding errors
-        nh = self.nhash - self.hashes
-        if logger.getEffectiveVerbose() > 0:
-            if nh > 0 and self.bytes >= self.filesize:
-                self.outfp.write('#' * nh)
-
-            self.outfp.flush()
-
-
-__mirror_environ = "CDA_MIRROR_SITE"
+__MIRROR_ENVIRON = "CDA_MIRROR_SITE"
 
 
 def get_mirror_location(useropt):
@@ -129,43 +78,20 @@ def get_mirror_location(useropt):
 
     if useropt is not None and useropt.strip() != "":
         useropt = useropt.strip()
-        v3("Using user-defined mirror: {}".format(useropt))
+        V3("Using user-defined mirror: {}".format(useropt))
         return useropt
 
     try:
-        ans = os.environ[__mirror_environ].strip()
+        ans = os.environ[__MIRROR_ENVIRON].strip()
         if ans != "":
-            v3("Using ${}={}".format(__mirror_environ, ans))
+            V3("Using ${}={}".format(__MIRROR_ENVIRON, ans))
             return ans
 
     except KeyError:
         pass
 
-    v3("Using CDA FTP site")
+    V3("Using CDA HTTPS site")
     return None
-
-
-# NOTE: use of os.path.join for the path manipulation for the FTP site
-# is only going to work when the script is run on a machine for which
-# the semantics matches that of UNIX, but that is the only supported
-# platforms for CIAO.
-
-class ChandraFTP(ftplib.FTP):
-    """A container for the ftplib.FTP class, with
-    additional fields to help identify mirrors for the
-    Chandra Data Archive.
-    """
-
-    def __init__(self, host='', user='', passwd='', basedir=''):
-        """Connect to a Chandra Data Archive mirror, where basedir is
-        the location of the byobsid directory."""
-
-        self.basedir = os.path.join(basedir, 'byobsid')
-        v3("ChandraFTP: basedir={}".format(self.basedir))
-        v3("Connecting to host={} user={} passwd={}".format(host,
-                                                            user,
-                                                            passwd))
-        ftplib.FTP.__init__(self, host=host, user=user, passwd=passwd)
 
 
 # The order of these is important as we want the most specific first -
@@ -188,29 +114,23 @@ known_file_types_str.sort()
 known_file_types_str = " ".join(known_file_types_str)
 
 
-def extract_file_type(fname):
+def extract_file_type(filename):
     """Return the 'type' of the given file, e.g. "evt2", "asol1".
 
     Returns None for an unrecognized file type.
     """
 
-    if fname is None or fname.strip() == "":
-        raise ValueError("No file given")
-    fn = fname.strip()
-    if fn[-1] == "/":
-        return None
-
-    if fn == "oif.fits":
+    if filename == "oif.fits":
         return "oif"
-    if fn.lower() == "00readme":
+    if filename.lower() == "00readme":
         return "readme"
-    if 'vv' in fn:
+    if 'vv' in filename:
         return "vv"
 
-    for ft in known_file_types:
-        suffix = '_{}'.format(ft)
-        if suffix in fn:
-            return ft
+    for ftype in known_file_types:
+        suffix = '_{}'.format(ftype)
+        if suffix in filename:
+            return ftype
 
     return None
 
@@ -219,22 +139,17 @@ known_file_formats = ["fits", "jpg", "pdf", "ps", "html", "ascii"]
 known_file_formats.sort()
 
 
-def extract_file_format(fname):
+def extract_file_format(filename):
     """Returns "ascii", "fits", "jpg", "pdf", or None depending of the
-    file name."""
+    file name.
+    """
 
-    if fname is None or fname.strip() == "":
-        raise ValueError("No file given")
-    fn = fname.strip()
-    if fn[-1] == "/":
-        return None
-
-    if fname == "00README":
+    if filename == "00README":
         return "ascii"
 
-    for ff in known_file_formats:
-        if fn.find(ff) != -1:
-            return ff
+    for fformat in known_file_formats:
+        if filename.find(fformat) != -1:
+            return fformat
 
     return None
 
@@ -246,94 +161,64 @@ def create_directory(dname):
 
     if dname == "" or os.path.exists(dname):
         return
-    v3("Creating directory: '{}'".format(dname))
+
+    V3("Creating directory: '{}'".format(dname))
     if dname[-1] == "/":
         parent = os.path.dirname(dname[:-1])
     else:
         parent = os.path.dirname(dname)
+
     if not os.path.exists(parent):
         create_directory(parent)
+
     os.mkdir(dname, 0o777)
-
-
-def stringify_size(s):
-    "Convert a file size, in bytes, to a text string."
-
-    def myint(f):
-        return int(f + 0.5)
-
-    if s < 1024:
-        lbl = "< 1 Kb"
-    elif s < 1024 * 1024:
-        lbl = "%d Kb" % (myint(s / 1024.0))
-    elif s < 1024 * 1024 * 1024:
-        lbl = "%d Mb" % (myint(s / (1024 * 1024.0)))
-    else:
-        lbl = "%.1f Gb" % (s / (1024 * 1024 * 1024.0))
-
-    return lbl
-
-
-def stringify_dt(dt):
-    """Convert two times into a text string giving a 'human readable'
-    version of the time difference (the dt argument)
-    """
-
-    if dt < 1:
-        return "< 1 s"
-
-    def myint(f):
-        return int(f + 0.5)
-
-    d = myint(dt // (24 * 3600))
-    dt2 = dt % (24 * 3600)
-    h = myint(dt2 // 3600)
-    dt3 = dt % 3600
-    m = myint(dt3 // 60)
-    s = myint(dt3 % 60)
-
-    if d > 0:
-        lbl = "%d day" % d
-        if d > 1:
-            lbl += "s"
-        if h > 0:
-            lbl += " %d h" % h
-
-    elif h > 0:
-        lbl = "%d h" % h
-        if m > 0:
-            lbl += " %d m" % m
-
-    elif m > 0:
-        lbl = "%d m" % m
-        if s > 0:
-            lbl += " %d s" % s
-
-    else:
-        lbl = "%d s" % s
-
-    return lbl
 
 
 class ObsIdFile:
     """A file that is part of a Chandra ObsId.
 
-    It is used to allow the file to be easily downloaded via FTP
+    It is used to allow the file to be easily downloaded
     rather than as something useful for data analysis.
     """
 
-    def __init__(self, obsid, filename):
-        """Create a record for the given file (filename should include
-        any path elements after the byobsid directory).
+    def __init__(self, obsid, url):
+        """Create a record for the given file.
         """
 
+        # should parse the url and then extract the component properly
+        # but do it this way for simplicity
+        #
+        toks = url.strip().split('/')
+        filename = toks[-1]
+        if filename == '':
+            raise ValueError("Sent a directory, not a file: {}".format(url))
+
         self.obsid = str(obsid)
+        self.url = url
         self.filename = filename
         self.filetype = extract_file_type(filename)
         self.fileformat = extract_file_format(filename)
 
-        # assume we are in the byobsid directory (to support mirrors)
-        self.path = os.path.join(self.obsid[-1], self.obsid, self.filename)
+        # work out the subdirectory path for this file; should this
+        # be sent in here?
+        #
+        while True:
+            try:
+                tok = toks.pop(0)
+            except IndexError:
+                raise ValueError('Expected URL to include /byobsid/ fragment: {}'.format(url))
+
+            if tok == 'byobsid':
+                break
+
+        if len(toks) < 3:
+            raise ValueError('Expected more directories: {}'.format(url))
+
+        toks.pop(0)
+
+        # can now combine the rest to get the path (dropping the actual
+        # file name)
+        self.localpath = '/'.join(toks[:-1])
 
         self.filesize = None
 
@@ -347,32 +232,31 @@ class ObsIdFile:
         the file is one of these formats."""
         return self.fileformat in formats
 
-    def get_filesize(self, ftp):
+    def get_filesize(self, headers):
         """Returns the file size in bytes.
 
-        The ftp object should be a FTP object connected to the
-        archive.
+        The hdr value is added to the request header to enable the
+        user-agent to be changed (or any other header).
         """
 
-        if self.filesize is None:
-            # the ftp.size command seems to be returning unreliable
-            # results, so manually parse the list output to grab the
-            # value, falling back to size if necessary
-            #
-            path = os.path.join(ftp.basedir, self.path)
-            v3("Finding size of: {}".format(path))
+        if self.filesize is not None:
+            return self.filesize
 
-            def hdlr(line):
-                v3("Looking for a filesize in " + line)
-                toks = line.split()
-                self.filesize = int(toks[4])
+        V3("Finding size of: {}".format(self.url))
 
-            try:
-                ftp.retrlines("LIST " + path, hdlr)
-            except Exception:
-                v3("Problem parsing LIST for filesize of " + path)
-                self.filesize = ftp.size(path)
+        req = urllib.request.Request(self.url, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as rsp:
+                try:
+                    size = int(rsp.info().get('content-length', 0))
+                except ValueError:
+                    size = 0
 
+        except urllib.error.URLError as uerr:
+            V3("Unable to get size of {} - {}".format(self.url, uerr))
+            size = 0
+
+        self.filesize = size
         return self.filesize
 
     def get_download_line_header(self, slabel):
@@ -389,9 +273,8 @@ class ObsIdFile:
                                                   self.fileformat,
                                                   slabel)
 
-    def download(self, ftp):
-        """Download the file given the FTP object ftp,
-        which is assumed to be connected to the archive.
+    def download(self, headers):
+        """Download the file.
 
         The file is written to the location obsid/filename and screen
         output will be displayed to indicate the process of the
@@ -407,249 +290,132 @@ class ObsIdFile:
         set to 0).
         """
 
-        verbose = logger.getEffectiveVerbose() > 0
+        verbose = LOGGER.getEffectiveVerbose() > 0
 
-        v3("Starting download of {}".format(self.filename))
-        s = self.get_filesize(ftp)
+        V3("Starting download of {}".format(self.filename))
+        size = self.get_filesize(headers)
 
-        slabel = stringify_size(s)
+        if self.localpath != '':
+            create_directory(self.localpath)
 
-        fname = os.path.join(self.obsid, self.filename)
-        fpath = os.path.join(ftp.basedir, self.path)
-        subdname = os.path.dirname(fname)
-        if subdname != "":
-            create_directory(subdname)
+        outfile = os.path.join(self.localpath, self.filename)
 
-        try:
-            fs = os.path.getsize(fname)
-            v3("Checking on-disk file size ({}) against archive size ({}): {}".format(fs, s, fs == s))
-            if fs == s:
-                lbl = self.get_download_line_header(slabel)
-                v1("{}  already downloaded".format(lbl))
-                return (0, 0)
-
-            elif fs > s:
-                v0("Archive size is less than disk size for {} - {} vs {} bytes.".format(fname, s, fs))
-                return (0, 0)
-            else:
-                startfrom = fs
-
-        except OSError:
-            startfrom = None
-
-        try:
-            fp = open(fname, 'ab')
-        except IOError:
-            raise IOError("Unable to create '{}'".format(fname))
-
-        # it is unclear from the documentation whether this seek is needed, but
-        # do so just in case
-        #
-        if startfrom is not None and fp.tell() == 0:
-            fp.seek(0, 2)
-
-        # Can not use v1 here since do not want to add an end-of-line character
+        # Can not use V1 here since do not want to add an end-of-line
+        # character
         if verbose:
+            slabel = downloadutils.stringify_size(size)
             sys.stdout.write(self.get_download_line_header(slabel))
 
-        lfp = LoggingFile(fp, s, sys.stdout, startfrom=startfrom)
-        t0 = time.time()
-        try:
-            if startfrom is None:
-                ftp.retrbinary("RETR " + fpath, lfp.write, 8 * 1024)
-            else:
-                ftp.retrbinary("RETR " + fpath, lfp.write, 8 * 1024, startfrom)
-        except ftplib.error_perm as pe:
-            if verbose:
-                sys.stdout.write("\n")
-            v3("download error: {}".format(pe))
-            raise IOError("Unable to download {} - file may be unusable".format(fname))
-
-        t1 = time.time()
-        bytes = fp.tell()
-        fp.close()
-        lfp.close()
-
-        dt = t1 - t0
-        kb = bytes / 1024.0
-        if verbose:
-            sys.stdout.write("  {:>13s}  {:.1f} kb/s\n".format(stringify_dt(dt), kb / dt))
-
-        if s != bytes:
-            v0("WARNING file sizes do not match: expected {} but downloaded {}".format(s, bytes))
-
-        return (bytes, dt)
+        return downloadutils.download_progress(self.url,
+                                               size,
+                                               outfile,
+                                               headers=headers,
+                                               verbose=verbose)
 
 
 class ObsId:
     """Access the files for the given obsid.
+
+    This was developed when FTP access was used; it may not be
+    so useful now we've switched to HTTP.
     """
 
-    dirnames = ["primary", "secondary", "aspect", "ephem"]
+    def __init__(self, obsid, base_url, hdr):
+        """Store the available files for the given obsid.
 
-    def __init__(self, obsid, ftp):
-        """Store the available files for the given obsid,
-        using the FTP object which should be connected to the
-        archive.
+        Note that base_url is a string and not parsed URL.
+        hdr is the dictionary containing the header keywords
+        to add to any request.
         """
 
         self.obsid = obsid
+        self.base_url = base_url
+        self.header = hdr
+
         ostr = str(obsid)
-        dname = os.path.join(ftp.basedir, ostr[-1], ostr)
-        v3("Looking for directory: {}".format(dname))
-        try:
-            ftp.cwd(dname)
-        except ftplib.error_perm:
-            raise IOError("Unable to find the directory for {}".format(obsid))
+        urlname = "{}/{}/{}".format(base_url, ostr[-1], ostr)
+        V3("Looking for directory: {}".format(urlname))
 
-        if logger.getEffectiveVerbose() > 2:
-            v3("Directory contents for ObsId {}".format(obsid))
-            ftp.dir("*", "*/*")
-
-        # Hard code the directories rather than use a generic parser
-        #
-        topfiles = ftp.nlst()
-        primfiles = ftp.nlst("primary")
-        secfiles = ftp.nlst("secondary")
-        ephfiles = ftp.nlst("secondary/ephem")
-        aspfiles = ftp.nlst("secondary/aspect")
-        infiles = topfiles + primfiles + secfiles + ephfiles + aspfiles
-
-        self.files = [ObsIdFile(obsid, f) for f in infiles
-                      if os.path.basename(f) not in self.dirnames]
-        v3("Found {} files".format(len(self.files)))
+        urls = downloadutils.find_all_downloadable_files(urlname, hdr)
+        self.files = [ObsIdFile(obsid, url) for url in urls]
+        V3("Found {} files".format(len(self.files)))
 
     def filter_files(self, types=None, formats=None):
         """Filter the list of files by the given types and/or formats.
         """
 
-        v3("Before filtering: {} files".format(len(self.files)))
+        V3("Before filtering: {} files".format(len(self.files)))
         if types is not None:
             self.files = [f for f in self.files if f.is_type(types)]
         if formats is not None:
             self.files = [f for f in self.files if f.is_format(formats)]
 
-        v3("After filtering: {} files".format(len(self.files)))
+        V3("After filtering: {} files".format(len(self.files)))
 
-    def get_download_size(self, ftp):
+    def get_download_size(self):
         """Get the download size for the files in the ObsId,
         in bytes.
 
-        ftp should be a FTP object connected to the archive.
+        This is quite expensive as it requires multiple requests
+        to the HTTP server (at least the first time).
         """
 
-        return sum([f.get_filesize(ftp) for f in self.files])
+        return sum([f.get_filesize(self.header) for f in self.files])
 
-    def download(self, ftp):
+    def download(self):
         """Download the files for the ObsId to the current
         working directory.
 
         The screen output is determined by the logger instance.
+
+        The downloads are done in order of decreasing file size.
         """
 
-        v3("Downloading {} files".format(len(self.files)))
-        s = self.get_download_size(ftp)
+        V3("Downloading {} files".format(len(self.files)))
+        s = self.get_download_size()
         if s == 0:
-            v1("No files found for ObsId {}!".format(self.obsid))
+            V1("No files found for ObsId {}!".format(self.obsid))
             return
 
-        v1("Downloading files for ObsId {}, total size is {}.\n".format(self.obsid, stringify_size(s)))
-        v1("  Type     Format      Size  0........H.........1  Download Time Average Rate")
-        v1("  ---------------------------------------------------------------------------")
+        size_label = downloadutils.stringify_size(s)
+        V1("Downloading files for ObsId {}, total size is {}.\n".format(self.obsid, size_label))
+        V1("  Type     Format      Size  0........H.........1  Download Time Average Rate")
+        V1("  ---------------------------------------------------------------------------")
 
         nbytes = 0
-        dt = 0
-        for f in self.files:
-            (a, b) = f.download(ftp)
-            nbytes += a
-            dt += b
+        dtime = 0
 
-        if logger.getEffectiveVerbose() > 0:
+        # re-order into decreasing file size; given that
+        # get_download_size has been called we can use the
+        # filesize attribute.
+        #
+        order = sorted([(f.filesize, f) for f in self.files],
+                       key=itemgetter(0), reverse=True)
+
+        for oelem in order:
+            fileobj = itemgetter(1)(oelem)
+            (a, b) = fileobj.download(self.header)
+            nbytes += a
+            dtime += b
+
+        if LOGGER.getEffectiveVerbose() > 0:
             if len(self.files) > 1 and nbytes > 0:
                 sys.stdout.write("\n")
-                v1("      Total download size for ObsId {} = {}".format(self.obsid, stringify_size(nbytes)))
-                v1("      Total download time for ObsId {} = {}".format(self.obsid, stringify_dt(dt)))
+                V1("      Total download size for ObsId {} = {}".format(self.obsid, downloadutils.stringify_size(nbytes)))
+                V1("      Total download time for ObsId {} = {}".format(self.obsid, downloadutils.stringify_dt(dtime)))
             sys.stdout.write("\n")
 
 
-def _parse_mirror(mirror, username=None, userpass=None):
-    """Return (ftp site, base directory, username, password) for the given
-    mirror argument (see init_ftp and download_chandra_obsids
-    for the format of mirror).
-
-    The username and userpass arguments, if set, override any values
-    given as part of the mirror FTP URL.
-
-    If no username or password is given then we default to
-    DEFAULT_USERNAME and DEFAULT_PASSWORD respectively.
+def get_http_header():
+    """Set up the user-agent setting.
     """
 
-    url = urlparse(mirror)
-
-    # The ftp scheme is required to make it easier to support
-    # other schemes (e.g. file:// for local access) in the future.
-    if url.scheme != "ftp":
-        raise ValueError('The mirror site must begin with ftp://')
-
-    if username is None:
-        name = url.username
-    else:
-        name = username
-
-    if name is None:
-        name = DEFAULT_USERNAME
-
-    if userpass is None:
-        passwd = url.password
-    else:
-        passwd = userpass
-
-    if passwd is None:
-        passwd = DEFAULT_PASSWORD
-
-    return (url.hostname, url.path, name, passwd)
-
-
-def init_ftp(mirror=None, username=None, userpass=None):
-    """Login to the Chandra archive, anonymously, and return
-    a FTP object. The working directory will be set to byobsid/
-    from the location given by mirror.
-
-    If mirror is None then it is taken to be
-
-      ftp://cda.cfa.harvard.edu/pub/
-
-    Login details use the username and userpass values if set,
-    otherwise values extracted from the mirror (if set), otherwise
-    uses the DEFAULT_USERNAME and DEFAULT_PASSWORD values.
-    """
-
-    if mirror is None:
-        base = 'ftp://cda.cfa.harvard.edu/pub'
-    else:
-        base = mirror
-
-    (ftpsite, dirname, uname, passwd) = _parse_mirror(base, username, userpass)
-    v3("FTP mirror={} ftpsite={} dirname={} name={} password={}".format(base, ftpsite, dirname, uname, passwd))
-
-    v3("Connecting to FTP site")
-    ftp = ChandraFTP(host=ftpsite, user=uname, passwd=passwd, basedir=dirname)
-
-    # Not strictly necessary, but should error out if the directory
-    # does not exist
-    dname = os.path.join(dirname, "byobsid")
-    v3("Changing to byobsid directory: {}".format(dname))
-    ftp.cwd(dname)
-
-    v3("Connected to server and in byobsid directory")
-    return ftp
+    return {'User-Agent': 'cxc/download-chandra-obsid'}
 
 
 def download_chandra_obsids(obsids,
                             filetypes=None,
-                            mirror=None,
-                            username=None,
-                            userpass=None
+                            mirror=None
                             ):
     """Download the obsids from the Chandra Data Archive -
     https://cxc.harvard.edu/cda/ - or a mirror site.
@@ -664,11 +430,11 @@ def download_chandra_obsids(obsids,
     file, and aspect solution files.
 
     The mirror argument, if set to None (the default), means that the
-    CDA FTP archive is used. Set it to the name of a mirror archive to
-    use that location instead. The value should refer to the directory
-    that contains the "byobsid" directory and start with ftp://.  The
+    CDA HTTPS archive is used (the BASE_URL settign). Set it to the name
+    of a mirror archive to use that location instead. The value should
+    refer to the directory that contains the "byobsid" directory.  The
     default value is equivalent to setting mirror to
-    ftp://cda.cfa.harvard.edu/pub/
+    https://cxc.cfa.harvard.edu/cdaftp/
 
     This routine does *not* check the CDA_MIRROR_SITE environment
     variable if mirror=None (this is assumed to have been resolved by
@@ -679,12 +445,6 @@ def download_chandra_obsids(obsids,
     data; the routine will just not be able to download the missing
     data sets; i.e. *no* fall over to the CDA archive is provided in
     this case).
-
-    The username and password for the FTP site uses the username and
-    userpass arguments, if given, otherwise the values extracted from
-    the mirror argument (if set and included - e.g.
-    ftp://anonymous@anonymous:cda.cfa.harvard.edu/pub/), otherwise
-    the DEFAULT_USERNAME and DEFAULT_PASSWORD settings are used.
 
     The return value is an array of booleans that indicate whether the
     ObsId was available in the archive (it does not indicate whether
@@ -704,39 +464,50 @@ def download_chandra_obsids(obsids,
 
     before calling this routine (the first argument can be
     any string).
+
+    Notes
+    -----
+    With the move to HTTPS from FTP, the username and userpass
+    arguments have been removed as they are now unused.
+
     """
 
     out = []
-    try:
-        ftp = init_ftp(mirror=mirror, username=username, userpass=userpass)
-
-    except socket.gaierror as ge:
-        v3("Unable to log in: msg={0}".format(ge))
-        if mirror is None:
-            raise IOError("Unable to connect to the Chandra Data Archive.")
-        else:
-            raise IOError("Unable to connect to the Chandra Data Archive mirror at {0}.".format(mirror))
 
     if mirror is None:
         sitename = "archive"
+        base_url = BASE_URL
     else:
         sitename = "mirror"
+        base_url = mirror
+
+    # validate this URL
+    check = urllib.parse.urlparse(base_url)
+    if check.scheme not in ["https", "http"]:
+        raise ValueError("Require https/http URL, but sent {}".format(base_url))
+
+    # add on /byobsid
+    if not base_url.endswith('/'):
+        base_url += '/'
+
+    base_url += "byobsid"
+
+    hdr = get_http_header()
 
     for obsid in obsids:
-        v3("Setting up for ObsId {0}".format(obsid))
+        V3("Setting up for ObsId {0}".format(obsid))
         try:
-            oid = ObsId(obsid, ftp)
+            oid = ObsId(obsid, base_url, hdr)
         except IOError as ie:
-            v3("Unable to cd to ObsId {0}: msg={1}".format(obsid, ie))
-            v1("Skipping ObsId {0} as it was not found on the {1} site.".format(obsid, sitename))
+            V3("Unable to cd to ObsId {0}: msg={1}".format(obsid, ie))
+            V1("Skipping ObsId {0} as it was not found on the {1} site.".format(obsid, sitename))
             out.append(False)
             continue
 
         oid.filter_files(types=filetypes, formats=None)
-        oid.download(ftp)
+        oid.download()
         out.append(True)
 
-    ftp.close()
     return out
 
 # End

--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -22,10 +22,29 @@ Support downloading data from URLs in CIAO.
 
 A collection of routines related to data download used in CIAO.
 
+retrieve_url
+------------
+
 CIAO 4.11 does not include any SSL support, instead relying on the OS.
 This can cause problems on certain platforms. So try with Python and
 then fall through to curl or wget. This can hopefully be removed for
 CIAO 4.12 or later, but kept in just for now.
+
+find_downloadable_files
+-----------------------
+
+Given a URL of a directory, return the files and sub-directories
+available. This requires that the web server supports the Apache
+mod_autoindex functionality, and is written for accessing the
+Chandra Data Archive. Support for other web sites is not guaranteed.
+
+find_all_downloadable_files
+---------------------------
+
+Similar to find_downloadble_files but recurses through all sub-directories.
+
+Stability
+---------
 
 This is an internal module, and so the API it provides is not
 considered stable (e.g. we may remove this module at any time). Use
@@ -33,22 +52,30 @@ at your own risk.
 
 """
 
+import ssl
 
 from io import BytesIO
 from subprocess import check_output
-import urllib
-import urllib.request
+
 import urllib.error
+import urllib.request
+
+from html.parser import HTMLParser
 
 import ciao_contrib.logger_wrapper as lw
 
 logger = lw.initialize_module_logger("downloadutils")
 
+v0 = logger.verbose0
+v1 = logger.verbose1
+v2 = logger.verbose1
 v3 = logger.verbose3
 v4 = logger.verbose4
 
 
-__all__ = ('retrieve_url', )
+__all__ = ('retrieve_url',
+           'find_downloadable_files',
+           'find_all_downloadable_files')
 
 
 def manual_download(url):
@@ -126,8 +153,7 @@ def retrieve_url(url, timeout=None):
         v3("Retrieving URL: {} timeout={}".format(url, timeout))
         if timeout is None:
             return urllib.request.urlopen(url)
-        else:
-            return urllib.request.urlopen(url, timeout=timeout)
+        return urllib.request.urlopen(url, timeout=timeout)
 
     except urllib.error.URLError as ue:
         v3("Error opening URL: {}".format(ue))
@@ -151,3 +177,217 @@ def retrieve_url(url, timeout=None):
         # re-raise the error here after logging it.
         #
         raise
+
+
+class DirectoryContents(HTMLParser):
+    """Extract the output of the mod_autoindex Apache directive.
+
+    Limited testing. It assumes that the files are given as links,
+    there's no other links on the page, and the parent directory
+    is listed as 'parent directory' (after removing the white space
+    and converting to lower case).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.dirs = []
+        self.files = []
+        self.current = None
+        super().__init__(*args, **kwargs)
+
+    def add_link(self):
+        """We've found a link, add it to the store"""
+        if self.current is None:
+            return
+
+        if self.current.endswith('/'):
+            store = self.dirs
+        else:
+            store = self.files
+
+        store.append(self.current)
+        self.current = None
+
+    def handle_starttag(self, tag, attrs):
+        if tag.upper() != 'A':
+            return
+
+        # In case we have a missing close tag
+        self.add_link()
+
+        attrs = dict(attrs)
+        try:
+            href = attrs['href']
+        except KeyError:
+            raise ValueError("Missing href attribute for a tag")
+
+        self.current = href
+
+    def handle_endtag(self, tag):
+        # do not expect end tags within <a> here, so we can
+        # treat it as the end of the a link if we find it
+        # (to support missing end tags).
+        #
+        if self.current is None:
+            return
+
+        self.add_link()
+
+    def handle_data(self, data):
+        if self.current is None:
+            return
+
+        # Skip the link to the parent directory
+        data = data.strip()
+        if data.lower() == 'parent directory':
+            self.current = None
+
+
+def unpack_filelist_html(txt, baseurl):
+    """Extract the contents of the page (assumed to be a directory listing).
+
+    Parameters
+    ----------
+    txt : str
+        The HTML contents to parse.
+    baseurl : str
+        The URL of the page.
+
+    Returns
+    -------
+    urls : dict
+        The keys are directories and files, and the contents are
+        a list of absolute URLs (as strings).
+
+    """
+
+    parser = DirectoryContents()
+    parser.feed(txt)
+
+    if not baseurl.endswith('/'):
+        baseurl += '/'
+
+    dirs = [baseurl + d for d in parser.dirs]
+    files = [baseurl + f for f in parser.files]
+
+    return {'directories': dirs, 'files': files}
+
+
+def find_downloadable_files(urlname, headers):
+    """Find the files and directories present in the given URL.
+
+    Report the files present at the given directory, for those
+    web servers which support an Apache-like mod_autoindex
+    function (i.e. return a HTML file listing the files and
+    sub-directories).
+
+    Parameters
+    ----------
+    urlname : str
+        This must represent a directory.
+    headers : dict
+        The headers to add to the HTTP request (e.g. user-agent).
+
+    Returns
+    -------
+    urls : dict
+        The keys are directories and files, and the contents are
+        a list of absolute URLs (as strings).
+
+    See Also
+    --------
+    find_all_downloadable_files
+
+    Notes
+    -----
+    This is intended for use with the Chandra Data Archive, and
+    so there's no guarantee it will work for other web servers:
+    they may not return the necessary information, or use a
+    different markup.
+
+    Requests are made with *no* SSL validation (since there are
+    problems with CIAO 4.12 installed via ciao-install on a Ubuntu
+    machine).
+    """
+
+    no_context = ssl._create_unverified_context()
+    req = urllib.request.Request(urlname, headers=headers)
+    try:
+        with urllib.request.urlopen(req, context=no_context) as rsp:
+            html_contents = rsp.read().decode('utf-8')
+
+    except urllib.error.URLError as ue:
+        v2("URLError for {}".format(urlname))
+        v2(str(ue))
+        try:
+            emsg = "Unable to reach {}\n{}".format(urlname, ue.reason)
+        except KeyError:
+            try:
+                is404 = ue.code == 404
+            except KeyError:
+                raise IOError("Unable to access {}\n{}".format(urlname, ue))
+
+            if is404:
+                emsg = "There is no directory {}".format(urlname)
+            else:
+                emsg = "Unable to access {}\ncode={}".format(urlname, ue.code)
+
+        raise IOError(emsg)
+
+    return unpack_filelist_html(html_contents, urlname)
+
+
+def find_all_downloadable_files(urlname, headers):
+    """Find the files present in the given URL, including sub-directories.
+
+    Report the files present at the given directory and
+    sub-directory, for those web servers which support an Apache-like
+    mod_autoindex function (i.e. return a HTML file listing the files
+    and sub-directories).
+
+    Parameters
+    ----------
+    urlname : str
+        This must represent a directory.
+    headers : dict
+        The headers to add to the HTTP request (e.g. user-agent).
+
+    Returns
+    -------
+    urls : list of str
+        A list of absolute URLs.
+
+    See Also
+    --------
+    find_downloadable_files
+
+    Notes
+    -----
+    This is intended for use with the Chandra Data Archive, and
+    so there's no guarantee it will work for other web servers:
+    they may not return the necessary information, or use a
+    different markup.
+
+    Requests are made with *no* SSL validation (since there are
+    problems with CIAO 4.12 installed via ciao-install on a Ubuntu
+    machine).
+    """
+
+    v3("Finding all files available at: {}".format(urlname))
+    base = find_downloadable_files(urlname, headers)
+    out = base['files']
+    todo = base['directories']
+    v4("Found sub-directories: {}".format(todo))
+
+    while True:
+        v4("Have {} sub-directories to process".format(len(todo)))
+        if todo == []:
+            break
+
+        durl = todo.pop()
+        v3("Recursing into {}".format(durl))
+        subdir = find_downloadable_files(durl, headers)
+        out += subdir['files']
+        v4("Adding sub-directories: {}".format(subdir['directories']))
+        todo += subdir['directories']
+
+    return out

--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -327,31 +327,15 @@ def find_downloadable_files(urlname, headers):
     Requests are made with *no* SSL validation (since there are
     problems with CIAO 4.12 installed via ciao-install on a Ubuntu
     machine).
+
+    There is no attempt to make a "nice" error message for a user
+    here, as that is better done in the calling code.
     """
 
     no_context = ssl._create_unverified_context()
     req = urllib.request.Request(urlname, headers=headers)
-    try:
-        with urllib.request.urlopen(req, context=no_context) as rsp:
-            html_contents = rsp.read().decode('utf-8')
-
-    except urllib.error.URLError as ue:
-        v2("URLError for {}".format(urlname))
-        v2(str(ue))
-        try:
-            emsg = "Unable to reach {}\n{}".format(urlname, ue.reason)
-        except KeyError:
-            try:
-                is404 = ue.code == 404
-            except KeyError:
-                raise IOError("Unable to access {}\n{}".format(urlname, ue))
-
-            if is404:
-                emsg = "There is no directory {}".format(urlname)
-            else:
-                emsg = "Unable to access {}\ncode={}".format(urlname, ue.code)
-
-        raise IOError(emsg)
+    with urllib.request.urlopen(req, context=no_context) as rsp:
+        html_contents = rsp.read().decode('utf-8')
 
     return unpack_filelist_html(html_contents, urlname)
 

--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2018
+#  Copyright (C) 2018, 2020
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -20,9 +20,12 @@
 """
 Support downloading data from URLs in CIAO.
 
+A collection of routines related to data download used in CIAO.
+
 CIAO 4.11 does not include any SSL support, instead relying on the OS.
 This can cause problems on certain platforms. So try with Python and
-then fall through to curl or wget.
+then fall through to curl or wget. This can hopefully be removed for
+CIAO 4.12 or later, but kept in just for now.
 
 This is an internal module, and so the API it provides is not
 considered stable (e.g. we may remove this module at any time). Use
@@ -43,6 +46,9 @@ logger = lw.initialize_module_logger("downloadutils")
 
 v3 = logger.verbose3
 v4 = logger.verbose4
+
+
+__all__ = ('retrieve_url', )
 
 
 def manual_download(url):

--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -539,6 +539,11 @@ class ProgressBar:
         self.hdl.flush()
 
 
+def myint(x):
+    """Convert to an integer, my way."""
+    return int(x + 0.5)
+
+
 def stringify_dt(dt):
     """Convert a time interval into a "human readable" string.
 
@@ -569,9 +574,6 @@ def stringify_dt(dt):
     if dt < 1:
         return "< 1 s"
 
-    def myint(f):
-        return int(f + 0.5)
-
     d = myint(dt // (24 * 3600))
     dt2 = dt % (24 * 3600)
     h = myint(dt2 // 3600)
@@ -598,6 +600,54 @@ def stringify_dt(dt):
 
     else:
         lbl = "%d s" % s
+
+    return lbl
+
+
+def stringify_size(s):
+    """Convert a file size to a text string.
+
+    Parameters
+    ----------
+    size : int
+        File size, in bytes
+
+    Returns
+    -------
+    filesize : str
+        A "nice" representation of the size
+
+    Examples
+    --------
+
+    >>> stringify_size(1023)
+    '< 1 Kb'
+
+    >>> stringify_size(1024)
+    '1 Kb'
+
+    >>> stringify_size(1025)
+    '1 Kb'
+
+    >>> stringify_size(54232)
+    '53 Kb'
+
+    >>> stringify_size(4545833)
+    '4 Mb'
+
+    >>> stringify_size(45458330000)
+    '4.2 Gb'
+
+    """
+
+    if s < 1024:
+        lbl = "< 1 Kb"
+    elif s < 1024 * 1024:
+        lbl = "%d Kb" % (myint(s / 1024.0))
+    elif s < 1024 * 1024 * 1024:
+        lbl = "%d Mb" % (myint(s / (1024 * 1024.0)))
+    else:
+        lbl = "%.1f Gb" % (s / (1024 * 1024 * 1024.0))
 
     return lbl
 

--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -711,7 +711,7 @@ def download_progress(url, size, outfile,
     # read in everything in one go and then you read from the in-memory
     # buffer).
     #
-    # Is this (still) true?
+    # From https://stackoverflow.com/a/24900110 - is it still true?
     #
     purl = urllib.request.urlparse(url)
     if purl.scheme == 'https':
@@ -772,6 +772,12 @@ def download_progress(url, size, outfile,
     if headers is None:
         headers = {'User-Agent':
                    'ciao_contrib.downloadutils.download_progress'}
+    else:
+        # Ensure we copy the header dictionary, since we are going
+        # to add to it. It is assumed that a shallow copy is
+        # enough.
+        #
+        headers = headers.copy()
 
     # Could hide this if startfrom = 0 and size <= chunksize, but
     # it doesn't seem worth it.

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -11,7 +11,7 @@
 ]>
 <cxchelptopics>
   <ENTRY key="download_chandra_obsid" context="tools"
-	 refkeywords="download ftp chandra obsid obsids
+	 refkeywords="download ftp http https chandra obsid obsids
 		      data archive cda mirror public chaser webchaser
 		      dco download_chandra_obsids
                       &cdaenv;
@@ -79,7 +79,7 @@
 	exist on disk as long as they are the correct size.
 	If the on-disk version is smaller than the archive
 	version, then download will be resumed rather than
-	started again. 
+	started again.
 	A warning message will be displayed if the on-disk version
 	is larger than the archive version.
       </PARA>
@@ -92,16 +92,16 @@
 	Unless the -q or --quiet flag was used, each file that
 	is downloaded will be displayed on screen, giving the
 	"type", format, file type before a progress bar of
-	# marks (each # mark indicates 10% of the file).
-	Once the file has been downloaded an average 
+	# marks (each # mark indicates 5% of the file).
+	Once the file has been downloaded an average
 	rate is displayed for the download. Examples of the
 	output for two files are shown below:
       </PARA>
 <VERBATIM>
 Type     Format      Size  0........H.........1  Download Time Average Rate
 ---------------------------------------------------------------------------
-vv       pdf        78 Kb  ####################          &lt; 1 s  843.1 kb/s
 evt2     fits       17 Mb  ####################            2 s  7170.3 kb/s
+vv       pdf        78 Kb  ####################          &lt; 1 s  843.1 kb/s
 </VERBATIM>
       <PARA>
 	If a file has already been downloaded then the message
@@ -113,44 +113,44 @@ evt2     fits       17 Mb  ####################            2 s  7170.3 kb/s
     <QEXAMPLELIST>
       <QEXAMPLE>
 	<SYNTAX>
-	  <LINE>&pr; download_chandra_obsid 1843</LINE>
+	  <LINE>&pr; download_chandra_obsid 1842</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    This will download all the data files for ObsId 1843 to
-	    the directory 1843/. The screen output for the run
+	    This will download all the data files for ObsId 1842 to
+	    the directory 1842/. The screen output for the run
 	    will look something like the following (where many lines
 	    have been excluded, indicated by the "..." lines):
 	  </PARA>
 
 <VERBATIM>
-Downloading files for ObsId 1843, total size is 81 Mb.
+Downloading files for ObsId 1842, total size is 81 Mb.
 
-Type   Format   Size  0........H.........1  Download Time Average Rate
-----------------------------------------------------------------------
-readme ascii   11 Kb  ####################          &lt; 1 s  433.7 kb/s
+Type     Format   Size  0........H.........1  Download Time Average Rate
+------------------------------------------------------------------------
+evt1     fits    36 Mb  ####################           46 s  818.4 kb/s
+evt2     fits    19 Mb  ####################           23 s  809.1 kb/s
 ...
-evt2   fits    17 Mb  ####################            4 s  4740.2 kb/s
-asol   fits     2 Mb  ####################          &lt; 1 s  5239.1 kb/s
-bpix   fits    13 Kb  ####################          &lt; 1 s  575.7 kb/s
-fov    fits     6 Kb  ####################          &lt; 1 s  610.6 kb/s
-...
-osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
+readme   ascii   11 Kb  ####################          &lt; 1 s  91.7 kb/s
+eph1     fits     6 Kb  ####################          &lt; 1 s  109.7 kb/s
+fov      fits     6 Kb  ####################          &lt; 1 s  108.1 kb/s
+msk      fits     5 Kb  ####################          &lt; 1 s  62.0 kb/s
+pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 
-    Total download size for ObsId 1843 = 81 Mb
-    Total download time for ObsId 1843 = 16 s
+    Total download size for ObsId 1842 = 81 Mb
+    Total download time for ObsId 1842 = 1 m 45 s
 </VERBATIM>
 	</DESC>
       </QEXAMPLE>
 
       <QEXAMPLE>
 	<SYNTAX>
-	  <LINE>&pr; download_chandra_obsid 1843 evt1,bpix,asol,fov,readme</LINE>
+	  <LINE>&pr; download_chandra_obsid 1842 evt1,bpix,asol,fov,readme</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
 	    Here we restrict the download to just the evt1, bpix,
-	    asol, fov, and readme files from ObsId 1843.
+	    asol, fov, and readme files from ObsId 1842.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -198,7 +198,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 
       <QEXAMPLE>
 	<SYNTAX>
-	  <LINE>&pr; download_chandra_obsid -m ftp://cda.cfa.harvard.edu/pub 1842</LINE>
+	  <LINE>&pr; download_chandra_obsid -m https://cxc.cfa.harvard.edu/cdaftp/ 1842</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -214,7 +214,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 	  </PARA>
 	  <PARA>
 	    <SYNTAX>
-	      <LINE>&pr; setenv &cdaenv; ftp://cda.cfa.harvard.edu/pub</LINE>
+	      <LINE>&pr; setenv &cdaenv; https://cxc.cfa.harvard.edu/cdaftp/</LINE>
 	      <LINE>&pr; download_chandra_obsid 1842</LINE>
 	    </SYNTAX>
 	  </PARA>
@@ -239,22 +239,37 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 	for the data.
       </PARA>
       <PARA>
-        The mirror location should include the URL of the FTP site
-        (the leading ftp:// is required) and the path up to, but not including,
+        The mirror location should include the URL of the HTTP or
+	HTTPS site
+        (the leading https:// or http:// is required) and the path up to, but not including,
         the byobsid/ directory. So, for the Chandra Data Archive itself
         you would use
-        <EQUATION>ftp://cda.cfa.harvard.edu/pub</EQUATION>
+        <EQUATION>https://cxc.cfa.harvard.edu/cdaftp/</EQUATION>
         (although obviously in this case you do not need to use the mirror
         option).
         Please see the documentation for the mirror site to find out
         the correct path to use.
       </PARA>
+      <!--
       <PARA>
         If needed, you can include a username and password in the mirror
-        setting, following 
+        setting, following
         <HREF link="https://tools.ietf.org/html/rfc3986">RFC3986</HREF>,
         for instance
         <EQUATION>ftp://anonymous:foo@bar.com@cda.cfa.harvard.edu/pub</EQUATION>
+	</PARA>
+	-->
+    </ADESC>
+
+    <ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+      <PARA title="Archive has moved">
+	The script now uses the HTTPS service provided by the
+	Chandra Data Archive as the FTP service is being retired.
+	The archive is now available at https://cxc.cfa.harvard.edu/cdaftp/
+      </PARA>
+      <PARA title="Order by file size">
+	For each observation, the files are now sorted by decreasing
+	file size before being downloaded.
       </PARA>
     </ADESC>
 
@@ -263,7 +278,6 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
         Updated to use ftp://cda.cfa.harvard.edu as the default FTP server.
       </PARA>
     </ADESC>
-
 
     <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
       <PARA>
@@ -275,7 +289,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 
     <ADESC title="Changes in the scripts 4.6.5 (June 2014) release">
       <PARA title="Added evt1a and adat file types">
-	It is now possible to select evt1a and adat 
+	It is now possible to select evt1a and adat
 	(PCAD Level 1 ACA image) files using the
 	filetype argument. The adat files can be used with the
         monitor_photom script.
@@ -285,7 +299,7 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
     <ADESC title="Changes in the scripts 4.5.4 (August 2013) release">
       <PARA title="Support for CDA mirror sites">
 	The --mirror command-line argument and support for the
-	&cdaenv; environment variable 
+	&cdaenv; environment variable
 	has been added to allow data access from a
 	mirror of the Chandra Data Archive site.
       </PARA>
@@ -309,10 +323,10 @@ osol   fits   354 Kb  ####################          &lt; 1 s  1764.3 kb/s
 	See the
 	<HREF link="https://cxc.harvard.edu/ciao/bugs/download_chandra_obsid.html">bugs page
 	for this script</HREF> on the CIAO website for an up-to-date
-	listing of known bugs. 
+	listing of known bugs.
       </PARA>
     </BUGS>
-    
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+
+    <LASTMODIFIED>February 2020</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -277,7 +277,7 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 	the list of supported file types.  Note that it will take some
 	time before these files appear in the archive (as the
 	reprocessing has not started yet). Please review the <HREF
-	LINK="https://cxc.harvard.edu/cda/">Archive status page</HREF>
+	link="https://cxc.harvard.edu/cda/">Archive status page</HREF>
 	for information on data products.
       </PARA>
     </ADESC>

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
  <!ENTITY tool "download_chandra_obsid">
 
- <!ENTITY ftypes "aoff aqual asol bias bpix cntr_img dtf eph0 eph1 evt1 evt1a evt2 flt fov full_img msk mtl oif osol pbk pha2 plt readme adat soff src2 src_img stat sum vv">
+ <!ENTITY ftypes "adat aoff aqual arf asol bias bpix cntr_img dtf eph0 eph1 evt1 evt1a evt2 flt fov full_img msk mtl oif osol pbk pha2 plt readme rmf soff src2 src_img stat sum vv">
 
  <!ENTITY pr "unix&#37;">
 
@@ -270,6 +270,15 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
       <PARA title="Order by file size">
 	For each observation, the files are now sorted by decreasing
 	file size before being downloaded.
+      </PARA>
+      <PARA title="Support for ARF and RMF access">
+	The next reprocessing of the Chandra archive will add grating
+	ARF and RMF products, so "arf" and "rmf" have been added to
+	the list of supported file types.  Note that it will take some
+	time before these files appear in the archive (as the
+	reprocessing has not started yet). Please review the <HREF
+	LINK="https://cxc.harvard.edu/cda/">Archive status page</HREF>
+	for information on data products.
       </PARA>
     </ADESC>
 


### PR DESCRIPTION
Switch `download_chandra_obsid` over to HTTPS file access. Support for FTP has been removed. This is to fix #330

Minor changes:
  - add support for `arf` and `rmf` file types (in preparation for Repro 5)
  - file download, per obsid, is now done in descending order of file size

Details

The progress-bar code has been separated out into a separate class, rather than being entwined into the FTP download code. I have also tried to move the code out so it is more re-usable, although there is some potential issue over screen output (particularly for already-downloaded files).

All https downloads are done with no checking of the SSL context. This is to avoid problems with "classic" CIAO and Ubuntu (and possibly other systems), where the SSL library can't access the necessary certificates.

I noted that in the case of "partial" downloads, the final file size reported for an obsid is the total of all the files, not just what was downloaded. I'm not sure anyone but me would notice/care.