### PR TITLE
srcflux merged fluxes and friends

### DIFF
--- a/bin/srcflux
+++ b/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "27 July 2020"
+__revision__ = "04 August 2020"
 
 import os
 
@@ -2043,7 +2043,10 @@ def merge_aprates( cts, conf, rate=False ):
     q = m*r
     Q = np.sum(q)
 
-    R = Q / M if M > 0 else np.nan
+    if M == 0:
+        R = np.nan
+    else:
+        R = Q / M 
 
     chk = np.sum(exp_s)
     if chk != 0:

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -19,7 +19,7 @@
 #
 
 toolname = "srcflux"
-__revision__ = "29 September 2020"
+__revision__ = "04 November 2020"
 
 import os
 
@@ -1906,7 +1906,7 @@ def merge_modelflux( stk_params, myparams ):
 
         for p_a_r in zip(pi_files, arf_files, rmf_files):
             ondisk = [ os.path.exists(x) for x in p_a_r]
-            if all(ondisk) == False:
+            if not all(ondisk):
                 continue
             p_good.append(p_a_r[0])
             a_good.append(p_a_r[1])
@@ -2005,7 +2005,7 @@ def merge_aprates( cts, conf, rate=False ):
     alpha  = np.array(cts["psffrac"])[good]
     beta   = np.array(cts["bg_psffrac"] )[good]
     exptime = np.array(cts["exptime"])[good]
-    if True == rate:
+    if rate:
         exp_s  = exptime
         exp_b  = exptime
     else:
@@ -2084,7 +2084,7 @@ def merge_aprates( cts, conf, rate=False ):
         delme(outfile.name)
         return badval
     
-    if wtaf == False:
+    if not wtaf:
         delme(outfile.name)
         return badval
 
@@ -2677,13 +2677,7 @@ def process_single_obi( myparams, pars ):
         mfluxfiles = get_model_flux( taskrunner, myparams, at_energy, src, bkg, (at_energy == with_bands[0]) )        
         photfluxfiles = get_fluximage_flux( taskrunner, myparams, at_energy, src, bkg )
 
-        # ---
-        try:
-            taskrunner.run_tasks( processes=myparams.nproc )
-        except Exception as ee:
-            print(ee)
-            raise
-        # ---
+        taskrunner.run_tasks( processes=myparams.nproc )
       
         add_aprates_to_output( myparams, at_energy, outfiles )
         add_effevt_to_outfile( myparams, at_energy, srcfiles, bkgfiles )
@@ -2721,7 +2715,7 @@ def obi_main(pars):
         obipars["bpixfile"] = infile[4]
         obipars["dtffile"] = infile[5]
 
-        if False == is_single_obi:
+        if not is_single_obi:
             obipars["outroot"] = "{}obi{:03d}_".format( pars["outroot"], ii+1)
 
         set_bands(obipars)        

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 #
-# Copyright (C) 2013-2018,2020 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013-2020 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1579,7 +1579,7 @@ def get_nh_from_colden( myparams, token, at_energy, ii ):
     return nh
     
 
-def replace_nh_tokens( myparams, at_energy, ii ):
+def replace_nh_tokens( myparams, at_energy, ii, in_pi=None ):
     """
     Look for and replace any special %*_NH% tokens in the 
     model parameter strings.
@@ -1596,7 +1596,10 @@ def replace_nh_tokens( myparams, at_energy, ii ):
         if token not in modelparam:
             return modelparam
             
-        pi = myparams.outroot+"{:04d}.pi".format(ii)
+        if in_pi is None:
+            pi = myparams.outroot+"{:04d}.pi".format(ii)
+        else:
+            pi = in_pi
         if not os.path.exists(pi):
             verb1("Cannot locate spectrum file, will try to get from colden")
             nh = get_nh_from_colden( myparams, token, at_energy, ii )
@@ -1622,7 +1625,7 @@ def replace_nh_tokens( myparams, at_energy, ii ):
     return mparams, absparams
 
 
-def run_modelflux( myparams, at_energy, outroot, src, bkg, ii, make_resp, inarf, inrmf ):
+def run_modelflux( myparams, at_energy, outroot, src, bkg, ii, make_resp, inarf, inrmf, inpi=None ):
     """
     Run the modelflux script to get the conversion factor
     from a 1 c/s rate to the model flux in the
@@ -1672,7 +1675,7 @@ def run_modelflux( myparams, at_energy, outroot, src, bkg, ii, make_resp, inarf,
         elo = 0.1
         ehi = 10.0
 
-    mparams, absparams = replace_nh_tokens( myparams, at_energy, ii )
+    mparams, absparams = replace_nh_tokens( myparams, at_energy, ii, inpi )
 
     modelflux = make_tool("modelflux")
     modelflux.arf = arf
@@ -1903,8 +1906,10 @@ def merge_modelflux( stk_params, myparams ):
 
         pi_files = [ p.outroot+"{:04d}.pi".format(snum+1) for p in stk_params ]
         arf_files = [ p.outroot+"{:04d}_nopsf.arf".format(snum+1) for p in stk_params ]
+        rmf_files = [ p.outroot+"{:04d}.rmf".format(snum+1) for p in stk_params ]
         combine_spectra.src_spectra=[x for x in pi_files if os.path.exists(x)]
         combine_spectra.src_arf=[x for x in arf_files if os.path.exists(x)]
+        combine_spectra.src_rmf=[x for x in rmf_files if os.path.exists(x)]
         combine_spectra.outroot = myparams.outroot+"{:04d}".format(snum+1)
         combine_spectra.clobber=True
         vv = combine_spectra()
@@ -1912,12 +1917,13 @@ def merge_modelflux( stk_params, myparams ):
             verb2(vv)
 
         verb2("Running model_flux")
-        out_arf = combine_spectra.outroot+"src.arf"
-        out_rmf = combine_spectra.outroot+"src.rmf"
+        out_arf = combine_spectra.outroot+"_src.arf"
+        out_rmf = combine_spectra.outroot+"_src.rmf"
+        out_pi = combine_spectra.outroot+"_src.pi"
         for at_energy in bands:
             myroot = get_root( myparams, at_energy )
             outroot = myroot+"_{:04d}.dat".format(snum+1)
-            run_modelflux( myparams, at_energy, outroot, None, None, snum+1, False, out_arf, out_rmf )
+            run_modelflux( myparams, at_energy, outroot, None, None, snum+1, False, out_arf, out_rmf, out_pi )
             tab = read_file( outroot )
             outfiles[at_energy]["mflux_cnv"].append( tab.get_column("MFLUX_CNV").values[0] )
             outfiles[at_energy]["umflux_cnv"].append( tab.get_column("UMFLUX_CNV").values[0] )
@@ -1944,6 +1950,8 @@ def counts_helper( ):
                'mean_bg_exp' : [],
                'exptime' : [],
                'inside_fov': [],
+               'net_photflux_aper' : [],
+               'net_photflux_aper_hi' : [],
                }
     return retval
 
