### PR TITLE
update combine_spectra to work around addresp NUM keywords bug

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -68,6 +68,12 @@ Updated scripts
     tool.  The background BACKSCAL column was incorrectly copied
     from the source region.
 
+  combine_spectra
+  
+    The script has been updated to recompute the NUMELT and NUMGRP
+    keywords in the output RMF files.
+
+
   dax
 
     Updated the Regions -> PSF Fraction task to force regions in

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -70,8 +70,9 @@ Updated scripts
 
   combine_spectra
   
-    The script has been updated to recompute the NUMELT and NUMGRP
-    keywords in the output RMF files.
+    The script has been updated to remove the 
+    optional NUMELT and NUMGRP keywords in the output RMF files
+    as they may have incorrect values as output from the addresp tool.
 
 
   dax

--- a/bin/combine_spectra
+++ b/bin/combine_spectra
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2013,2014,2016-2019
+# Copyright (C) 2013,2014,2016-2020
 #       Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
@@ -21,29 +21,10 @@ from __future__ import print_function
 
 
 toolname = "combine_spectra"
-__revision__ = "18 November 2019"
+__revision__ = "07 April 2020"
 
 import sys
-
-
-# Make sure this shows up first!
 import os
-try:
-    if not __file__.startswith(os.environ['ASCDS_INSTALL']):
-        _thisdir = os.path.dirname(__file__)
-        _libname = "python{}.{}".format(sys.version_info.major,
-                                        sys.version_info.minor)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
-        if os.path.isdir(_pathdir):
-            os.sys.path.insert(0, _pathdir)
-        else:
-            print("*** WARNING: no {}".format(_pathdir))
-
-        del _libname
-        del _pathdir
-        del _thisdir
-except KeyError:
-    raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
 
 
 
@@ -415,6 +396,53 @@ def fix_arf_exposure( arfs, outarf, method ):
     tab.write()
 
 
+def fix_rmf_numkeywords(outrmf):
+    """
+    The NUMGRP and NUMELT keywords should be equal to the sum of 
+    the N_GRP and N_CHAN columns, respectively.   It looks like 
+    instead they are just copied from the 1st input file.
+    
+    Go ahead an update them.    
+    """
+    
+    if "" == outrmf:
+        return
+    
+    # Since RMF files are special: variable length columns and 
+    # multiple extensions (EBOUNDS); I don't trust that crates will 
+    # open in rw mode will work correctly.  So I'm going to use
+    # dmhedit to just modify keywords in-place.
+
+    from pycrates import read_file
+    tab = read_file(outrmf+"[cols n_grp,n_chan]", mode="r")
+    chan = tab.get_column("n_chan").values
+    numelt = sum( [sum(c) for c in chan]) # variable length array col
+    verb2("The updated NUMELT keyword is {}".format(numelt))
+
+    grp = tab.get_column("n_grp").values
+    numgrp = sum(grp)
+    verb2("The updated NUMGRP keyword is {}".format(numgrp))
+    
+    from ciao_contrib.runtool import dmhedit
+    dmhedit.infile=outrmf
+    dmhedit.file=""
+    dmhedit.op="add"
+    dmhedit.datatype="ulong"
+    dmhedit.unit=""
+
+    if tab.get_key("NUMGRP") is not None:
+        dmhedit.key="NUMGRP"
+        dmhedit.value=numgrp
+        dmhedit.comment="The sum of the N_GRP column"
+        dmhedit()
+    
+    if tab.get_key("NUMELT") is not None:
+        dmhedit.key="NUMELT"
+        dmhedit.value=numelt
+        dmhedit.comment="The sum of the N_CHAN column"
+        dmhedit()
+
+
 
 def run_addresp( arfs, rmfs, phas, root, method ):
     """
@@ -444,6 +472,7 @@ def run_addresp( arfs, rmfs, phas, root, method ):
     outarf = addresp.outarf if os.path.exists( addresp.outarf ) else ""
 
     fix_arf_exposure( arfs, outarf, method)
+    fix_rmf_numkeywords(outrmf)
 
     return outrmf,outarf
 

--- a/bin/combine_spectra
+++ b/bin/combine_spectra
@@ -402,7 +402,7 @@ def fix_rmf_numkeywords(outrmf):
     the N_GRP and N_CHAN columns, respectively.   It looks like 
     instead they are just copied from the 1st input file.
     
-    Go ahead an update them.    
+    As these are optional keywords, just delete them.
     """
     
     if "" == outrmf:
@@ -414,32 +414,19 @@ def fix_rmf_numkeywords(outrmf):
     # dmhedit to just modify keywords in-place.
 
     from pycrates import read_file
-    tab = read_file(outrmf+"[cols n_grp,n_chan]", mode="r")
-    chan = tab.get_column("n_chan").values
-    numelt = sum( [sum(c) for c in chan]) # variable length array col
-    verb2("The updated NUMELT keyword is {}".format(numelt))
-
-    grp = tab.get_column("n_grp").values
-    numgrp = sum(grp)
-    verb2("The updated NUMGRP keyword is {}".format(numgrp))
+    tab=read_file(outrmf, mode="r")
     
     from ciao_contrib.runtool import dmhedit
+    dmhedit.punlearn()
     dmhedit.infile=outrmf
-    dmhedit.file=""
-    dmhedit.op="add"
-    dmhedit.datatype="ulong"
-    dmhedit.unit=""
+    dmhedit.op="delete"
 
     if tab.get_key("NUMGRP") is not None:
         dmhedit.key="NUMGRP"
-        dmhedit.value=numgrp
-        dmhedit.comment="The sum of the N_GRP column"
         dmhedit()
     
     if tab.get_key("NUMELT") is not None:
         dmhedit.key="NUMELT"
-        dmhedit.value=numelt
-        dmhedit.comment="The sum of the N_CHAN column"
         dmhedit()
 
 

--- a/share/doc/xml/combine_spectra.xml
+++ b/share/doc/xml/combine_spectra.xml
@@ -364,10 +364,10 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 
   <ADESC title="Changes in the script 4.12.2 (April 2020) release">
     <PARA>
-      The combine_spectra script has been updated to recompute the 
+      The combine_spectra script has been updated to delete the 
       NUMGRP and NUMELT keywords in the output RMF files. These
-      scripts run the addresp tool which simply copies those header
-      keywords from the first RMF file.    
+      keywords are optional and may be incorrectly set by the addresp
+      tool.
     </PARA>
   </ADESC>
 

--- a/share/doc/xml/combine_spectra.xml
+++ b/share/doc/xml/combine_spectra.xml
@@ -362,6 +362,16 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 </ADESC>
 
 
+  <ADESC title="Changes in the script 4.12.2 (April 2020) release">
+    <PARA>
+      The combine_spectra script has been updated to recompute the 
+      NUMGRP and NUMELT keywords in the output RMF files. These
+      scripts run the addresp tool which simply copies those header
+      keywords from the first RMF file.    
+    </PARA>
+  </ADESC>
+
+
   <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
     <PARA>
       Updated to remove the grating order, tg_m, from the subspace


### PR DESCRIPTION
`addresp` is just copying the header from the 1st RMF file and not updating the NUMGRP and NUMELT keywords (should be the sum of the N_GRP and N_CHAN columns, respectively).  These are optional keywords, but if they are there, they should be correct.  Xspec 12.11.0 seems to use these and has been seen to crash when the values are incorrect.

Note: grating RMFs don't have those keywords, so if they are not in the input file, then this update will not create them in the output file. 