### PR TITLE
More helpful error for choosing wrong pix_adj parameter

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -560,7 +560,7 @@ def event1_inputs(params):
                 elif pix_adj_value == 'edser':
                     params["pix_adj_value"] = 'EDSER'
                 elif pix_adj_value != 'default':
-                    raise ValueError("invalid pix_adj parameter, expected 'default', 'centroid', 'edser', 'randomize', or 'none'")
+                    raise ValueError("invalid pix_adj parameter, for ACIS data choose from 'default', 'centroid', 'edser', 'randomize', or 'none'")
 
             if params["instrume"] == 'HRC':
                 if pix_adj_value == 'randomize':
@@ -568,7 +568,7 @@ def event1_inputs(params):
                 elif pix_adj_value == 'none':
                     params["pix_adj_value"] = '0.0'
                 elif pix_adj_value != 'default':
-                    raise ValueError("invalid pix_adj parameter, expected 'default', 'randomize', or 'none'")
+                    raise ValueError("invalid pix_adj parameter, for HRC data choose from 'default', 'randomize', or 'none'")
 
             params["hdr_asolfile"] = keys["ASOLFILE"].value if "ASOLFILE" in keys else None
             params["hdr_bpixfile"] = keys["BPIXFILE"].value if "BPIXFILE" in keys else None


### PR DESCRIPTION
A local user just asked me for help after choosing `pix_adj="edser"` and receiving an "invalid pix_adj" error. I then started to look into the code to see where it came from and only after I realized that the ObsID in question was HRC data. Since the error messages are thrown inside an if block that tests for the instrument name, it can't hurt to print out the instrument name in the error message. When working with just one observation, users should know what they are dealing with, but anyone who processes a number of ObsIDs might not automatically associate ObsID and instrument for all datasets and might appreciate the hint.