@@ -1974,20 +1982,24 @@ def merge_aprates( cts, rate=False ):
     TODO:  CSC1 approach.  Take instead from xaprate/naprates/etc
     
     """
-    import aper as aper
-    good = ( np.array( cts["inside_fov"] ) == True )
+    #~ import aper as aper
+    from ciao_contrib.runtool import aprates
+    from tempfile import NamedTemporaryFile
+    outfile = NamedTemporaryFile(suffix=".par", delete=False)
 
+    good = ( np.array( cts["inside_fov"] ) == True )
 
     c      = np.array( cts["counts"] )[good]
     b      = np.array( cts["bg_counts"] )[good]
     alpha  = np.array(cts["psffrac"])[good]
     beta   = np.array(cts["bg_psffrac"] )[good]
+    exptime = np.array(cts["exptime"])[good]
     if True == rate:
-        exp_s  = np.array(cts["exptime"])[good]
-        exp_b  = np.array(cts["exptime"])[good]
+        exp_s  = exptime
+        exp_b  = exptime
     else:
-        exp_s  = np.array(cts["exptime"] )[good] * np.array(cts["mean_src_exp"])[good]
-        exp_b  = np.array(cts["exptime"] )[good] * np.array(cts["mean_bg_exp"])[good]
+        exp_s  = exptime * np.array(cts["mean_src_exp"])[good]
+        exp_b  = exptime * np.array(cts["mean_bg_exp"])[good]
     area_s = np.array(cts["area"])[good]
     area_b = np.array(cts["bg_area"])[good]
 
@@ -1995,7 +2007,6 @@ def merge_aprates( cts, rate=False ):
     C = int(np.sum(c))
     B = int(np.sum(b))
 
-    # sigma = exp_s / exp_b 
     f = alpha * exp_s
     g = beta *exp_b
 
@@ -2012,21 +2023,70 @@ def merge_aprates( cts, rate=False ):
 
     R = Q / M
 
-    photflux = aper.aper( C, B, R, F, G) 
+
+    Alpha = np.sum(alpha*exp_s)/np.sum(exp_s)
+    Beta = np.sum(beta*exp_b)/np.sum(exp_b)
+    E_S = np.sum(exp_s) 
+    E_B = np.sum(exp_b) 
+    A_S = 1.0
+    A_B = (E_S/E_B)*R
+    T_S = np.sum(exptime)
+    T_B = np.sum(exptime)
+
+    aprates.n = C
+    aprates.A_s = A_S
+    aprates.alpha = Alpha
+    aprates.T_s = T_S
+    aprates.E_s = E_S
+    aprates.eng_s = 1.0
+    aprates.flux_s = 1.0
+    aprates.m = B
+    aprates.A_b = A_B
+    aprates.beta = Beta
+    aprates.T_b = T_B
+    aprates.E_b = E_B
+    aprates.eng_b = 1.0
+    aprates.flux_b = 1.0
+    aprates(outfile=outfile.name, clobber=True, verbose=0)
+
+    from paramio import pget
+    pf = pget(outfile.name, "photflux_aper_mode")
+    pfl = pget(outfile.name, "photflux_aper_err_lo")
+    pfh = pget(outfile.name, "photflux_aper_err_up")
+    conf = pget(outfile.name, "photflux_aper_conf")
+    if os.path.exists(outfile.name):
+        os.unlink(outfile.name)
 
     retval = { 'src_cts' : C,
                'bkg_cts' : B,
                'backscl' : R,
                'srcwexp' : F,
                'bkgwexp' : G,
-               'value' : photflux[0],
-               'lolimit' : photflux[1],
-               'hilimit' : photflux[2],
-               'conf' : 0.68, # hard coded in aper module
+               'value' : float(pf),
+               'lolimit' : float(pfl),
+               'hilimit' : float(pfh),
+               'conf' : float(conf),
                'numobi': len(c) ,
                }
                
     return retval
+
+
+def merge_photfluxes(cts):
+    good = ( np.array( cts["inside_fov"] ) == True )
+
+    exptime = np.array(cts["exptime"])[good]    
+    photflux    = np.array(cts["net_photflux_aper"])[good]
+    photflux_hi = np.array(cts["net_photflux_aper_hi"])[good]
+    
+    for ii in range(len(photflux)):
+        if photflux[ii] == 0:
+            photflux[ii] = photflux_hi[ii] # Use the upper limit
+
+    P = np.sum( exptime * photflux ) / np.sum(exptime)
+    retval = { 'value' : P }
+    return retval
+
     
 
 def merge_eff2evt( cts ):
@@ -2059,6 +2119,7 @@ def merge_counts( stk_params, myparams):
         retvals[b] = { 'rates' : [],
                       'fluxes' : [],
                       'eff2evt' : [],
+                      'photfluxes' : [],
                       }
 
     verb1("Combining count rates")
@@ -2070,7 +2131,13 @@ def merge_counts( stk_params, myparams):
             srcfiles = [ "{}{}[#row={}]".format(get_root(src,at_energy), __osuf__, snum+1) for src in stk_params  ]
             cts = merge_get_counts( srcfiles )
             retvals[at_energy]['rates'].append( merge_aprates(cts, rate=True) )
+
+            # TODO: this is wrong for photon fluxes; inconsistent with how per-obi are computed
+            # from fluxed images.
             retvals[at_energy]['fluxes'].append( merge_aprates(cts, rate=False) )
+
+            retvals[at_energy]['photfluxes'].append( merge_photfluxes(cts) )
+
             retvals[at_energy]['eff2evt'].append( merge_eff2evt(cts) )
 
     return retvals
@@ -2112,16 +2179,27 @@ def merge_write_output( stk_params, myparams, modelflux_vals, merge_fluxes ):
         pick_and_write( "MERGED_RATE_AREASCAL", "Merged area scale used in rates", "", "backscl", "rates")
         pick_and_write( "PSF_WEIGHTED_TOTAL_EXPOSURE_TIME", "Sum(EXPOSURE) weighted by PSF fraction", "s", "srcwexp", "rates")
 
-        pick_and_write( "MERGED_NET_PHOTFLUX_APER", "Merged count rate", "photon/cm**2/s", "value", "fluxes" )
-        pick_and_write( "MERGED_NET_PHOTFLUX_APER_LO", "Merged count rate lower limit", "photon/cm**2/s", "lolimit", "fluxes" )
-        pick_and_write( "MERGED_NET_PHOTFLUX_APER_HI", "Merged count rate upper limit", "photon/cm**2/s", "hilimit", "fluxes" )        
         pick_and_write( "MERGED_PHOTFLUX_AREASCAL", "Merged area scale used in rates", "", "backscl", "fluxes")
         pick_and_write( "PSF_WEIGHTED_TOTAL_SRC_EXPOSURE", "Sum(EXPOSURE_MAP) weighted by PSF fraction", "cm**2 s", "srcwexp", "fluxes")
         pick_and_write( "PSF_WEIGHTED_TOTAL_BG_EXPOSURE", "Sum(EXPOSURE_MAP) weighted by PSF fraction", "cm**2 s", "bkgwexp", "fluxes")
 
-        total_net_rate = [ r['value'] for r in merge_fluxes[at_energy]['rates']]
-        total_net_rate_lolim = [ r['lolimit'] for r in merge_fluxes[at_energy]['rates']]
-        total_net_rate_hilim = [ r['hilimit'] for r in merge_fluxes[at_energy]['rates']]        
+
+        #pick_and_write( "MERGED_NET_PHOTFLUX_APER", "Merged count rate", "photon/cm**2/s", "value", "fluxes" )
+        #pick_and_write( "MERGED_NET_PHOTFLUX_APER_LO", "Merged count rate lower limit", "photon/cm**2/s", "lolimit", "fluxes" )
+        #pick_and_write( "MERGED_NET_PHOTFLUX_APER_HI", "Merged count rate upper limit", "photon/cm**2/s", "hilimit", "fluxes" )        
+
+        total_net_rate = [ float(r['value']) for r in merge_fluxes[at_energy]['rates']]
+        total_net_rate_lolim = [ float(r['lolimit']) for r in merge_fluxes[at_energy]['rates']]
+        total_net_rate_hilim = [ float(r['hilimit']) for r in merge_fluxes[at_energy]['rates']]        
+
+        total_photflux = [r['value'] for r in merge_fluxes[at_energy]['photfluxes']]
+        total_photflux_cnv = np.array(total_photflux) / np.array(total_net_rate)  # TODO upper limit
+        total_photflux_lolim = np.array(total_net_rate_lolim)*total_photflux_cnv
+        total_photflux_hilim = np.array(total_net_rate_hilim)*total_photflux_cnv
+        
+        add_array_to_crate( intab, "MERGED_NET_PHOTFLUX_APER", total_photflux, "Merged model scaled photflux", "photon/cm**2/s")
+        add_array_to_crate( intab, "MERGED_NET_PHOTFLUX_APER_LO", total_photflux_lolim, "Merged model scaled photflux lower limit", "photon/cm**2/s")
+        add_array_to_crate( intab, "MERGED_NET_PHOTFLUX_APER_HI", total_photflux_hilim, "Merged model scaled photflux upper limit", "photon/cm**2/s")
 
         total_mflux_cnv = modelflux_vals[at_energy]['mflux_cnv']
         total_umflux_cnv = modelflux_vals[at_energy]['umflux_cnv']
@@ -2590,7 +2668,7 @@ def obi_main(pars):
         obipars["dtffile"] = infile[5]
 
         if False == is_single_obi:
-            obipars["outroot"] = "{}_obi{:03d}".format( pars["outroot"], ii)
+            obipars["outroot"] = "{}obi{:03d}".format( pars["outroot"], ii)
 
         set_bands(obipars)        
         Params = namedtuple( 'Params', obipars.keys() )
@@ -2638,13 +2716,13 @@ def main():
         summarize_results( myparams, obi=None, single=True )
         return
 
-    #merged_fluxes = merge_counts( stk_pars, myparams) 
-    #modelflux_vals = merge_modelflux( stk_pars, myparams )
-    #merge_write_output( stk_pars, myparams, modelflux_vals, merged_fluxes)
+    merged_fluxes = merge_counts( stk_pars, myparams) 
+    modelflux_vals = merge_modelflux( stk_pars, myparams )
+    merge_write_output( stk_pars, myparams, modelflux_vals, merged_fluxes)
 
     for ii,ss in enumerate(stk_pars):
         summarize_results( ss, obi=ii, single=False )
-    #summarize_results( myparams, obi=None, single=False )
+    summarize_results( myparams, obi=None, single=False )
     
     
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1908,7 +1908,15 @@ def merge_modelflux( stk_params, myparams ):
         pi_files = [ p.outroot+"{:04d}.pi".format(snum+1) for p in stk_params ]
         arf_files = [ p.outroot+"{:04d}_nopsf.arf".format(snum+1) for p in stk_params ]
         rmf_files = [ p.outroot+"{:04d}.rmf".format(snum+1) for p in stk_params ]
-        combine_spectra.src_spectra=[x for x in pi_files if os.path.exists(x)]
+
+        _p = [x for x in pi_files if os.path.exists(x)]
+        if combine_spectra.src_spectra is None:
+            for at_energy in bands:
+                outfiles[at_energy]["mflux_cnv"].append(np.nan)
+                outfiles[at_energy]["umflux_cnv"].append(np.nan)
+            return outfiles
+
+        combine_spectra.src_spectra=_p
         combine_spectra.src_arf=[x for x in arf_files if os.path.exists(x)]
         combine_spectra.src_rmf=[x for x in rmf_files if os.path.exists(x)]
         combine_spectra.outroot = myparams.outroot+"{:04d}".format(snum+1)
@@ -1990,6 +1998,7 @@ def merge_aprates( cts, conf, rate=False ):
 
     good = ( np.array( cts["inside_fov"] ) == True )
 
+
     c      = np.array( cts["counts"] )[good]
     b      = np.array( cts["bg_counts"] )[good]
     alpha  = np.array(cts["psffrac"])[good]
@@ -2033,6 +2042,23 @@ def merge_aprates( cts, conf, rate=False ):
     A_B = (E_S/E_B)*R
     T_S = np.sum(exptime)
     T_B = np.sum(exptime)
+
+    if not any(good):
+        retval = { 'src_cts' : C,
+                   'bkg_cts' : B,
+                   'backscl' : R,
+                   'srcwexp' : F,
+                   'bkgwexp' : G,
+                   'value' : np.nan,
+                   'lolimit' : np.nan,
+                   'hilimit' : np.nan,
+                   'conf' : float(conf),
+                   'numobi': len(c) ,
+                   }
+        return retval
+
+
+
 
     aprates.n = C
     aprates.A_s = A_S

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -2714,13 +2714,13 @@ def main():
         summarize_results( myparams, obi=None, single=True )
         return
 
-    merged_fluxes = merge_counts( stk_pars, myparams) 
-    modelflux_vals = merge_modelflux( stk_pars, myparams )
-    merge_write_output( stk_pars, myparams, modelflux_vals, merged_fluxes)
+    #M#merged_fluxes = merge_counts( stk_pars, myparams) 
+    #M#modelflux_vals = merge_modelflux( stk_pars, myparams )
+    #M#merge_write_output( stk_pars, myparams, modelflux_vals, merged_fluxes)
 
     for ii,ss in enumerate(stk_pars):
         summarize_results( ss, obi=ii, single=False )
-    summarize_results( myparams, obi=None, single=False )
+    #M#summarize_results( myparams, obi=None, single=False )
     
     
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -2402,7 +2402,7 @@ def summarize_results( myparams, obi=None, single=False ):
         verbstr = "\n\nSummary of source fluxes\n"
     else:
         if obi is not None:
-            verbstr = "\n\nSummary of source fluxes in OBI {:03d}\n".format(obi)
+            verbstr = "\n\nSummary of source fluxes in OBI {:03d}\n".format(obi+1)
         else:
             verbstr = "\n\nSummary of merged source fluxes\n"
 
@@ -2732,14 +2732,14 @@ def obi_main(pars):
         obipars["dtffile"] = infile[5]
 
         if False == is_single_obi:
-            obipars["outroot"] = "{}obi{:03d}_".format( pars["outroot"], ii)
+            obipars["outroot"] = "{}obi{:03d}_".format( pars["outroot"], ii+1)
 
         set_bands(obipars)        
         Params = namedtuple( 'Params', obipars.keys() )
         myparams = Params( *tuple(obipars.values()))
         check_parameters( myparams )
 
-        verb1("Processing OBI {:03d}".format(ii))
+        verb1("Processing OBI {:03d}".format(ii+1))
         process_single_obi( myparams, pars )
 
         # save info

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -610,6 +610,7 @@ def simulate_psfs( myparams, at_energy, src, bkg, simulator ):
         simulate_psf.extended=True
         simulate_psf.numiter=1
         simulate_psf.keepiter=False
+        simulate_psf.random_seed=myparams.random_seed
         simulate_psf.verbose=0
             
         vv = simulate_psf()

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -2179,14 +2179,12 @@ def merge_write_output( stk_params, myparams, modelflux_vals, merge_fluxes ):
         pick_and_write( "MERGED_RATE_AREASCAL", "Merged area scale used in rates", "", "backscl", "rates")
         pick_and_write( "PSF_WEIGHTED_TOTAL_EXPOSURE_TIME", "Sum(EXPOSURE) weighted by PSF fraction", "s", "srcwexp", "rates")
 
+        pick_and_write( "MERGED_NET_APRATES_PHOTFLUX_APER", "Merged count rate", "photon/cm**2/s", "value", "fluxes" )
+        pick_and_write( "MERGED_NET_APRATES_PHOTFLUX_APER_LO", "Merged count rate lower limit", "photon/cm**2/s", "lolimit", "fluxes" )
+        pick_and_write( "MERGED_NET_APRATES_PHOTFLUX_APER_HI", "Merged count rate upper limit", "photon/cm**2/s", "hilimit", "fluxes" )        
         pick_and_write( "MERGED_PHOTFLUX_AREASCAL", "Merged area scale used in rates", "", "backscl", "fluxes")
         pick_and_write( "PSF_WEIGHTED_TOTAL_SRC_EXPOSURE", "Sum(EXPOSURE_MAP) weighted by PSF fraction", "cm**2 s", "srcwexp", "fluxes")
         pick_and_write( "PSF_WEIGHTED_TOTAL_BG_EXPOSURE", "Sum(EXPOSURE_MAP) weighted by PSF fraction", "cm**2 s", "bkgwexp", "fluxes")
-
-
-        #pick_and_write( "MERGED_NET_PHOTFLUX_APER", "Merged count rate", "photon/cm**2/s", "value", "fluxes" )
-        #pick_and_write( "MERGED_NET_PHOTFLUX_APER_LO", "Merged count rate lower limit", "photon/cm**2/s", "lolimit", "fluxes" )
-        #pick_and_write( "MERGED_NET_PHOTFLUX_APER_HI", "Merged count rate upper limit", "photon/cm**2/s", "hilimit", "fluxes" )        
 
         total_net_rate = [ float(r['value']) for r in merge_fluxes[at_energy]['rates']]
         total_net_rate_lolim = [ float(r['lolimit']) for r in merge_fluxes[at_energy]['rates']]

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/export/miniconda/envs/srcflux/bin/python
 
 #
 # Copyright (C) 2013-2020 Smithsonian Astrophysical Observatory
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "29 June 2020"
+__revision__ = "12 February 2020"
 
 import os
 
@@ -1910,11 +1910,11 @@ def merge_modelflux( stk_params, myparams ):
         rmf_files = [ p.outroot+"{:04d}.rmf".format(snum+1) for p in stk_params ]
 
         _p = [x for x in pi_files if os.path.exists(x)]
-        if combine_spectra.src_spectra is None:
+        if _p is None or 0 == len(_p):
             for at_energy in bands:
                 outfiles[at_energy]["mflux_cnv"].append(np.nan)
                 outfiles[at_energy]["umflux_cnv"].append(np.nan)
-            return outfiles
+            continue  # next source
 
         combine_spectra.src_spectra=_p
         combine_spectra.src_arf=[x for x in arf_files if os.path.exists(x)]
@@ -2031,34 +2031,52 @@ def merge_aprates( cts, conf, rate=False ):
     q = m*r
     Q = np.sum(q)
 
-    R = Q / M
+    R = Q / M if M > 0 else np.nan
 
+    chk = np.sum(exp_s)
+    if chk != 0:
+        Alpha = np.sum(alpha*exp_s)/chk
+    else:
+        Alpha = np.nan
+        
+    chk = np.sum(exp_b)
+    if chk != 0:
+        Beta = np.sum(beta*exp_b)/chk
+    else:
+        Beta = np.nan
 
-    Alpha = np.sum(alpha*exp_s)/np.sum(exp_s)
-    Beta = np.sum(beta*exp_b)/np.sum(exp_b)
     E_S = np.sum(exp_s) 
     E_B = np.sum(exp_b) 
     A_S = 1.0
-    A_B = (E_S/E_B)*R
+
+    if E_B != 0:
+        A_B = (E_S/E_B)*R
+    else:
+        A_B = np.nan
     T_S = np.sum(exptime)
     T_B = np.sum(exptime)
 
+
+    badval = { 'src_cts' : C,
+               'bkg_cts' : B,
+               'backscl' : R,
+               'srcwexp' : F,
+               'bkgwexp' : G,
+               'value' : np.nan,
+               'lolimit' : np.nan,
+               'hilimit' : np.nan,
+               'conf' : float(conf),
+               'numobi': len(c) ,
+               }
+
+    pp = [C,A_S,Alpha,T_S,E_S,B,A_B,Beta,T_B,E_B]
+    wtaf=np.isfinite(pp).all()
+
     if not any(good):
-        retval = { 'src_cts' : C,
-                   'bkg_cts' : B,
-                   'backscl' : R,
-                   'srcwexp' : F,
-                   'bkgwexp' : G,
-                   'value' : np.nan,
-                   'lolimit' : np.nan,
-                   'hilimit' : np.nan,
-                   'conf' : float(conf),
-                   'numobi': len(c) ,
-                   }
-        return retval
-
-
-
+        return badval
+    
+    if wtaf == False:
+        return badval
 
     aprates.n = C
     aprates.A_s = A_S
@@ -2091,7 +2109,7 @@ def merge_aprates( cts, conf, rate=False ):
                'srcwexp' : F,
                'bkgwexp' : G,
                'value' : float(pf),
-               'lolimit' : float(pfl),
+               'lolimit' : float(pfl) if pfl != "INDEF" else np.nan,
                'hilimit' : float(pfh),
                'conf' : float(conf),
                'numobi': len(c) ,
@@ -2102,6 +2120,9 @@ def merge_aprates( cts, conf, rate=False ):
 
 def merge_photfluxes(cts):
     good = ( np.array( cts["inside_fov"] ) == True )
+
+    if not any(good):
+        return { 'value' : np.nan }
 
     exptime = np.array(cts["exptime"])[good]    
     photflux    = np.array(cts["net_photflux_aper"])[good]
@@ -2123,6 +2144,8 @@ def merge_eff2evt( cts ):
 
     """
     good = ( np.array( cts["inside_fov"] ) == True )
