### PR TITLE
allow image, add energy keyword

### DIFF
--- a/bin/src_psffrac
+++ b/bin/src_psffrac
@@ -280,8 +280,9 @@ def main():
     energy = parse_ebands( pars["energy"] )
 
     # Convert ra/dec to theta/phi and x/y
-    myfile = read_file( pars["infile"]+"[#row=1]" ) # use #row=1 to speed up
+    myfile = read_file( pars["infile"])
     mykeys = get_keys_from_crate( myfile )
+    mykeys["ENERGY"] = energy
 
     ra_vals, dec_vals = sky_to_cel( myfile, sky_x,sky_y)
 

--- a/share/doc/xml/src_psffrac.xml
+++ b/share/doc/xml/src_psffrac.xml
@@ -214,6 +214,14 @@ region(ds9.reg)
         </PARAM>
     </PARAMLIST>
 
+    <ADESC title="Changes in CIAO 4.12.3 (June 2020) release">
+      <PARA>
+        The input file can now be an image or an table.  The 
+        energy value used is now stored in the ENERGY keyword.      
+      </PARA>
+    
+    </ADESC>
+
 
     <ADESC title="Changes in CIAO 4.7.2 (April 2015) release">
       <PARA>
@@ -229,7 +237,7 @@ region(ds9.reg)
             across the field of view and also as a function of energy.
             It becomes highly elliptical and contains many sharp
             features that makes providing an accurate 2D analytic model 
-            impossible.    The
+            impossible.    
             The calibration file used, the REEF (radially enclosed energy
             fraction) file, was created assuming a flat detector.  This is 
             accurate for HRC and for ACIS-7, but the other ACIS CCDs are 


### PR DESCRIPTION
This fixes #378 .

The `#row` filter was put in there to try to make `srcflux` run faster; but it actually doesn't make any diff.  (pycrates does 'lazy' loading of table anyway).  This allows` src_psffrac` to be run using images -- really it just needs header info.  Also went ahead an added an `ENERGY` keyword to record how the data were created.


