### PR TITLE
check_ciao_caldb: handle new DET_GAIN indexing CALDB 4.9.2

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,6 +1,18 @@
-## ? ##
+## 4.12.3 - July 2020 ##
 
 Updated scripts
+
+  check_ciao_caldb
+
+    The script has been updated to handle changes to the way that the
+    ACIS DET_GAIN file is indexed in CALDB 4.9.2. This file is used in
+    a check that the CALDB is set up correctly. Users who run an old
+    version of the script with CALDB 4.9.2 or later will see the
+    following warning when check_ciao_caldb is run:
+
+    WARNING: 2 matches found for DET_GAIN query, expected only 1.
+     match = /soft/ciao/CALDB/data/chandra/acis/det_gain/acisD2000-01-29gain_ctiN0008.fits[1]
+     match = /soft/ciao/CALDB/data/chandra/acis/det_gain/acisD2000-01-29gain_ctiN0008.fits[1]
 
   check_ciao_version
 

--- a/bin/check_ciao_caldb
+++ b/bin/check_ciao_caldb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-Copyright (C) 2009-2011, 2015, 2019
+Copyright (C) 2009-2011, 2015, 2019, 2020
           Smithsonian Astrophysical Observatory
 
 
@@ -43,7 +43,7 @@ Aim:
 """
 
 toolname = "check_ciao_caldb"
-version = "21 November 2019"
+version = "01 July 2020"
 
 import os
 import time
@@ -137,10 +137,13 @@ def check_caldb_query(caldb, caldbver):
     cdb.FP_TEMP = (153, "K")
     cdb.OBS_MODE = "POINTING"
 
+    # The "DATE-OBD" field is needed by changes made in CALDB 4.9.2
+    cdb.start = "2020-07-01"
+
     # cdb.GRATTYPE = ""
 
     for (key, unit) in cdb.allneeded:
-        if key not in ["GRATTYPE", "start", "stop"]:
+        if key not in ["GRATTYPE", "stop"]:
             print("WARNING: the script needs updating to set the {0} parameter; please contact the CXC helpdesk!".format(key))
 
     files = cdb.search

--- a/share/doc/xml/check_ciao_caldb.xml
+++ b/share/doc/xml/check_ciao_caldb.xml
@@ -28,10 +28,10 @@
 	The tool only tests the basic installation, and so
 	provides a quick and easy test.
 	It does not
-	perform the same verification steps as 
-	either the 
+	perform the same verification steps as
+	either the
 	calvalid tool from CIAO (see "ahelp calvalid")
-	or the 
+	or the
 	the chkcif
 	tool from the FTOOLS package (as described on the
 	<HREF link="https://cxc.harvard.edu/caldb/downloads/index.html#dl_verify">Download the CIAO
@@ -50,7 +50,7 @@
 	are any newer versions of the CALDB available. This step requires
 	internet access. If a newer version is available then see the
 	<HREF link="https://cxc.harvard.edu/caldb/downloads">CALDB downloads
-	page</HREF> or the 
+	page</HREF> or the
 	<HREF link="https://cxc.harvard.edu/ciao/threads/ciao_install_tool/">ciao_install
 	thread</HREF>.
       </PARA>
@@ -109,7 +109,7 @@ ERROR: The latest available CALDB version is &lt;latest version&gt;
 	</DESC>
       </QEXAMPLE>
     </QEXAMPLELIST>
-    
+
     <ADESC title="What is checked?">
       <PARA>
 	The script is intended to provide a simple check of the CALDB installation,
@@ -130,10 +130,27 @@ ERROR: The latest available CALDB version is &lt;latest version&gt;
       </PARA>
       <PARA title="Version check">
 	The --latest flag causes the script to look at the
-	<HREF link="https://cxc.harvard.edu/caldb/downloads/releasenotes.html">CALDB release 
+	<HREF link="https://cxc.harvard.edu/caldb/downloads/releasenotes.html">CALDB release
 	notes</HREF> page to look for the latest version released for CIAO,
 	and this value is compared against the version of the local CALDB
 	installation.
+      </PARA>
+    </ADESC>
+
+    <ADESC title="Changes in the scripts 4.12.3 (July 2020) release">
+      <PARA>
+	The script has been updated to handle a change in how the CALDB indexes
+	the ACIS DET_GAIN files, as this is used as a query to check the installation
+	is correct. Users with old versions of the script will see the warning
+	message:
+      </PARA>
+<VERBATIM>
+WARNING: 2 matches found for DET_GAIN query, expected only 1.
+ match = /soft/ciao/CALDB/data/chandra/acis/det_gain/acisD2000-01-29gain_ctiN0008.fits[1]
+ match = /soft/ciao/CALDB/data/chandra/acis/det_gain/acisD2000-01-29gain_ctiN0008.fits[1]
+</VERBATIM>
+      <PARA>
+	when running the script.
       </PARA>
     </ADESC>
 
@@ -161,7 +178,7 @@ ERROR: The latest available CALDB version is &lt;latest version&gt;
 	on the CIAO website for an up-to-date listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>December 2018</LASTMODIFIED>
+    <LASTMODIFIED>July 2020</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Without the fix users with CALDB 4.9.2 or later will see a
warning about returning multiple files for DET_GAIN (even if
it appears to be the same file).