+    if not any(good):
+        return {'src' : np.nan, 'bkg': np.nan}
 
     s    = np.array(cts["flux_aper"])[good]
     b    = np.array(cts["bg_flux_aper"])[good]

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "12 February 2020"
+__revision__ = "29 June 2020"
 
 import os
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "27 August 2020"
+__revision__ = "29 September 2020"
 
 import os
 
@@ -43,6 +43,8 @@ import sys
 import stk as stk
 from ciao_contrib._tools.taskrunner import TaskRunner
 from ciao_contrib.runtool import make_tool
+from pycrates import read_file
+from tempfile import NamedTemporaryFile
 
 import numpy as np
 np.seterr( all='ignore' )
@@ -64,6 +66,14 @@ class delme( str ):
     def __del__( self ):
         infile = self.__str__().split("[")[0]  # may have a DM filter
         gorm(infile.strip("@-"))  # may be a local stack
+
+
+class Params(object):
+    '''I tried to use a named tuple for this, but they don't 
+    pickle very well, and were completely broken on OSX py3.8.
+    So instead i'll use this dummy class to hold the parameter
+    values as individual attributes (to be added later)'''
+    pass
 
 
 def gorm( infile ):
@@ -119,8 +129,7 @@ def run_roi( infile, fovfile, tmproot="/tmp", bkgmode='mul', bkgradius=3, bkgfun
     """
     Create src and background regions for each source    
     """
-    from ciao_contrib.runtool import roi
-
+    roi = make_tool("roi")
     roi.punlearn()  # make sure clean for num_srcs below
     roi.infile = infile
 
@@ -228,8 +237,7 @@ def validate_src_and_bkg_regions( myroot, infile, tmpdir, src, bkg ):
     
 
     def region_to_phys( reg ):
-        from ciao_contrib.runtool import dmmakereg
-        from tempfile import NamedTemporaryFile
+        dmmakereg = make_tool("dmmakereg")
         tmproot = NamedTemporaryFile( dir=tmpdir)
         tfile = tmproot.name
         tmproot.close()        
@@ -285,7 +293,6 @@ def choose_skyfov_method( asolfiles ):
     applied. With these new files we can start to use the new 
     skyfov convex hull algorithm.    
     """    
-    from pycrates import read_file
 
     skyfov_choices={ 'ASPSOLOBI' : 'convexhull' , 'ASPSOL' : 'minmax' }
     if asolfiles is None or 1 != len(asolfiles):
@@ -302,7 +309,7 @@ def choose_skyfov_method( asolfiles ):
 def run_skyfov( myparams ):
     
     import ciao_contrib._tools.obsinfo as o
-    from ciao_contrib.runtool import skyfov
+    skyfov = make_tool("skyfov")
 
     dot= "" if os.path.isdir(myparams.outroot) else "."
 
@@ -352,8 +359,7 @@ def save_regions( myparams, regions, flavor ):
         !!! TODO: Use new region module in ciao4.10 instead of dmmakereg
     
     """    
-    from ciao_contrib.runtool import dmmakereg
-    from tempfile import NamedTemporaryFile    
+    dmmakereg = make_tool("dmmakereg")
 
     # CIAO 4.10 changes to NULL regions no longer creates a fake
     # "point(0,0)" -- I'm using that so we'll put it back.
@@ -395,7 +401,7 @@ def make_regions( myparams ):
     We always want the 1st stuff so we always run this.
     """
 
-    from ciao_contrib.runtool import psfsize_srcs
+    psfsize_srcs = make_tool("psfsize_srcs")
 
     verb2("Converting coords and looking up PSF size")
     myroot = myparams.outroot
@@ -494,9 +500,9 @@ def get_counts( myparams, at_energy, src, bkg ):
     Get the counts in the region using dmextract.
     We add the input columns from the PSF script with dmpaste
     """
-    from ciao_contrib.runtool import dmextract
-    from ciao_contrib.runtool import dmpaste
-    from pycrates import read_file
+    
+    dmextract = make_tool("dmextract")
+    dmpaste = make_tool("dmpaste")
 
     verb1("Extracting counts")
 
@@ -635,10 +641,10 @@ def get_psf_from_file( myparams, at_energy, src, bkg, simulate=None ):
 
     verb2("Getting PSF from file")
 
-    from ciao_contrib.runtool import dmextract
-    from ciao_contrib.runtool import dmmerge
-    from ciao_contrib.runtool import dmpaste
-    from ciao_contrib.runtool import dmstat
+    dmextract = make_tool("dmextract")
+    dmmerge = make_tool("dmmerge")
+    dmpaste = make_tool("dmpaste")
+    dmstat = make_tool("dmstat")
 
     myroot = get_root( myparams, at_energy )
 
@@ -669,7 +675,6 @@ def get_psf_from_file( myparams, at_energy, src, bkg, simulate=None ):
     infiles = [ "{}[sky=region({})][bin sky={}]".format(*x) for x in list(zip(psf_stk,fov,src_stk))]
     bgfiles = [ "{}[sky=region({})][bin sky={}]".format(*x) for x in list(zip(psf_stk,fov,bkg_stk))]
 
-    from tempfile import NamedTemporaryFile
     all_files = []
     for s,b in zip( infiles, bgfiles ):
         tmproot = NamedTemporaryFile( dir=myparams.tmpdir)
@@ -722,8 +727,8 @@ def get_psf_from_region( myparams, at_energy, src, bkg ):
     For circle regions, get PSF frac for radius
     """
 
-    from ciao_contrib.runtool import dmpaste
-    from ciao_contrib.runtool import src_psffrac
+    dmpaste = make_tool("dmpaste")
+    src_psffrac = make_tool("src_psffrac")
     
     verb2("Converting coords and looking up PSF size")
 
@@ -754,7 +759,7 @@ def get_ideal_psf( myparams, at_energy, src, bkg ):
     """
     Ideal PSF is source = 100% and background = 0%
     """
-    from ciao_contrib.runtool import dmtcalc
+    dmtcalc = make_tool("dmtcalc")
 
     verb1( "Setting Ideal PSF : alpha=1 , beta=0")
 
@@ -778,9 +783,8 @@ def run_arfcorr_and_dme( myparams, at_energy, src, bkg,ii):
         regions
     """
 
-    from ciao_contrib.runtool import dmextract
     from ciao_contrib.runtool import new_pfiles_environment as newpf
-    from ciao_contrib.runtool import make_tool
+    dmextract = make_tool("dmextract")
 
     verb1("Getting PSF fraction by running arfcorr {}".format(ii))
 
@@ -852,8 +856,8 @@ def get_psf_from_model( myparams, at_energy, src, bkg):
     Get PSF by making a model via arfcorr.  THis is the
     wrapper about above that runs the jobs in parallel.
     """
-    from ciao_contrib.runtool import dmmerge
-    from ciao_contrib.runtool import dmpaste
+    dmmerge = make_tool("dmmerge")
+    dmpaste = make_tool("dmpaste")
 
     verb1("Making PSF models ")
 
@@ -903,7 +907,7 @@ def run_aprates( c_s, a_s, alpha, c_b, a_b, beta, exposure, conf, outfile ):
     Run aprates tool, save the values in an ASCII file
     that can be combined together later
     """
-    from ciao_contrib.runtool import aprates
+    aprates = make_tool("aprates")
 
     def write_null( outfile ):        
         with open(outfile, "w") as fp:
@@ -968,8 +972,7 @@ def get_livetime_keywords( infile ):
     isn't there).  Also return just LIVETIME keyword value for HRC
     and in case it lands on a chip that isn't on.
     """
-    from pycrates import read_file
-   
+       
     tab = read_file( infile )
     live_times = [ tab.get_key_value("LIVTIME{}".format(n)) for n in range(10)]
     the_live_time = tab.get_key_value( "LIVETIME")
@@ -981,8 +984,7 @@ def get_net_rate_aper( taskrunner, myparams, at_energy, src, bkg ):
     Wrapper around aprates that runs them in parallel then collects
     the outputs
     """
-    from pycrates import read_file
-
+    
     verb1("Getting net rate and confidence limits")
 
     myroot = get_root( myparams, at_energy )
@@ -1021,8 +1023,7 @@ def get_net_rate_aper( taskrunner, myparams, at_energy, src, bkg ):
 def add_aprates_to_output( myparams, at_energy, outfiles):
     """
     """    
-    from pycrates import read_file
-
+    
     myroot = get_root( myparams, at_energy)
     intab = read_file( myroot+__osuf__, mode="rw")
 
@@ -1053,13 +1054,13 @@ def add_aprates_to_output( myparams, at_energy, outfiles):
         gorm( pp )
 
 
-def run_eff2evt( infile, outfile, energy="INDEF" ):
+def run_eff2evt( infile, outfile, energy):
     """
     Run EFF2EVT tool to get a model independent flux
 
     """
-    from ciao_contrib.runtool import eff2evt
-    from ciao_contrib.runtool import dmstat
+    eff2evt = make_tool("eff2evt")
+    dmstat = make_tool("dmstat")
 
     verb1("Running eff2evt for {}".format(outfile))
 
@@ -1108,10 +1109,8 @@ def bound_src_and_bkg( src, bkg, tmpdir ):
     
     """
     
-    def bounds( ss ):
-        from ciao_contrib.runtool import dmmakereg
-        from tempfile import NamedTemporaryFile
-        from pycrates import read_file
+    def bounds( ss ):        
+        dmmakereg = make_tool("dmmakereg")
 
         tmproot = NamedTemporaryFile(dir=tmpdir)
         tfile = tmproot.name
@@ -1150,7 +1149,8 @@ def run_fluximage( infile, outroot, at_energy, src, bkg, myparams ):
 
     """
     
-    from ciao_contrib.runtool import fluximage,dmextract
+    fluximage = make_tool("fluximage")
+    dmextract = make_tool("dmextract")
 
     fov = locate_fovfile( myparams)
 
@@ -1273,7 +1273,7 @@ def get_model_independent_flux( taskrunner, myparams, at_energy, src, bkg ):
         infile = inroot+"[sky={}]".format(src_stk[ii-1])
         outfile= myroot+"_{:04d}_src.dat".format(ii)
         taskrunner.add_task( outfile, "", run_eff2evt,
-            infile, outfile, energy=mono )
+            infile, outfile, mono )
         srcfiles.append( delme(outfile) )
     
     bkgfiles = []
