### PR TITLE
Update changelog for 4.12.2 release

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,12 +1,39 @@
 
 ## 4.12.2 - April 2020 ##
 
-Note that the CXC-provided FTP service has been deprecated, and will
-soon be removed. It is important to update to version 4.12.2 of the
-contributed scripts package, or later, otherwise scripts will fail
-or may hang indefinitely.
+CIAO users are *strongly encouraged* to update to the 4.12.2
+contributed-script release!
+
+Main updates:
+
+ - The DS 10.8.3 release, which was released on March 24 2020 and is
+   used to process Chandra data, has changed how the aspect-solution
+   files for an observation are created. The CONTENT keyword for the
+   new asol files is "ASPSOLOBI" whereas data created with previous
+   versions uses the value of "ASPSOL". For new data, the method
+   parameter of skyfov can be set to convexhull, which gives a better
+   approximation of the field-of-view of the observation. A number of
+   scripts have been updated to use these new aspect-solution files,
+   including: chandra_repro, apply_fov_limits, fluximage, flux_obs,
+   merge_obs, and srcflux.
+
+ - The DS 10.8.3 release also now creates ARF and RMF files for
+   grating observations. The download_chandra_obsid script has
+   been updates with support for these files.
+
+ - The CXC is moving to providing data access via https rather than
+   ftp, and a number of scripts have been updated to use the new
+   service.
 
 Updated scripts
+
+  chandra_repro
+
+    The skyfov method=convexhull algorithm will now be used when
+    the script find the new style aspect solution files (those with
+    CONTENT="ASPSOLOBI").  This new FOV provides a tighter fitting
+    polygon around each chip and will provide, for example, a better
+    estimate of the geometric area of a region at the edge of the chip.
 
   download_chandra_obsid
 
@@ -51,25 +78,6 @@ Updated scripts
   correct_periscope_drift
 
     The script will now run when the verbose parameter is set to 0.
-
-  chandra_repro
-
-    The skyfov method=convexhull algorithm will now be used when
-    the script find the new style aspect solution files (those with
-    CONTENT="ASPSOLOBI").  This new FOV provides a tighter fitting
-    polygon around each chip and will provide, for example, a better
-    estimate of the geometric area of a region at the edge of the chip.
-
-  apply_fov_limits, fluximage, flux_obs, merge_obs
-
-    These scripts have been updated to support the new aspect solution
-    files (those with CONTENT="ASPSOLOBI"), and use method=convexhull
-    when running skyfov with such data.
-
-  srcflux
-
-    Uses the new skyfov method=convexhull algorithm when new
-    aspect solution files with CONTENT=ASPSOLOBI are used.
 
 Updated Python modules
 

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -750,7 +750,7 @@ acisf084244478N003_2_bias0.fits.gz
       </PARAM>
     </PARAMLIST>
 
-<ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+<ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
   <PARA title="Synchronization with DS 10.8.3 updates">
   In the spring of 2020, a new aspect solution file is being created. 
   This file has the DY, DZ, and DTHETA offsets folded back into the

--- a/share/doc/xml/correct_periscope_drift.xml
+++ b/share/doc/xml/correct_periscope_drift.xml
@@ -211,7 +211,7 @@ Running tool dmhistory using:
      </PARA>
    </ADESC>
 
-   <ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+   <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
      <PARA>
        The script will now run when the verbose parameter is 0.
      </PARA>

--- a/share/doc/xml/dax.xml
+++ b/share/doc/xml/dax.xml
@@ -87,7 +87,7 @@ unix% ds9 -analysis $ASCDS_INSTALL/contrib/config/ciao.ds9 ...
 </DESC>
 
 
-<ADESC title="Changes in the 4.12.2 (March 2020) release">
+<ADESC title="Changes in the 4.12.2 (April 2020) release">
 
   <PARA>
     Updated the Regions -> PSF Fraction task to force regions in

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -261,7 +261,7 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 	-->
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+    <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
       <PARA title="Archive has moved">
 	The script now uses the HTTPS service provided by the
 	Chandra Data Archive as the FTP service is being retired.

--- a/share/doc/xml/download_obsid_caldb.xml
+++ b/share/doc/xml/download_obsid_caldb.xml
@@ -355,7 +355,7 @@ they are skipped and only the background files are actually retrieved.
     
     </PARAMLIST>
 
-    <ADESC title="Changes in the script 4.12.2 (March 2020) release">
+    <ADESC title="Changes in the script 4.12.2 (April 2020) release">
       <PARA>
         Change to use https:// to retrieve the Chandra CALDB files.      
       </PARA>

--- a/share/doc/xml/simulate_psf.xml
+++ b/share/doc/xml/simulate_psf.xml
@@ -949,7 +949,7 @@
         
     </ADESC>
 
-    <ADESC title="Changes in the sripts 4.12.2 (March 2020) release">
+    <ADESC title="Changes in the sripts 4.12.2 (April 2020) release">
         <PARA>
         Fixed bug that caused parameter values in the 
         script's HISTORY records to be reset to their default (blank) 

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -1733,7 +1733,7 @@ bounds(region(my.reg))
     </ADESC>
 
 
-    <ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+    <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
       <PARA>
     Now uses the new skyfov method=convexhull algorithm when new
     aspect solution files with CONTENT=ASPSOLOBI are provided.  This gives

--- a/share/doc/xml/tgsplit.xml
+++ b/share/doc/xml/tgsplit.xml
@@ -377,7 +377,7 @@ Created background spectrum: tgcat_obs7435_heg_p1_bkg.pha
 
 
 
-  <ADESC title="Changes in the scripts 4.12.2 (March 2020) release">
+  <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
     <PARA>
     Fix problem with TYPE:II PHA files created with the tgextract2
     tool.  The background BACKSCAL column was incorrectly copied


### PR DESCRIPTION
This adds a pre-amble to the 4.12.2 release notes, and updates a bunch of ahelp XML files to change `March 2020` to `April 2020`.