### PR TITLE
check_ciao_version: ignore conda updates to non-CIAO packages

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,3 +1,11 @@
+## ? ##
+
+Updated scripts
+
+  check_ciao_version
+
+    The script has been fixed for conda installs when a support
+    library has been updated
 
 ## 4.12.2 - April 2020 ##
 
@@ -34,9 +42,9 @@ Updated scripts
     CONTENT="ASPSOLOBI").  This new FOV provides a tighter fitting
     polygon around each chip and will provide, for example, a better
     estimate of the geometric area of a region at the edge of the chip.
-    
+
     While users should only have either the new CONTENT="ASPSOLOBI"
-    or the CONTENT="ASPSOL" aspect solution files in their primary 
+    or the CONTENT="ASPSOL" aspect solution files in their primary
     directory; it is possible that they will have both.  chandra_repro
     now checks for this and will only use the CONTENT="ASPSOLOBI" file.
 
@@ -69,8 +77,8 @@ Updated scripts
     from the source region.
 
   combine_spectra
-  
-    The script has been updated to remove the 
+
+    The script has been updated to remove the
     optional NUMELT and NUMGRP keywords in the output RMF files
     as they may have incorrect values as output from the addresp tool.
 

--- a/bin/check_ciao_version
+++ b/bin/check_ciao_version
@@ -2,7 +2,7 @@
 
 """
 
-Copyright (C) 2011, 2014, 2015, 2016, 2019
+Copyright (C) 2011, 2014, 2015, 2016, 2019, 2020
           Smithsonian Astrophysical Observatory
 
 
@@ -56,7 +56,7 @@ from optparse import OptionParser
 import socket
 
 toolname = "check_ciao_version"
-version = "21 November 2019"
+version = "16 June 2020"
 
 try:
     from ciao_contrib import logger_wrapper as lw
@@ -84,7 +84,7 @@ which requres that it downloads information from the CIAO web site.
 
 
 copyright_str = """
-Copyright (C) 2011, 2014, 2015, 2016, 2019
+Copyright (C) 2011, 2014, 2015, 2016, 2019, 2020
               Smithsonian Astrophysical Observatory
 
 This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
It turns out we can still get messages from updated "support"
libraries (e.g. openssl) which we need to fiter out. This fixed #385

At the moment this will not warn if there are any "support" libraries (such as openssl) that need to be updated, just the CIAO packages.