@@ -1281,7 +1281,7 @@ def get_model_independent_flux( taskrunner, myparams, at_energy, src, bkg ):
         infile = inroot+"[sky={}]".format(bkg_stk[ii-1])
         outfile= myroot+"_{:04d}_bkg.dat".format(ii)
         taskrunner.add_task( outfile, "", run_eff2evt,
-            infile, outfile, energy=mono )
+            infile, outfile, mono )
         bkgfiles.append( delme(outfile+"[cols BG_FLUX_APER=FLUX_APER]" ))
     
     return( srcfiles, bkgfiles )
@@ -1294,8 +1294,8 @@ def add_photflux_to_outfile( myparams, at_energy, photfiles ):
     verb1("Appending photflux results onto output")
     myroot = get_root( myparams, at_energy )
 
-    from ciao_contrib.runtool import dmmerge
-    from ciao_contrib.runtool import dmpaste
+    dmmerge = make_tool("dmmerge")
+    dmpaste = make_tool("dmpaste")
 
     zz = [ z+"[cols SRC_PHOTFLUX=counts,BG_PHOTFLUX=bg_counts,MEAN_SRC_EXP,MEAN_BG_EXP][subspace -sky]" for z in photfiles ]
 
@@ -1325,8 +1325,8 @@ def add_effevt_to_outfile( myparams, at_energy, srcfiles, bkgfiles ):
     verb1("Appending flux results onto output")
     myroot = get_root( myparams, at_energy )
 
-    from ciao_contrib.runtool import dmmerge
-    from ciao_contrib.runtool import dmpaste
+    dmmerge = make_tool("dmmerge")
+    dmpaste = make_tool("dmpaste")
 
     sdat = delme(myroot+"_src.dat")
     bdat = delme(myroot+"_bkg.dat")
@@ -1387,7 +1387,6 @@ def scale_eff2evt_fluxes( myparams, at_energy):
 
     verb1("Computing Net fluxes")
 
-    from pycrates import read_file
 
     intab = read_file( myroot+__osuf__, mode="rw")
 
