### PR TITLE
identify_name tries Sesame/CDS if CADC resolver fails

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,5 +1,5 @@
 
-## 4.12.2 - March 2020 ##
+## 4.12.2 - April 2020 ##
 
 Note that the CXC-provided FTP service has been deprecated, and will
 soon be removed. It is important to update to version 4.12.2 of the
@@ -27,7 +27,8 @@ Updated scripts
   find_chandra_obsid
 
     The script was broken by the DS 10.8.3 upgrade. This has now
-    been fixed.
+    been fixed. The name server now falls back to using the
+    Sesame service from CDS if the CADC server fails.
 
   tgsplit
 
@@ -64,6 +65,12 @@ Updated scripts
     Uses the new skyfov method=convexhull algorithm when new
     aspect solution files with CONTENT=ASPSOLOBI are used.
 
+Updated Python modules
+
+  coords.resolver
+
+    The identify_name routine now tries the Sesame server from CDS
+    if the CADC name server fails to identify the name.
 
 ## 4.12.1 - December 2019 ##
 

--- a/coords/resolver.py
+++ b/coords/resolver.py
@@ -317,7 +317,10 @@ def identify_name(name):
 
     try:
         return identify_name_cadc(name)
-    except ValueError:
+    except (ValueError, OSError):
+        # urllib errors seem to be suclasses of OSError so the
+        # above should be general enough to identify a problem
+        # with the CADC case.
         return identify_name_sesame(name)
 
 

--- a/share/doc/xml/identify_name.xml
+++ b/share/doc/xml/identify_name.xml
@@ -5,7 +5,8 @@
 <cxchelptopics>
   <ENTRY key="identify_name" context="contrib"
          refkeywords="identify find name object source resolver resolve coord coordinate coordinate coords
-		      position pos ra dec CADC NED IPAC VizieR CDS query
+		      position pos ra dec CADC NED IPAC VizieR CDS sesame query
+		      find_name findname
 		      coords.resolver coords_resolver"
 	 seealsogroups="contrib.coords">
 
@@ -22,14 +23,19 @@
 
     <DESC>
       <PARA>
-        The identify_name routine calls the Astronomical 
+        The identify_name routine calls the Astronomical
         <HREF link="http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver">name resolver</HREF>
-        provided by the Canadian Astronomy Data Center (CADC).
+        provided by the Canadian Astronomy Data Center (CADC),
+	or if this is not working, the
+	<HREF link="http://vizier.u-strasbg.fr/vizier/doc/sesame.htx">Sesame service</HREF>
+	from the Centre de Données astronomiques de Strasbourg.
+      </PARA>
+      <PARA>
         Given a name, it returns the Right Ascension, Declination,
         and coordinate system. If no position can be found then
         a ValueError is raised.
         This call requires a working internet connection, and so
-        may fail (e.g. if the CADC service is temporarily unavailable).
+        may fail (e.g. if both services are temporarily unavailable).
       </PARA>
 
       <PARA title="Loading the routine">
@@ -71,11 +77,18 @@ from coords.resolver import identify_name
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
+      <PARA>
+	The routine now falls back to using the Sesame service from
+	Simbad if the CADC server fails.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
       <PARA>
-        The routine now uses the service at 
+        The routine now uses the service at
         http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/cadc-target-resolver
-	rather than 
+	rather than
         http://www1.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/NameResolver
 	because problems were seen with the automatic redirects
 	for some queries.
@@ -84,14 +97,14 @@ from coords.resolver import identify_name
 
     <ADESC title="Changes in the scripts 4.5.4 (August 2013) release">
       <PARA>
-        The routine now uses the service at 
+        The routine now uses the service at
         http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/NameResolver
         rather than the more-specific version previously used:
         http://www1.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/NameResolver.
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>June 2019</LASTMODIFIED>
+    <LASTMODIFIED>April 2020</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
As the CADC service is currently flaky, and to support times when
it may go down (or be moved and we haven't noticed it), fall back
to Sesame from CDS.

We could make the choice optional (ie chose the ordering) which
would speed things up if you know one service is down for an
extended period, but leave that for a later revision.