### PR TITLE
WIP: update chandra repro for mix asol types

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "12 February 2020"
+version = "02 April 2020"
 
 # import standard python modules as required
 #
@@ -137,6 +137,63 @@ def error_out(params,msg,val):
     print("\n%s" % msg)
     raise ValueError("%s" % val)
 
+
+def filter_aspsolobi_from_aspsol(asol_list,mydir):
+    """As of DS10.8.3, there are now two flavors of aspect solution 
+    files, per OBI (CONTENT=ASPSOLOBI) and the original per-constant
+    aspect interval (cai) (CONTENT=ASPCOL).  Users should only ever
+    have one or the other. 
+    
+    Unfortunately, due to a quirk in the archive, users may have both.
+    
+    We know that there can be 1 and only 1 ASPSOLOBI file per obi (multi-obi
+    obsid's will need to have already been split, #repro5). 
+    
+    So if we find both ASPSOLOBI and ASPSOL files, we are going to pick
+    the ASPSOLOBI files.  This provides a better off-axis angle value.
+    
+    """
+    from pycrates import read_file
+
+    content_values = {}
+
+    for f in asol_list:
+        tab = read_file(f.strip("\n").strip(" "), mode="r")
+        content = tab.get_key_value("CONTENT")
+        if content in content_values:
+            content_values[content].append(f)
+        else:
+            content_values[content] = [f]
+        
+    if "ASPSOL" in content_values and "ASPSOLOBI" in content_values:
+        v0("WARNING: The primary directory has both CONTENT=ASPSOL and "+
+          "CONTENT=ASPSOLOBI files. Only the ASPSOLOBI file "+
+          "{} will be used".format(content_values["ASPSOLOBI"]))
+        # don't return yet, fall through to next check
+
+        # But I do want to go ahead and remove the old files from the
+        # output directory.
+        for oldasp in content_values["ASPSOL"]:
+            old = os.path.join(mydir, os.path.basename(oldasp.strip("\n").strip(" ")))
+            if os.path.exists(old):
+                os.unlink(old)
+
+
+    if "ASPSOLOBI" in content_values:
+        if len( content_values["ASPSOLOBI"] ) > 1:
+            error_out("Too many ASPSOLOBI aspect file found.  If this "+
+            "is a mutli-obi observations, be sure to split it first "+
+            "using the splitobs script")
+        return content_values["ASPSOLOBI"]
+    
+    if "ASPSOL" in content_values:
+        return content_values["ASPSOL"]
+    
+    error_out("Unknown CONTENT keywords found in the aspect solution files")
+    
+
+
+
 def _verify_have_list(myfile,mylist,mydir,params):
     '''Verify we have list of fits files in output directory'''
 
@@ -184,6 +241,8 @@ def _verify_have_list(myfile,mylist,mydir,params):
 
         # sort files
         asol_files.sort()
+
+        asol_files = filter_aspsolobi_from_aspsol(asol_files,mydir)
 
         # write out sorted list
         try:


### PR DESCRIPTION
@DougBurke can you review this.    I still need to do ahelp|doc updates but wanted to get your thoughts.

Since we know we want users to use the aspsolobi files -- if they are there, then this just skips|omits the old files with a warning

```bash
% chandra_repro 22916 out=blek 

Running chandra_repro
version: 12 February 2020


Processing input directory '/stage/pool1/kjg/22916'

Warning: Original level 1 event file was created with asol1 file named '['pcadf22916_000N001_asol1.fits']', however, the file found on disk is named 'pcadf701242066N001_asol1.fits'.
WARNING: The primary directory has both CONTENT=ASPSOL and CONTENT=ASPSOLOBI files. Only the ASPSOLOBI file ['/stage/pool1/kjg/22916/primary/pcadf22916_000N001_asol1.fits\n'] will be used
Resetting afterglow status bits in evt1.fits file...

Running the destreak tool on the evt1.fits file...
...
```

There are actually 2 warnings ... the 1st because the ASOLFILE doesn't match the ASPSOL filename, and then the more explicit ASPSOL v. ASPSOLOBI warning.

Or, I can make that warning fatal.


