### PR TITLE
chandra_repro updates to use skyfov.method=convexhull for new asol files

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -46,11 +46,18 @@ Updated scripts
 
     The script will now run when the verbose parameter is set to 0.
 
+  chandra_repro
+  
+    The skyfov method=convexhull algorithm will now be used when
+    the script find the new style aspect solution files (those with
+    CONTENT="ASPSOLOBI").  This new FOV provides a tighter fitting
+    polygon around each chip and will provide, for example,  a better 
+    estimate of the geometric area of a region at the edge of the chip.
+
   srcflux
   
     Uses the new skyfov method=convexhull algorithm when new
     aspect solution files with CONTENT=ASPSOLOBI are used.
-
 
 
 ## 4.12.1 - December 2019 ##

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010-2019  Smithsonian Astrophysical Observatory
+# Copyright (C) 2010-2020  Smithsonian Astrophysical Observatory
 #
 #
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "30 October 2019"
+version = "12 February 2020"
 
 # import standard python modules as required
 #
@@ -2137,6 +2137,34 @@ def set_ardlib(params):
     v2("Observation-specific bad pixel file is set in ardlib.par.")
 
 
+def choose_skyfov_method( asolfiles ):
+    """
+    Choose skyfov method parameter based on ASOL CONTENT keyword
+    
+    In Repro-5, there will be a new aspect solution file.  It will
+    differ from the previous file in how the offsets (DY,DZ) are
+    applied. With these new files we can start to use the new 
+    skyfov convex hull algorithm.    
+    """    
+    from pycrates import read_file
+    import stk as stk
+
+    skyfov_choices={ 'ASPSOLOBI' : 'convexhull' , 'ASPSOL' : 'minmax' }
+    if asolfiles is None: 
+        return skyfov_choices["ASPSOL"]
+
+    asolfiles = stk.build("@"+asolfiles)
+    if 1 != len(asolfiles):
+        # New obi based asol, there will be 1 file per obi (by design)
+        return skyfov_choices["ASPSOL"]
+
+    asol=read_file(asolfiles[0])
+    flavor=asol.get_key_value("CONTENT")
+    if flavor not in skyfov_choices:
+        raise ValueError("Unknown CONTENT keyword in {}".format(asolfiles[0]))
+    return skyfov_choices[flavor]
+
+
 def remake_fov1_file( pars ):
     """
     Since the event file may have extra time filters and/or may
@@ -2158,6 +2186,8 @@ def remake_fov1_file( pars ):
         v0("\nWARNING: Level 2 event file has 0 good-time\n")
     else:
         skyfov.aspect = "@{}[@{}]".format(pars["asol1_file"], pars["evt2_file"])
+
+    skyfov.method= choose_skyfov_method( pars["asol1_file"] )
 
     out = skyfov()
 

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -750,8 +750,29 @@ acisf084244478N003_2_bias0.fits.gz
       </PARAM>
     </PARAMLIST>
 
+<ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+  <PARA title="Synchronization with DS 10.8.3 updates">
+  In the spring of 2020, a new aspect solution file is being created. 
+  This file has the DY, DZ, and DTHETA offsets folded back into the
+  aspect solution itself (RA, Dec, Roll) and provides a better
+  estimate of the off-axis angles.  It can be identified by the file
+  name (a single file with OBS_ID and the OBI_NUM) and by the
+  CONTENT keyword set to "ASPSOLOBI". The event processing tools
+  like acis_process_events and hrc_process_events handle these 
+  new aspect solution files transparently.  Users will notice 
+  changes to their physical sky coordinates (x,y); however, 
+  the final celestial coordinates (RA,Dec) are the same to within
+  a fraction of pixel.
+  </PARA>
+  <PARA>
+  As a result of this change, the new skyfov method=convexhull algorithm
+  can now be used.  It provides a tighter bounding polygon around 
+  each chip which will provide a better estimate of the geometric area.  
+  </PARA>    
+</ADESC>
 
-<ADESC title="Changes in script 4.12.1 (December 2019) release">
+
+<ADESC title="Changes in scripts 4.12.1 (December 2019) release">
   <PARA>
     Updated to support new badpixels associated with bottom rows
     of each CCD due to 'shadow' cast by frame-store cover.  
@@ -759,7 +780,7 @@ acisf084244478N003_2_bias0.fits.gz
 </ADESC>
 
 
-<ADESC title="Change in script 4.11.5 (October 2019) release">
+<ADESC title="Change in scripts 4.11.5 (October 2019) release">
   <PARA>
     Internal only changes to correct verbose handling in newer versions
     of Python.


### PR DESCRIPTION
Not sure the DS10.8.3 blurb belongs in the ahelp file but needs a little bit of context methinks.

