### PR TITLE
correct_periscope_drift changes

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -42,6 +42,9 @@ Updated scripts
     Fixed bug that caused parameter values in the script's HISTORY 
     records to be reset to their default (blank) values.
 
+  correct_periscope_drift
+
+    The script will now run when the verbose parameter is set to 0.
 
 ## 4.12.1 - December 2019 ##
 

--- a/bin/correct_periscope_drift
+++ b/bin/correct_periscope_drift
@@ -58,13 +58,6 @@ v2 = make_verbose_level(TOOLNAME, 2)
 v3 = make_verbose_level(TOOLNAME, 3)
 v5 = make_verbose_level(TOOLNAME, 5)
 
-LOGLEVELS = {5: logging.DEBUG,
-             4: logging.INFO,
-             3: logging.WARNING,
-             2: logging.ERROR,
-             1: logging.CRITICAL,
-             0: logging.CRITICAL + 5}
-
 
 
 def process_command_line(argv):
@@ -486,11 +479,6 @@ def hardcopy(filename):
 
 
 def main(opt):
-
-    # Use verbose option to control sherpa output
-    #
-    logger = logging.getLogger("sherpa")
-    logger.setLevel(LOGLEVELS[opt['verbose']])
 
     events = extract_events(opt['evtfile'],
                             opt['x'], opt['y'], opt['radius'])

--- a/bin/correct_periscope_drift
+++ b/bin/correct_periscope_drift
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010, 2016, 2019  Smithsonian Astrophysical Observatory
+# Copyright (C) 2010, 2016, 2019, 2020  Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -42,7 +42,7 @@ from sherpa import plot
 
 
 TOOLNAME = "correct_periscope_drift"
-VERSION = "0.3"
+VERSION = "6 Feb 2020"
 
 # Set up the logging/verbose code
 initialize_logger(TOOLNAME)
@@ -58,7 +58,9 @@ LOGLEVELS = {5: logging.DEBUG,
              4: logging.INFO,
              3: logging.WARNING,
              2: logging.ERROR,
-             1: logging.CRITICAL}
+             1: logging.CRITICAL,
+             0: logging.CRITICAL + 5}
+
 
 
 def process_command_line(argv):
@@ -416,7 +418,7 @@ def ylimits(ymin, ymax):
         pychips.limits(pychips.Y_AXIS, ymin, ymax)
 
     else:
-        # unlike hardcoopy, we do not tell the user if the backend
+        # unlike hardcopy, we do not tell the user if the backend
         # is unknown, as this is a cosmetic change.
         #
         pass
@@ -468,10 +470,10 @@ def hardcopy(filename):
 # without having to worry about them calling sys.exit.
 
 
-@handle_ciao_errors(TOOLNAME, VERSION)
 def main(opt):
 
     # Use verbose option to control sherpa output
+    #
     logger = logging.getLogger("sherpa")
     logger.setLevel(LOGLEVELS[opt['verbose']])
 
@@ -595,7 +597,14 @@ def main(opt):
                      toolversion=VERSION)
 
 
-if __name__ == "__main__":
+@handle_ciao_errors(TOOLNAME, VERSION)
+def doit():
+    "Catch all errors raised in this set of routines"
+
     opt = process_command_line(sys.argv)
     display_start_info(opt)
     main(opt)
+
+
+if __name__ == "__main__":
+    doit()

--- a/bin/correct_periscope_drift
+++ b/bin/correct_periscope_drift
@@ -406,16 +406,12 @@ def ylimits(ymin, ymax):
     Notes
     -----
     Sherpa doesn't provide a back-end agnostic interface for this
-    functionality.
+    functionality. As of CIAO 4.12 this is not really needed.
     """
 
     if plot.backend.name == 'pylab':
         from matplotlib import pyplot as plt
         plt.ylim(ymin, ymax)
-
-    elif plot.backend.name == 'chips':
-        import pychips
-        pychips.limits(pychips.Y_AXIS, ymin, ymax)
 
     else:
         # unlike hardcopy, we do not tell the user if the backend
@@ -441,16 +437,12 @@ def hardcopy(filename):
     Notes
     -----
     Sherpa doesn't provide a back-end agnostic interface for this
-    functionality.
+    functionality. As of CIAO 4.12 this is not really needed.
     """
 
     if plot.backend.name == 'pylab':
         from matplotlib import pyplot as plt
         plt.savefig(filename)