@@ -1480,7 +1479,6 @@ def run_specextract( myparams, outroot, srcreg, bkgreg, ii, at_energy ):
     """
 
     from ciao_contrib.runtool import new_pfiles_environment as newpf
-    from ciao_contrib.runtool import make_tool
 
     verb1("Making response files for {}".format(outroot))
 
@@ -1590,7 +1588,6 @@ def replace_nh_tokens( myparams, at_energy, ii, in_pi=None ):
     colden.
     """
 
-    from pycrates import read_file
 
     def lookup_value( key, modelparam ):
         token = '%{}%'.format(key)
@@ -1626,13 +1623,12 @@ def replace_nh_tokens( myparams, at_energy, ii, in_pi=None ):
     return mparams, absparams
 
 
-def run_modelflux( myparams, at_energy, outroot, src, bkg, ii, make_resp, inarf, inrmf, inpi=None ):
+def run_modelflux( myparams, at_energy, outroot, src, bkg, ii, make_resp, inarf, inrmf, inpi ):
     """
     Run the modelflux script to get the conversion factor
     from a 1 c/s rate to the model flux in the
     energy band.
     """
-    from ciao_contrib.runtool import make_tool
 
     if inarf is None and inrmf is None:
 
@@ -1791,7 +1787,7 @@ def get_model_flux( taskrunner, myparams, at_energy, src, bkg, make_resp ):
         outroot = myroot+"_{:04d}.dat".format(ii+1)
         taskrunner.add_task( outroot, "", run_modelflux, myparams, 
             at_energy, outroot, src_stk[ii], bkg_stk[ii], ii+1, make_resp,
-            arfs[ii], rmfs[ii] )
+            arfs[ii], rmfs[ii], None )
         infiles.append( delme(outroot) )
 
     return infiles
@@ -1806,8 +1802,8 @@ def add_modelflux_to_output( myparams, at_energy, infiles ):
     
     myroot = get_root( myparams, at_energy )
 
-    from ciao_contrib.runtool import dmmerge
-    from ciao_contrib.runtool import dmpaste
+    dmmerge = make_tool("dmmerge")
+    dmpaste = make_tool("dmpaste")
     dmmerge.infile = infiles
 
     dmmerge.outfile = delme(myroot+"_mdls.dat")
@@ -1837,7 +1833,6 @@ def scale_modelflux_fluxes( myparams, at_energy ):
 
     verb1("Scaling model flux confidence limits")
 
-    from pycrates import read_file
     myroot = get_root( myparams, at_energy)
 
     intab = read_file( myroot+__osuf__, mode="rw")
@@ -1878,7 +1873,6 @@ def get_num_srcs( pars ):
     """
     Helper to get number of sources
     """
-    from pycrates import read_file
     bands = stk.build( pars.bands )
     myroot = get_root( pars, bands[0] )
     tab = read_file( myroot+__osuf__)
