### PR TITLE
Update xspec verison and CIAO version in docs

### DIFF
--- a/share/doc/xml/load_xspartcov.xml
+++ b/share/doc/xml/load_xspartcov.xml
@@ -57,8 +57,8 @@
 	This information is taken from the
 	<HREF link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/manual.html">XSpec
 	User's Guide</HREF>.
-	Version 12.10.0e of the XSpec
-	models is supplied with CIAO 4.11.
+	Version 12.10.1n of the XSpec
+	models is supplied with CIAO 4.12.
       </PARA>
 
     </DESC>


### PR DESCRIPTION
Really we probably need a variable to update this in automatically on release. Or is it intentional that 4.11 is cited because that's when the tool was added?

TBD: Check if there are other places with the same text, but I'm not doing that until you tell me that we actually *want* to update.

Note: Other models did updates the XSPEC string and CIAO 4.12, e.g. https://cxc.harvard.edu/sherpa/ahelp/xspcfabs.html