-
-    elif plot.backend.name == 'chips':
-        import pychips
-        pychips.print_window(filename, ['clobber', True])
 
     else:
         # could check if this has already been created, but if this

--- a/bin/correct_periscope_drift
+++ b/bin/correct_periscope_drift
@@ -37,7 +37,10 @@ from ciao_contrib._tools.fileio import outfile_clobber_checks
 import pycrates
 import paramio as pio
 
-from sherpa import ui
+from sherpa.data import Data1D
+from sherpa.models.basic import Polynom1D
+from sherpa.fit import Fit
+
 from sherpa import plot
 
 
@@ -52,6 +55,7 @@ initialize_logger(TOOLNAME)
 #
 v1 = make_verbose_level(TOOLNAME, 1)
 v2 = make_verbose_level(TOOLNAME, 2)
+v3 = make_verbose_level(TOOLNAME, 3)
 v5 = make_verbose_level(TOOLNAME, 5)
 
 LOGLEVELS = {5: logging.DEBUG,
@@ -269,7 +273,7 @@ def time_bins(times, x, nbins=20):
     return bin_centers, np.array(bin_x), np.array(bin_std)
 
 
-def _fit_poly(fit_data, evt_times, degree, data_id=0):
+def _fit_poly(fit_data, evt_times, degree):
     """
     Given event data transformed into Y or Z angle positions, and a degree of the desired
     fit polynomial, fit a polynomial to the data.
@@ -277,39 +281,49 @@ def _fit_poly(fit_data, evt_times, degree, data_id=0):
     :param fit_data: event y or z angle position data
     :param evt_times: times of event/fit_data
     :param degree: degree of polynomial to use for the fit model
-    :param data_id: sherpa dataset id to use for the fit
 
-    :returns: (sherpa model plot, sherpa model)
+    :returns: (sherpa data set, sherpa model)
     """
-    # Set initial value for fit data position error
-    init_error = 1
 
-    ui.clean()
-    ui.load_arrays(data_id, evt_times - evt_times[0], fit_data,
-                   np.zeros_like(fit_data) + init_error)
+    def scale_error(eterm):
+        return np.zeros_like(fit_data) + eterm
+
+    dset = Data1D('data',
+                  evt_times - evt_times[0],
+                  fit_data,
+                  staterror=scale_error(1))
+
     v2("Fitting a line to the data to get reduced stat errors")
-    # First just fit a line to get reduced errors on this set
-    ui.polynom1d.line
-    ui.set_model(data_id, 'line')
-    ui.thaw('line.c1')
-    ui.fit(data_id)
-    fit = ui.get_fit_results()
-    calc_error = init_error * np.sqrt(fit.rstat)
-    ui.set_staterror(data_id, calc_error)
+
+    # First just fit a line to get reduced errors on this set. Note that
+    # polynom1d models default to c0 being the only thawed parameter.
+    #
+    line = Polynom1D('line')
+    line.c1.thaw()
+    fit = Fit(dset, line).fit()
+    v3("Initial fit: succeeded={} rstat= {}".format(fit.succeeded, fit.rstat))
+
+    dset.staterror = scale_error(np.sqrt(fit.rstat))
+
     # Then fit the specified model
+    #
     v2("Fitting a polynomial of degree {} to the data".format(degree))
-    ui.polynom1d.fitpoly
-    ui.freeze('fitpoly')
+    fitpoly = Polynom1D('fitpoly')
+    fitpoly.c0 = 0
+
     # Thaw the coefficients requested by the degree of the desired polynomial
-    ui.thaw('fitpoly.c0')
-    fitpoly.c0.val = 0
     for deg in range(1, 1 + degree):
-        ui.thaw("fitpoly.c{}".format(deg))
-    ui.set_model(data_id, 'fitpoly')
-    ui.fit(data_id)
-    mp = ui.get_model_plot(data_id)
-    model = ui.get_model(data_id)
-    return mp, model
+        attr = "c{}".format(deg)
+        getattr(fitpoly, attr).thaw()
+
+    v3("Starting fit with:")
+    v3(str(fitpoly))
+    Fit(dset, fitpoly).fit()
+
+    v3("Ended fit with:")
+    v3(str(fitpoly))
+
+    return dset, fitpoly
 
 
 def write_key(crate, name, value, comment, units=""):
@@ -371,14 +385,23 @@ def make_fit_plot(evt_times, fit_data, mp, ax):
         plot.end()
 
 
-def make_data_plot(data_id, fit_data, ax):
+def make_data_plot(dset, model, fit_data, ax):
 
     # set minimum limit on data plot in arcsecs and set this explicitly
     # as a symmetric limit
     data_ymax = max(2.0, np.max(np.abs(fit_data)) + .2)
 
     # Adjust the default look of the plot
-    fplot = ui.get_fit_plot(data_id)
+    #
+    dplot = plot.DataPlot()
+    dplot.prepare(dset)
+
+    mplot = plot.ModelPlot()
+    mplot.prepare(dset, model)
+
+    fplot = plot.FitPlot()
+    fplot.prepare(dplot, mplot)
+
     dplot = fplot.dataplot
     dplot.plot_prefs['yerrorbars'] = False
     dplot.xlabel = 'Observation elapsed/delta time (s)'
@@ -520,23 +543,26 @@ def main(opt):
     fit_comments = []
     plot_list = []
 
-    for data_id, ax in enumerate(['yag', 'zag']):
+    for ax in ['yag', 'zag']:
         fit_data = ax_data[ax] - np.mean(ax_data[ax])
-        mp, model = _fit_poly(fit_data, evt_times, opt['corr_poly_degree'], data_id=data_id)
+        dset, model = _fit_poly(fit_data, evt_times, opt['corr_poly_degree'])
 
-        make_fit_plot(evt_times, fit_data, mp, ax)
+        mplot = plot.ModelPlot()
+        mplot.prepare(dset, model)
+
+        make_fit_plot(evt_times, fit_data, mplot, ax)
 
         fit_plot = "{}_fit_{}.png".format(opt['corr_plot_root'], ax)
         hardcopy(fit_plot)
         plot_list.append(fit_plot)
 
-        make_data_plot(data_id, fit_data, ax)
+        make_data_plot(dset, model, fit_data, ax)
 
         data_plot = "{}_data_{}.png".format(opt['corr_plot_root'], ax)
         hardcopy(data_plot)
         plot_list.append(data_plot)
 
-        asol_corr = np.interp(asol_times, mp.x + evt_times[0], mp.y)
+        asol_corr = np.interp(asol_times, mplot.x + evt_times[0], mplot.y)
         asol_col_to_fix = asol.get_column(ax_map[ax])
         fit_comments.append("Events show drift range of {:.2f} arcsec in {} axis".format(
                 np.max(asol_corr) - np.min(asol_corr), ax))

--- a/share/doc/xml/correct_periscope_drift.xml
+++ b/share/doc/xml/correct_periscope_drift.xml
@@ -65,13 +65,13 @@ verbose=2
          <DESC>
 <VERBATIM>
 Running: correct_periscope_drift
-  version = 0.3
+  version = 6 Feb 2020
 with parameters:
   infile=pcadf537654279N001_asol1.fits.gz
   evtfile=acisf16659N001_evt2.fits.gz
   outfile=driftcorr_asol1.fits
   verbose=2
-  and ASCDS_INSTALL is /soft/ciao-4.11
+  and ASCDS_INSTALL is /soft/ciao-4.12
 ------------------------------------------------------------
 Fitting a line to the data to get reduced stat errors
 Fitting a polynomial of degree 2 to the data
@@ -92,7 +92,7 @@ You *must* review the following plots before using this correction:
         corr_fit_zag.png
         corr_data_zag.png
 
-Adding HISTORY record for correct_periscope_drift (0.3)
+Adding HISTORY record for correct_periscope_drift (6 Feb 2020)
 Adding history to driftcorr_asol1.fits
 Running tool dmhistory using:
 >>> dmhistory driftcorr_asol1.fits correct_periscope_drift action=put
@@ -211,6 +211,12 @@ Running tool dmhistory using:
      </PARA>
    </ADESC>
 
+   <ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+     <PARA>
+       The script will now run when the verbose parameter is 0.
+     </PARA>
+   </ADESC>
+
    <ADESC title="Changes in the scripts 4.11.4 (2019) release">
      <PARA title="Matlotlib support">
        The plots now use the chosen Sherpa plotting backend,
@@ -244,7 +250,7 @@ Running tool dmhistory using:
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>June 2019</LASTMODIFIED>
+    <LASTMODIFIED>February 2020</LASTMODIFIED>
 
   </ENTRY>    
 </cxchelptopics>


### PR DESCRIPTION
- [X] support verbose=0 (#341)
- [X] hide python traceback parameter validation fails
- [X] remove ChIPS code
- [X] use lower-level Sherpa routines as do not need the session management