@@ -1892,7 +1886,6 @@ def merge_modelflux( stk_params, myparams ):
 
     Output File:  ${root}_${band}_${src#}.dat
     """
-    from pycrates import read_file
     bands = stk.build( myparams.bands)
     outfiles = {}
     for b in bands:
@@ -1978,7 +1971,6 @@ def counts_helper( ):
 
 
 def merge_get_counts( infiles ):
-    from pycrates import read_file    
     retval = counts_helper()
 
     for infile in infiles:
@@ -2004,8 +1996,7 @@ def merge_aprates( cts, conf, rate=False ):
     
     """
     #~ import aper as aper
-    from ciao_contrib.runtool import aprates
-    from tempfile import NamedTemporaryFile
+    aprates = make_tool("aprates")
     outfile = NamedTemporaryFile(suffix=".par", delete=False)
 
     good = ( np.array( cts["inside_fov"] ) == True )
@@ -2220,7 +2211,6 @@ def merge_write_output( stk_params, myparams, modelflux_vals, merge_fluxes ):
     
     """
     dmmerge = make_tool("dmmerge")
-    from pycrates import read_file
     
     for at_energy in stk.build( myparams.bands ):
         
@@ -2306,7 +2296,6 @@ def cleanup_outfile( myparams, pars, at_energy):
     """
 
     from ciao_contrib.runtool import add_tool_history
-    from pycrates import read_file
 
     myroot = get_root( myparams, at_energy )
 
@@ -2367,7 +2356,6 @@ def summarize_results( myparams, obi=None, single=False ):
     conf = float(myparams.conf)
 
     from coords.format import deg2ra, deg2dec
-    from pycrates import read_file
     
     _lead = 30
     _lead_fmt = "{:"+str(_lead)+"s}"
@@ -2546,7 +2534,6 @@ def check_infile( infile ):
 def check_pos_inside_fov( myparam ):
     
     from region import regParse, regInsideRegion
-    from pycrates import read_file
     fov = locate_fovfile( myparam )
 
     fov = regParse( "region({})".format(fov))
@@ -2693,7 +2680,11 @@ def process_single_obi( myparams, pars ):
         photfluxfiles = get_fluximage_flux( taskrunner, myparams, at_energy, src, bkg )
 
         # ---
-        taskrunner.run_tasks( processes=myparams.nproc )
+        try:
+            taskrunner.run_tasks( processes=myparams.nproc )
+        except Exception as ee:
+            print(ee)
+            raise
         # ---
       
         add_aprates_to_output( myparams, at_energy, outfiles )
@@ -2710,17 +2701,11 @@ def process_single_obi( myparams, pars ):
     cleanup_tempfiles(myparams, src,bkg)
 
 
-## This has to be global so it can be pickled.    
-from collections import namedtuple
-Params = None
-
 #
 # Main Routine
 #
 def obi_main(pars):
     # get parameters
-    global Params    # We need to make this global so it can be pickeled for taskrunner
-
     infiles = build_infile_stacks( pars )
     is_single_obi = ( len(infiles) == 1 )
 
@@ -2742,8 +2727,11 @@ def obi_main(pars):
             obipars["outroot"] = "{}obi{:03d}_".format( pars["outroot"], ii+1)
 
         set_bands(obipars)        
-        Params = namedtuple( 'Params', obipars.keys() )
-        myparams = Params( *tuple(obipars.values()))
+
+        myparams = Params()
+        for k in obipars.keys():
+            setattr(myparams, k, obipars[k])
+
         check_parameters( myparams )
 
         verb1("Processing OBI {:03d}".format(ii+1))
@@ -2756,10 +2744,8 @@ def obi_main(pars):
     return stk_pars
 
 
-
 @lw.handle_ciao_errors( toolname, __revision__)
 def main():
-    global Params    # We need to make this global so it can be pickeled for taskrunner
 
     # Load parameters
     from ciao_contrib.param_soaker import get_params
@@ -2780,8 +2766,10 @@ def main():
 
     # Do this after above so bands is set correctly
     pars["bands"] = stk_pars[0].bands
-    Params = namedtuple( 'Params', pars.keys() )
-    myparams = Params( *tuple(pars.values()))
+
+    myparams = Params()
+    for k in pars.keys():
+        setattr( myparams, k, pars[k])
 
     if len(stk_pars) == 1:
         summarize_results( myparams, obi=None, single=True )

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1977,7 +1977,7 @@ def merge_get_counts( infiles ):
     return retval
 
 
-def merge_aprates( cts, rate=False ):
+def merge_aprates( cts, conf, rate=False ):
     """
     TODO:  CSC1 approach.  Take instead from xaprate/naprates/etc
     
@@ -2047,6 +2047,7 @@ def merge_aprates( cts, rate=False ):
     aprates.E_b = E_B
     aprates.eng_b = 1.0
     aprates.flux_b = 1.0
+    aprates.conf = conf
     aprates(outfile=outfile.name, clobber=True, verbose=0)
 
     from paramio import pget
@@ -2130,11 +2131,11 @@ def merge_counts( stk_params, myparams):
         for at_energy in bands:
             srcfiles = [ "{}{}[#row={}]".format(get_root(src,at_energy), __osuf__, snum+1) for src in stk_params  ]
             cts = merge_get_counts( srcfiles )
-            retvals[at_energy]['rates'].append( merge_aprates(cts, rate=True) )
+            retvals[at_energy]['rates'].append( merge_aprates(cts, myparams.conf, rate=True) )
 
             # Note: slightly inconsistent with how per-obi are computed
             # from fluxed images.
-            retvals[at_energy]['fluxes'].append( merge_aprates(cts, rate=False) )
+            retvals[at_energy]['fluxes'].append( merge_aprates(cts, myparams.conf, rate=False) )
 
             retvals[at_energy]['photfluxes'].append( merge_photfluxes(cts) )
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "13 August 2020"
+__revision__ = "27 August 2020"
 
 import os
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "01 July 2020"
+__revision__ = "27 July 2020"
 
 import os
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "04 August 2020"
+__revision__ = "13 August 2020"
 
 import os
 
@@ -2068,6 +2068,10 @@ def merge_aprates( cts, conf, rate=False ):
         A_B = (E_S/E_B)*R
     else:
         A_B = np.nan
+
+    if A_B < 0:
+        A_B = np.nan
+
     T_S = np.sum(exptime)
     T_B = np.sum(exptime)
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -124,7 +124,7 @@ def run_roi( infile, fovfile, tmproot="/tmp", bkgmode='mul', bkgradius=3, bkgfun
     roi.punlearn()  # make sure clean for num_srcs below
     roi.infile = infile
 
-    if fovfile and fovfile.lower() is not "none":
+    if fovfile and fovfile.lower() != "none":
         roi.fovregion = 'region({})'.format(fovfile)
     else:
         roi.fovregion = ''
@@ -1915,7 +1915,7 @@ def merge_modelflux( stk_params, myparams ):
 
         for p_a_r in zip(pi_files, arf_files, rmf_files):
             ondisk = [ os.path.exists(x) for x in p_a_r]
-            if all(ondisk) is False:
+            if all(ondisk) == False:
                 continue
             p_good.append(p_a_r[0])
             a_good.append(p_a_r[1])

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -2462,11 +2462,12 @@ def summarize_results( myparams, obi=None, single=False ):
             unit[0] = "c/s"
         else: 
             hdr=hdr[0:3] # only 4 rows of output
+            srcno = vals[bands[0]].get_column("COMPONENT").values[ii]
 
             cols = [ "MERGED_NET_RATE_APER", "MERGED_NET_MFLUX_APER", "MERGED_NET_UMFLUX_APER" ]
             disp = [ "Rate", "Mod.Flux", "Unabs Mod.Flux" ]
 
-            hdr[0] = _lead_fmt.format("{} {}".format( ras, decs ))
+            hdr[0] = _lead_fmt.format("#{:04d}|{} {}".format( srcno, ras, decs ))
             hdr[1] = _lead_fmt.format("  NumObi={:d}".format( vals[bands[0]].get_column("NUM_OBI").values[ii]))
             
             if is_none( myparams.absmodel ):

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -2132,7 +2132,7 @@ def merge_counts( stk_params, myparams):
             cts = merge_get_counts( srcfiles )
             retvals[at_energy]['rates'].append( merge_aprates(cts, rate=True) )
 
-            # TODO: this is wrong for photon fluxes; inconsistent with how per-obi are computed
+            # Note: slightly inconsistent with how per-obi are computed
             # from fluxed images.
             retvals[at_energy]['fluxes'].append( merge_aprates(cts, rate=False) )
 
@@ -2191,7 +2191,7 @@ def merge_write_output( stk_params, myparams, modelflux_vals, merge_fluxes ):
         total_net_rate_hilim = [ float(r['hilimit']) for r in merge_fluxes[at_energy]['rates']]        
 
         total_photflux = [r['value'] for r in merge_fluxes[at_energy]['photfluxes']]
-        total_photflux_cnv = np.array(total_photflux) / np.array(total_net_rate)  # TODO upper limit
+        total_photflux_cnv = np.array(total_photflux) / np.array(total_net_rate)  
         total_photflux_lolim = np.array(total_net_rate_lolim)*total_photflux_cnv
         total_photflux_hilim = np.array(total_net_rate_hilim)*total_photflux_cnv
         
@@ -2714,13 +2714,13 @@ def main():
         summarize_results( myparams, obi=None, single=True )
         return
 
-    #M#merged_fluxes = merge_counts( stk_pars, myparams) 
-    #M#modelflux_vals = merge_modelflux( stk_pars, myparams )
-    #M#merge_write_output( stk_pars, myparams, modelflux_vals, merged_fluxes)
+    merged_fluxes = merge_counts( stk_pars, myparams) 
+    modelflux_vals = merge_modelflux( stk_pars, myparams )
+    merge_write_output( stk_pars, myparams, modelflux_vals, merged_fluxes)
 
     for ii,ss in enumerate(stk_pars):
         summarize_results( ss, obi=ii, single=False )
-    #M#summarize_results( myparams, obi=None, single=False )
+    summarize_results( myparams, obi=None, single=False )
     
     
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -18,8 +18,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
 toolname = "srcflux"
 __revision__ = "29 September 2020"
 

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1,4 +1,4 @@
-#!/export/miniconda/envs/srcflux/bin/python
+#!/usr/bin/env python
 
 #
 # Copyright (C) 2013-2020 Smithsonian Astrophysical Observatory
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "srcflux"
-__revision__ = "12 February 2020"
+__revision__ = "01 July 2020"
 
 import os
 
@@ -1909,16 +1909,28 @@ def merge_modelflux( stk_params, myparams ):
         arf_files = [ p.outroot+"{:04d}_nopsf.arf".format(snum+1) for p in stk_params ]
         rmf_files = [ p.outroot+"{:04d}.rmf".format(snum+1) for p in stk_params ]
 
-        _p = [x for x in pi_files if os.path.exists(x)]
-        if _p is None or 0 == len(_p):
+        p_good=[]
+        a_good=[]
+        r_good=[]
+
+        for p_a_r in zip(pi_files, arf_files, rmf_files):
+            ondisk = [ os.path.exists(x) for x in p_a_r]
+            if all(ondisk) is False:
+                continue
+            p_good.append(p_a_r[0])
+            a_good.append(p_a_r[1])
+            r_good.append(p_a_r[2])
+
+        
+        if p_good is None or 0 == len(p_good):
             for at_energy in bands:
                 outfiles[at_energy]["mflux_cnv"].append(np.nan)
                 outfiles[at_energy]["umflux_cnv"].append(np.nan)
             continue  # next source
 
-        combine_spectra.src_spectra=_p
-        combine_spectra.src_arf=[x for x in arf_files if os.path.exists(x)]
-        combine_spectra.src_rmf=[x for x in rmf_files if os.path.exists(x)]
+        combine_spectra.src_spectra = p_good
+        combine_spectra.src_arf = a_good
+        combine_spectra.src_rmf = r_good
         combine_spectra.outroot = myparams.outroot+"{:04d}".format(snum+1)
         combine_spectra.clobber=True
         vv = combine_spectra()
@@ -2073,9 +2085,11 @@ def merge_aprates( cts, conf, rate=False ):
     wtaf=np.isfinite(pp).all()
 
     if not any(good):
+        delme(outfile.name)
         return badval
     
     if wtaf == False:
+        delme(outfile.name)
         return badval
 
     aprates.n = C

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -2667,7 +2667,7 @@ def obi_main(pars):
         obipars["dtffile"] = infile[5]
 
         if False == is_single_obi:
-            obipars["outroot"] = "{}obi{:03d}".format( pars["outroot"], ii)
+            obipars["outroot"] = "{}obi{:03d}_".format( pars["outroot"], ii)
 
         set_bands(obipars)        
         Params = namedtuple( 'Params', obipars.keys() )

--- a/param/srcflux.par
+++ b/param/srcflux.par
@@ -31,6 +31,7 @@ ecffile,f,h,"CALDB",,,"REEF calibration file"
 parallel,b,h,yes,,,"Run processes in parallel?"
 nproc,i,h,INDEF,,,"Number of processors to use"
 tmpdir,s,h,"${ASCDS_WORK_PATH}",,,"Directory for temporary files"
+random_seed,i,h,-1,,,"PSF random seed, -1: current time"
 clobber,b,h,no,,,"OK to overwrite existing output file?"
 verbose,i,h,1,0,5,"Verbosity level"
 mode,s,h,"ql",,,

--- a/param/srcflux.par
+++ b/param/srcflux.par
@@ -1,7 +1,7 @@
 infile,f,a,"",,,"Input event file"
 pos,s,a,"",,,"Input source position: filename or RA,Dec"
 outroot,f,a,"",,,"Output root name"
-bands,s,h,"broad",,,"Energy bands"
+bands,s,h,"default",,,"Energy bands"
 srcreg,f,h,"",,,"Stack of source regions"
 bkgreg,f,h,"",,,"Stack of background regions"
 #

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -65,7 +65,7 @@
       </PARA>
       <PARA title="Estimating the PSF contribution">
 	The PSF contribution to both the source and background regions
-	can be estimated using one of four methods, controlled by the
+	can be estimated using one of five methods, controlled by the
 	psfmethod argument. Extended sources should use psfmethod=ideal,
 	which makes no correction, or psfmethod=psffile and provide
     an image of the surfrace brightness as the psffile parameter.
@@ -149,7 +149,7 @@ Position                               0.5 - 7.0 keV
 </VERBATIM>
 	  <PARA>
 	    Since source and background regions are not supplied, the script
-	    creates a region that encloses 90% of the PSF at 1.0 keV.
+	    creates a circular region that encloses 90% of the PSF at 1.0 keV.
 	  </PARA>
 <VERBATIM>
 &pr; dmlist rhooph_broad.flux"[cols shape,x,y,r]" data,clean
@@ -530,7 +530,147 @@ Position                               0.5 - 1.2 keV                           1
 	  </PARA>        
 	</DESC>
       </QEXAMPLE>
+
+
+  <QEXAMPLE>
+    <SYNTAX>
+    <LINE>&pr; srcflux "17244/repro/acisf17244_repro_evt2.fits,18681/repro/acisf18681_repro_evt2.fits" \</LINE>
+    <LINE>      pos="9:42:32.2119,+12:20:51.349" psfmethod=quick out=merge_17244_18681/out</LINE>
+    </SYNTAX>
+<DESC>
+  <PARA>
+  This example shows how to combine the photometry for multiple observations.
+  </PARA>
+<VERBATIM>
+srcflux
+          infile = 17244/repro/acisf17244_repro_evt2.fits,18681/repro/acisf18681_repro_evt2.fits
+             pos = 9:42:32.2119,+12:20:51.349
+         outroot = merge_17244_18681/out
+           bands = broad
+          srcreg = 
+          bkgreg = 
+         bkgresp = yes
+       psfmethod = quick
+         psffile = 
+            conf = 0.9
+         binsize = 1
+         rmffile = 
+         arffile = 
+           model = xspowerlaw.pow1
+       paramvals = pow1.PhoIndex=2.0
+        absmodel = xsphabs.abs1
+       absparams = abs1.nH=%GAL%
+           abund = angr
+         fovfile = 
+        asolfile = 
+         mskfile = 
+        bpixfile = 
+         dtffile = 
+         ecffile = CALDB
+        parallel = yes
+           nproc = INDEF
+          tmpdir = /tmp
+         clobber = no
+         verbose = 1
+            mode = ql
+
+Processing OBI 000
+Extracting counts
+Getting net rate and confidence limits
+Getting model independent fluxes 
+Getting model fluxes 
+Getting photon fluxes 
+Running tasks in parallel with 4 processors.
+Running aprates for merge_17244_18681/out_obi0000001_broad_rates.par
+Running eff2evt for merge_17244_18681/out_obi000broad_0001_src.dat
+Running eff2evt for merge_17244_18681/out_obi000broad_0001_bkg.dat
+Making response files for merge_17244_18681/out_obi0000001
+Running modeflux for region 1
+Using GAL=0.032 for source 1
+Adding net rates to output
+Appending flux results onto output
+Appending photflux results onto output
+Computing Net fluxes
+Adding model fluxes to output
+Scaling model flux confidence limits
+Processing OBI 001
+Extracting counts
+Getting net rate and confidence limits
+Getting model independent fluxes 
+Getting model fluxes 
+Getting photon fluxes 
+Running tasks in parallel with 4 processors.
+Running aprates for merge_17244_18681/out_obi0010001_broad_rates.par
+Running eff2evt for merge_17244_18681/out_obi001broad_0001_src.dat
+Running eff2evt for merge_17244_18681/out_obi001broad_0001_bkg.dat
+Making response files for merge_17244_18681/out_obi0010001
+Running modeflux for region 1
+Using GAL=0.032 for source 1
+Adding net rates to output
+Appending flux results onto output
+Appending photflux results onto output
+Computing Net fluxes
+Adding model fluxes to output
+Scaling model flux confidence limits
+Combining count rates
+Combining spectra and running model flux for each source
+Running modeflux for region 1
+Using GAL=0.032 for source 1
+
+
+Summary of source fluxes in OBI 000
+
+      Position                               0.5 - 7.0 keV                           
+                                             Value        90% Conf Interval          
+#0001|9 42 32.21 +12 20 51.3  Rate           0.00262 c/s (0.00204,0.00319)           
+                              Flux           2.85E-14 erg/cm2/s (2.22E-14,3.48E-14)  
+                              Mod.Flux       2.4E-14 erg/cm2/s (1.87E-14,2.93E-14)   
+                              Unabs Mod.Flux 2.53E-14 erg/cm2/s (1.97E-14,3.09E-14)  
+
+
+
+Summary of source fluxes in OBI 001
+
+      Position                               0.5 - 7.0 keV                           
+                                             Value        90% Conf Interval          
+#0001|9 42 32.21 +12 20 51.3  Rate           0.00247 c/s (0.00205,0.00288)           
+                              Flux           2.41E-14 erg/cm2/s (2.01E-14,2.82E-14)  
+                              Mod.Flux       2.26E-14 erg/cm2/s (1.88E-14,2.65E-14)  
+                              Unabs Mod.Flux 2.39E-14 erg/cm2/s (1.99E-14,2.79E-14)  
+
+
+
+Summary of merged source fluxes
+
+      Position                               0.5 - 7.0 keV                           
+                                             Value        90% Conf Interval          
+9 42 32.21 +12 20 51.3        Rate           0.00252 c/s (0.00218,0.00286)           
+  NumObi=2                    Mod.Flux       2.31E-14 erg/cm2/s (2E-14,2.62E-14)     
+                              Unabs Mod.Flux 2.44E-14 erg/cm2/s (2.11E-14,2.76E-14)  
+</VERBATIM>
+
+<PARA>
+    The data for each observation are extracted and calibrated separately.
+    Then the data are combined together to compute the combined (merged)
+    count rate, photon fluxes, and model fluxes.  (Merged model independent, ie 
+    eff2evt fluxes, are not currently computed.)    
+    
+</PARA>
+<PARA>
+  The "NumObi" value reports the number of observations in which the
+  source was imaged.  The output .flux file contains a subset of the
+  per-obsid output .flux files with the column names prefixed with "MERGED".
+</PARA>
+
+</DESC>
+  
+  </QEXAMPLE>
     </QEXAMPLELIST>
+
+
+
+
+
 
     <PARAMLIST>
       <PARAM name="infile" type="file" filetype="input" reqd="yes" stacks="yes">
@@ -545,8 +685,7 @@ Position                               0.5 - 1.2 keV                           1
       <PARA>
         Multiple event files can be input.  The script will 
         iterate over each event file individually, producing the 
-        same set of properties and data products.  The results 
-        are not merged.      
+        same set of properties and data products.  
       </PARA>
 
 
@@ -1132,6 +1271,33 @@ bounds(region(my.reg))
       </PARAM>
     </PARAMLIST>
 
+
+    <ADESC title="Multiple Observations">
+      <PARA>
+        Users can specify a stack of input event files.  srcflux will
+        produce results for each observation separately as well as 
+        computing properties based on the merged products.     
+      </PARA>
+      <PARA>
+      If source and background regions are not supplied, a circle 
+      enclosing  90% of the PSF region at 1keV is computed separately
+      for each observation.  If regions are supplied, users must supply
+      the regions separately for each observation.  So for example, if 
+      there 1 position input but 3 event files, then users need to supply 
+      3 pairs of source and background regions.
+      </PARA>
+
+      <PARA>
+        Absorbed and Unabsorbed model fluxes are computed by combining
+        the ARF and RMF file using the combine_spectra script.
+        Count rates and photon fluxes are computed by running the 
+        aprates tool with the sum of the source and background counts,
+        and weighting by the exposure and PSF fractions.
+      </PARA>
+    </ADESC>
+
+
+
     <ADESC title="PSF Correction">
       <PARA>
 	For extended sources, or when the PSF scattering is being
@@ -1170,7 +1336,8 @@ bounds(region(my.reg))
     <ADESC title="Output files">
       <PARA>
 	This is a list of
-	the column definitions in the output .flux file.
+	the column definitions in the output .flux file created for 
+    each observation.
 	A '*' in the Orig column indicates that the
 	value was computed directly by dmextract.
       </PARA>
@@ -1334,6 +1501,8 @@ bounds(region(my.reg))
 	  &nodmx;
 	  <DATA>Dec of position (decimal degrees)</DATA>
 	</ROW>
+
+
 <!--
 	<ROW>
 	  <DATA>DETX</DATA>
@@ -1597,6 +1766,175 @@ bounds(region(my.reg))
 	  <DATA>Sherpa absorption parameters</DATA>
 	</ROW>
       </TABLE>
+
+
+    <PARA>
+    If multiple event files are supplied, then the results are combined
+    together into a merged .flux file.  It contains the following columns:
+    
+    </PARA>
+
+
+    <TABLE>
+    <ROW>
+	  <DATA>Name</DATA>
+	  <DATA>Description</DATA>
+    </ROW>
+<ROW>
+<DATA>RAPOS</DATA>
+<DATA>Right Ascension of source location </DATA>
+</ROW>
+<ROW>
+<DATA>DECPOS</DATA>
+<DATA>Declination of source location</DATA>
+</ROW>
+<ROW>
+<DATA>COMPONENT</DATA>
+<DATA>integer number identifying region number</DATA>
+</ROW>
+<ROW>
+<DATA>TOTAL_COUNTS</DATA>
+<DATA>Sum of counts in source region from all observations</DATA>
+</ROW>
+<ROW>
+<DATA>TOTAL_BG_COUNTS</DATA>
+<DATA>Sum of counts in background region from all observations</DATA>
+</ROW>
+<ROW>
+<DATA>NUM_OBI</DATA>
+<DATA>Number of observations the source falls within the Field-of-View</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_RATE_APER</DATA>
+<DATA>The merged net rate computed from total counts</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_RATE_APER_LO</DATA>
+<DATA>Lower confidence level of merged net rate computed using
+aprates, the total counts, and exposure weighted PSFs</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_RATE_APER_HI</DATA>
+<DATA>Same as previous for the upper confidence level.</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_RATE_AREASCAL</DATA>
+<DATA>The exposure-time and PSF weighted area scaling factor</DATA>
+</ROW>
+<ROW>
+<DATA>PSF_WEIGHTED_TOTAL_EXPOSURE_TIME</DATA>
+<DATA>Exposure time weighted by PSF fraction</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_APRATES_PHOTFLUX_APER</DATA>
+<DATA>Net photon flux computed using aprates and mean exposure-map
+values.  This is different from the per-observation photon flux values
+which are computed by summing pixels in the exposure weighted (fluxed)
+images.
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_APRATES_PHOTFLUX_APER_LO</DATA>
+<DATA>
+    The aprates_photflux lower confidence level 
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_APRATES_PHOTFLUX_APER_HI</DATA>
+<DATA>    The aprates_photflux upper confidence level 
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_PHOTFLUX_AREASCAL</DATA>
+<DATA>The area scaling weighted by expoure map and PSF fraction.</DATA>
+</ROW>
+<ROW>
+<DATA>PSF_WEIGHTED_TOTAL_SRC_EXPOSURE</DATA>
+<DATA>Weighted sum of exposure map pixels in the source region scaled by the 
+PSF fraction.
+</DATA>
+</ROW>
+<ROW>
+<DATA>PSF_WEIGHTED_TOTAL_BG_EXPOSURE</DATA>
+<DATA>Same as above for the background region.
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_PHOTFLUX_APER</DATA>
+<DATA>
+The merged net photon flux by weighted averaging the per-observation values.
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_PHOTFLUX_APER_LO</DATA>
+<DATA>The lower confidence value on the net photon flux computed by scaling
+the net rate errors.
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_PHOTFLUX_APER_HI</DATA>
+<DATA>Same as above for the upper confidence value.
+</DATA>
+</ROW>
+<ROW>
+<DATA>MFLUX_CNV</DATA>
+<DATA>The absorbed model flux conversion factor obtained by running
+modelflux on the combined ARF and RMF.
+</DATA>
+</ROW>
+<ROW>
+<DATA>UMFLUX_CNV</DATA>
+<DATA>same as above for the unabsorbed model
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_MFLUX_APER</DATA>
+<DATA>The net rate scaled by the model-dependent, absorbed model conversion
+factor (MFLUX_CNV).
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_MFLUX_APER_LO</DATA>
+<DATA>Same as above for the lower confidence limit
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_MFLUX_APER_HI</DATA>
+<DATA>Same as above for the upper confidence limit.
+</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_UMFLUX_APER</DATA>
+<DATA>Same as the MERGED_NET_MFLUX_APER, but for just the unabsorbed 
+model component</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_UMFLUX_APER_LO</DATA>
+<DATA>Same as above for the lower confidence limit</DATA>
+</ROW>
+<ROW>
+<DATA>MERGED_NET_UMFLUX_APER_HI</DATA>
+<DATA>Same as above for the upper confidence limit</DATA>
+</ROW>
+<ROW>
+<DATA>TOTAL_FLUX_APER</DATA>
+<DATA>Total exposure weighted model-independent, ie eff2evt, flux in
+the source region.</DATA>
+</ROW>
+<ROW>
+<DATA>TOTAL_BG_FLUX_APER</DATA>
+<DATA>Same as above for the background region.
+</DATA>
+</ROW>
+    
+    
+    
+    </TABLE>
+
+
+
+
+
     </ADESC>
 
     <ADESC title="Processing steps">

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -987,6 +987,13 @@ bounds(region(my.reg))
 	    created with ChaRT or MARX.  The filenames are then supplied via the
 	    psffile parameter.
 	    </ITEM> 
+        <ITEM>marx: allows the use to run MARX to simulate the PSF at the
+        source location at the characteristic energy for the energy band. 
+        This runs the simulate_psf script, which requires that users have
+        already setup to use MARX and specifically that the MARX_ROOT
+        environment variable is set to the root directory of the MARX installation.        
+        </ITEM>
+
 	  </LIST>
 	</DESC>        
       </PARAM>
@@ -2088,7 +2095,7 @@ the source region.</DATA>
     </ADESC>
 
 
-    <ADESC title="Changes in the script 4.12.3 (July 2020) release">
+    <ADESC title="Changes in the script 4.13.1 (December 2020) release">
       <PARA title="Merged Outputs">
         When multiple event files are specified, users will now also
         get a flux estimate from all the observations combined.  Currently

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -91,7 +91,7 @@ srcflux
           infile = acisf00635_repro_evt2.fits
              pos = 16:27:33.115 -24:41:15.51
          outroot = rhooph
-           bands = broad
+           bands = default
           srcreg = 
           bkgreg = 
          bkgresp = yes
@@ -813,7 +813,7 @@ Summary of merged source fluxes
 
 	</DESC>        
       </PARAM>
-      <PARAM name="bands" type="string" reqd="no" stacks="yes" def="broad" units="keV">
+      <PARAM name="bands" type="string" reqd="no" stacks="yes" def="default" units="keV">
 	<SYNOPSIS>Energy bands and characteristic energy value</SYNOPSIS>
 	<DESC>
 	  <PARA>
@@ -857,14 +857,19 @@ Summary of merged source fluxes
 		</ROW>
 	  </TABLE>
 	  
-	  <PARA title="CSC">
+      <PARA title="default"> 
+        The value "default" will select band="broad" for ACIS datasets
+        and band="wide" for HRC datasets.      
+      </PARA>
+      
+	  <PARA title="csc">
 	    The value "csc" can be used as a short form for the
 	    combination of "soft,medium,hard".
 	  </PARA>
       <PARA title="wide">
-        The "wide" energy band can only be used with HRC.
-      </PARA>
-        
+        HRC data can only use the "wide" energy band.  Using the default
+        band="default" will automatically select the wide energy band.
+      </PARA>        
 	  <PARA title="Explicit ranges">
 	    If you want to use different values to those of the CSC then
 	    you can use the format lo:hi:eff - where lo, hi and eff
@@ -2235,6 +2240,6 @@ the source region.</DATA>
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>February 2020</LASTMODIFIED>
+    <LASTMODIFIED>June 2020</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -1302,10 +1302,8 @@ bounds(region(my.reg))
       <PARA>
       If source and background regions are not supplied, a circle 
       enclosing  90% of the PSF region at 1keV is computed separately
-      for each observation.  If regions are supplied, users must supply
-      the regions separately for each observation.  So for example, if 
-      there 1 position input but 3 event files, then users need to supply 
-      3 pairs of source and background regions.
+      for each observation.  If regions are supplied, the same regions are 
+      used for each input event file.      
       </PARA>
 
       <PARA>

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -1268,6 +1268,22 @@ bounds(region(my.reg))
 	<SYNOPSIS>Directory for temporary files</SYNOPSIS>
       </PARAM>
 
+          <PARAM name="random_seed" type="integer" def="-1" reqd="no">
+            <SYNOPSIS>
+              Initial random seed for PSF simulations. It is passed to the 
+              simulate_psf tool when  psfmethod=marx.
+            </SYNOPSIS>
+            <DESC>
+              <PARA>
+                The random_seed is set to initialize the simulation.  
+                With random_seed equal to the default value of -1, the
+                script will use a random value for the
+                initial random_seed.
+              </PARA>
+            </DESC>
+          </PARAM>
+
+
       <PARAM name="clobber" type="boolean" def="no">
 	<SYNOPSIS>Overwrite existing files?</SYNOPSIS>
       </PARAM>
@@ -2022,7 +2038,8 @@ the source region.</DATA>
 
 
       <PARA title="Using with Merged Datasets">
-	Users should not use this script with merged datasets.
+	Users should not use this script with merged datasets; rather they should 
+    supply the individual observations separately.
 	Users should review the material on
 	<HREF link="https://cxc.harvard.edu/ciao/caveats/merged_events.html">
 	  Extracting spectra from Merged Datasets
@@ -2030,10 +2047,6 @@ the source region.</DATA>
 	regarding
 	the issues of trying to extract and fit a spectra from
 	a merged observation as they apply directly to this script.
-	To summarize, while it is trivial to simply combine the
-	counts, even something as simple as NET_COUNTS is
-	problematic if the source was observed on different
-	CCD's.
       </PARA>
       
       <PARA title="Gratings"> 
@@ -2074,6 +2087,34 @@ the source region.</DATA>
       </PARA>
 
     </ADESC>
+
+
+    <ADESC title="Changes in the script 4.12.3 (July 2020) release">
+      <PARA title="Merged Outputs">
+        When multiple event files are specified, users will now also
+        get a flux estimate from all the observations combined.  Currently
+        model independent fluxes are not combined; but rates, photon fluxes,
+        and model fluxes (absorbed and unabsorbed) are computed.  
+        Uncertainties are computed using the aprates tool.  Variable 
+        sources will likely yield incorrect flux estimates.      
+      </PARA>
+    
+      <PARA title="Other">
+        In addition the energy band parameter has been changed to 
+        band=default.  This allows both ACIS (default is broad band)
+        and HRC (default is wide band) to work without explicitly 
+        changing this parameter.      
+      </PARA>
+      <PARA>
+        A new random_seed parameter has been added which is passed to 
+        the simulate_psf script when psfmethod=marx.  The default random_seed=-1
+        will use the current time to seed the random stream.
+      </PARA>
+      
+    
+    </ADESC>
+
+
 
 
     <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -546,7 +546,7 @@ srcflux
           infile = 17244/repro/acisf17244_repro_evt2.fits,18681/repro/acisf18681_repro_evt2.fits
              pos = 9:42:32.2119,+12:20:51.349
          outroot = merge_17244_18681/out
-           bands = broad
+           bands = default
           srcreg = 
           bkgreg = 
          bkgresp = yes
@@ -570,21 +570,22 @@ srcflux
         parallel = yes
            nproc = INDEF
           tmpdir = /tmp
-         clobber = no
+     random_seed = -1
+         clobber = yes
          verbose = 1
             mode = ql
 
-Processing OBI 000
+Processing OBI 001
 Extracting counts
 Getting net rate and confidence limits
 Getting model independent fluxes 
 Getting model fluxes 
 Getting photon fluxes 
 Running tasks in parallel with 4 processors.
-Running aprates for merge_17244_18681/out_obi0000001_broad_rates.par
-Running eff2evt for merge_17244_18681/out_obi000broad_0001_src.dat
-Running eff2evt for merge_17244_18681/out_obi000broad_0001_bkg.dat
-Making response files for merge_17244_18681/out_obi0000001
+Running aprates for merge_17244_18681/out_obi001_0001_broad_rates.par
+Running eff2evt for merge_17244_18681/out_obi001_broad_0001_src.dat
+Running eff2evt for merge_17244_18681/out_obi001_broad_0001_bkg.dat
+Making response files for merge_17244_18681/out_obi001_0001
 Running modeflux for region 1
 Using GAL=0.032 for source 1
 Adding net rates to output
@@ -593,17 +594,17 @@ Appending photflux results onto output
 Computing Net fluxes
 Adding model fluxes to output
 Scaling model flux confidence limits
-Processing OBI 001
+Processing OBI 002
 Extracting counts
 Getting net rate and confidence limits
 Getting model independent fluxes 
 Getting model fluxes 
 Getting photon fluxes 
 Running tasks in parallel with 4 processors.
-Running aprates for merge_17244_18681/out_obi0010001_broad_rates.par
-Running eff2evt for merge_17244_18681/out_obi001broad_0001_src.dat
-Running eff2evt for merge_17244_18681/out_obi001broad_0001_bkg.dat
-Making response files for merge_17244_18681/out_obi0010001
+Running aprates for merge_17244_18681/out_obi002_0001_broad_rates.par
+Running eff2evt for merge_17244_18681/out_obi002_broad_0001_src.dat
+Running eff2evt for merge_17244_18681/out_obi002_broad_0001_bkg.dat
+Making response files for merge_17244_18681/out_obi002_0001
 Running modeflux for region 1
 Using GAL=0.032 for source 1
 Adding net rates to output
@@ -618,7 +619,7 @@ Running modeflux for region 1
 Using GAL=0.032 for source 1
 
 
-Summary of source fluxes in OBI 000
+Summary of source fluxes in OBI 001
 
       Position                               0.5 - 7.0 keV                           
                                              Value        90% Conf Interval          
@@ -629,7 +630,7 @@ Summary of source fluxes in OBI 000
 
 
 
-Summary of source fluxes in OBI 001
+Summary of source fluxes in OBI 002
 
       Position                               0.5 - 7.0 keV                           
                                              Value        90% Conf Interval          
@@ -644,7 +645,7 @@ Summary of merged source fluxes
 
       Position                               0.5 - 7.0 keV                           
                                              Value        90% Conf Interval          
-9 42 32.21 +12 20 51.3        Rate           0.00252 c/s (0.00218,0.00286)           
+#0001|9 42 32.21 +12 20 51.3  Rate           0.00252 c/s (0.00218,0.00286)           
   NumObi=2                    Mod.Flux       2.31E-14 erg/cm2/s (2E-14,2.62E-14)     
                               Unabs Mod.Flux 2.44E-14 erg/cm2/s (2.11E-14,2.76E-14)  
 </VERBATIM>


### PR DESCRIPTION
The code to compute merged fluxes has been around for a while but has not been enabled (commented out).  This update enables this code; so now when users supply multiple event files they will also get an estimate of the combined flux.

This update also includes the parameter change to set the energy band to default, and to add the random_seed parameter so we can control the simulate_psf (psfmethod=marx) output.

This fixes : #384   #381  #399 #414 
