### PR TITLE
roi utilities

### DIFF
--- a/bin/rank_roi
+++ b/bin/rank_roi
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2020 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"Assign overlapping region area based on selected metric"
+
+import os
+import sys
+
+from region import CXCRegion
+from pycrates import read_file, IMAGECrate
+from ciao_contrib.runtool import make_tool
+import ciao_contrib.logger_wrapper as lw
+
+
+toolname = "rank_roi"
+__revision__ = "10 June 2020"
+
+lw.initialize_logger(toolname)
+lgr = lw.get_logger(toolname)
+verb0 = lgr.verbose0
+verb1 = lgr.verbose1
+verb2 = lgr.verbose2
+
+"""
+The way the roi tool works, specifically when using
+
+    group=exclude
+
+is that all overlaping area is ignored.  So if  file 1 has :
+circleA - EllipseB, the there will be another file with
+EllipseB - circleA.  The overlap area between A and B is omitted.
+
+The goal of this script is to assign that overlap area to the
+"best" source.  Here we define "best" as the source with the largest
+number of counts.
+
+    Note: "best" could also be defined as the faintest, biggest,
+    smallest, roundest, ... limitless options
+
+We know that the 1st shape in the SRCREG extension is "the" shape
+from which any overlapping shapes are excluded and FOV's intersected.
+
+Thankfully, the way roi works, this 1st shape is identically
+replicated in other roi files where it is excluded.  So if
+we know that circleA in both files is exactly the same (no
+string truncation nonsense).
+"""
+
+
+class ROIFile():
+    """Hold the contents of a single ROI output file"""
+
+    def __init__(self, filename, out_template):
+        """init class from a single roi file
+
+        The 1st shape, `self.region[0]`, is the shape-of-interest
+        for this ROIFile object.
+        """
+        self.filename = filename
+        self.region = CXCRegion(filename)
+        self.roi = self.region[0]
+        self.metric = None
+        self.del_other = []
+        _cr = read_file(filename)
+
+        self.regionid = int(_cr.get_key_value("REGIONID").lstrip("0"))
+        self.outfile = out_template.format(self.regionid)
+
+    def run_dmstat(self, propfile):
+        """Run dmstat
+
+        This is common to most of the metrics"""
+        self.dmstat = make_tool("dmstat")
+        self.dmstat.infile = "{}[sky={}]".format(propfile, self.roi)
+        self.dmstat(centroid=False)
+
+    def compute_metric(self, propfile):
+        """Compute some metric for shape of interest"""
+        raise NotImplementedError("Implement in the subclasses")
+
+    def remove_from(self, other):
+        """Determine if self should get overlap area or
+        release it to another shape
+
+        The easiest way to do this is to identify which indices
+        the other shape is located at and translate that into
+        a DM #row filter.
+        """
+        # skip self
+        if other.roi == self.roi:
+            return
+
+        # skip if other is bigger
+        if other.metric > self.metric:
+            return
+
+        # remove all instances of other from self.  With fov files
+        # the roi file may have multiple instances of other.roi, be
+        # sure to remove them all.
+        idx = self.region.index(~other.roi)
+        self.del_other.extend(idx)
+
+    def write(self, pars):
+        """Write out a new roi file by copying selected rows from
+        the input.
+
+        This turns out to be a lot easier than trying to copy
+        header, history, wcs's from input to output.
+        """
+        dmcopy = make_tool("dmcopy")
+
+        if len(self.del_other) > 0:
+            # +1: array index -> dm row number
+            rr = ", ".join([str(x+1) for x in self.del_other])
+            ff = "{}[exclude #row={}]"
+            ff = ff.format(self.filename, rr)
+        else:
+            ff = self.filename
+
+        dmcopy(ff, self.outfile, clobber=pars["clobber"], opt="all")
+
+        from ciao_contrib.runtool import add_tool_history
+        add_tool_history(self.outfile, toolname, pars,
+                         toolversion=__revision__)
+
+
+class MostFlux(ROIFile):
+    """
+    The metric we're using the sum of the pixel values in region.
+    This can be counts (or could be say photon flux).
+    """
+    def compute_metric(self, propfile):
+        self.run_dmstat(propfile)
+        self.metric = float(self.dmstat.out_sum)
+
+
+class LeastFlux(ROIFile):
+    """
+    The metric we're using the sum of the pixel values in region.
+    This can be counts (or could be say photon flux).
+    """
+    def compute_metric(self, propfile):
+        self.run_dmstat(propfile)
+        self.metric = -1.0*float(self.dmstat.out_sum)
+
+
+class BrightestPixel(ROIFile):
+    """Pick region with brighest pixel
+    """
+    def compute_metric(self, propfile):
+        self.run_dmstat(propfile)
+        self.metric = float(self.dmstat.out_max)
+
+
+class FaintestPixel(ROIFile):
+    """Pick region with most faint max pixel
+    """
+    def compute_metric(self, propfile):
+        self.run_dmstat(propfile)
+        self.metric = -1.0*float(self.dmstat.out_max)
+
+
+class LargestArea(ROIFile):
+    """Pick region with most area
+    """
+    def compute_metric(self, propfile):
+        self.metric = self.roi.area()
+
+
+class SmallestArea(ROIFile):
+    """Pick region with least area
+    """
+    def compute_metric(self, propfile):
+        self.metric = -1.0*self.roi.area()
+
+
+def map_metric(func):
+    """Map string to object type"""
+    retval = {'min': LeastFlux, 'max': MostFlux,
+              'bright': BrightestPixel, 'faint': FaintestPixel,
+              'big': LargestArea, 'small': SmallestArea, }
+    return retval[func]
+
+
+def load_rois(pars):
+    'Load all roi files'
+    verb1("Loading ROI files")
+    import stk
+    rois = stk.build(pars["roifiles"])
+
+    metric = map_metric(pars["method"])
+    rois_reg = [metric(r, pars["outfile"]) for r in rois]
+    verb1("{} ROI files parsed".format(len(rois_reg)))
+    return rois_reg
+
+
+def clobber_outfiles(pars, rois_reg):
+    'Remove outfiles'
+    verb1("Checking clobber")
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    pars["clobber"] = ("yes" == pars["clobber"])
+    for r in rois_reg:
+        outfile_clobber_checks(pars["clobber"], r.outfile)
+
+
+def compute_metric(pars, rois_reg):
+    'Compute roi metric'
+    verb1("Checking infile (image v. table)")
+    infile = pars["infile"]
+    oo = read_file(infile)
+    if isinstance(oo, IMAGECrate) is not True:
+        infile = infile+"[bin sky]"
+        verb1("Infile is a table, will bin into an image")
+    verb1("Computing metric for all ROIs")
+    for r in rois_reg:
+        r.compute_metric(infile)
+        verb2("region {}\tmetric {}".format(r.regionid, r.metric))
+
+
+def pick_winner(rois_reg):
+    'Determine which roi is best'
+    verb1("Determining which ROIs should get overlap area")
+    for r in rois_reg:
+        for k in rois_reg:
+            k.remove_from(r)
+
+
+def write_outputs(pars, rois_reg):
+    'Write output'
+    verb1("Writing out new roi files")
+    for r in rois_reg:
+        r.write(pars)
+
+
+@lw.handle_ciao_errors(toolname, __revision__)
+def main():
+    'main program'
+
+    from ciao_contrib.param_soaker import get_params
+    pars = get_params(toolname, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
+
+    rois_reg = load_rois(pars)
+    clobber_outfiles(pars, rois_reg)
+    compute_metric(pars, rois_reg)
+    pick_winner(rois_reg)
+    write_outputs(pars, rois_reg)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as E:
+        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n",
+              file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)

--- a/bin/regphystocel
+++ b/bin/regphystocel
@@ -48,6 +48,12 @@ class PhysicalRegion(object):
     def read_region(self, infile, text, tags):
         "Load region"
         from region import CXCRegion
+
+        if "'" in infile:
+            raise ValueError("ERROR: Found \"'\" in region string; make sure radii are in physical pixels")
+        if '"' in infile:
+            raise ValueError("ERROR: Found '\"' in region string; make sure radii are in physical pixels")
+
         self.physical_region = CXCRegion(infile)
         self.load_tags_and_text( infile, text, tags )
 
@@ -246,15 +252,19 @@ class PhysicalRegion(object):
 
     def write(self, outfile, clobber=True):
         """Write output"""
-        from ciao_contrib._tools.fileio import outfile_clobber_checks
-        outfile_clobber_checks(clobber, outfile)
+        
+        if outfile == "-":
+            fp = sys.stdout
+        else:
+            from ciao_contrib._tools.fileio import outfile_clobber_checks
+            outfile_clobber_checks(clobber, outfile)
+            fp=open(outfile, "w")
 
-        with open(outfile, "w") as fp:
-            fp.write('# Region file format: DS9 version 4.1\n')
-            fp.write('global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n')
-            fp.write('fk5\n')
-            fp.write(self.cel_region_str)
-            fp.write("\n")
+        fp.write('# Region file format: DS9 version 4.1\n')
+        fp.write('global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n')
+        fp.write('fk5\n')
+        fp.write(self.cel_region_str)
+        fp.write("\n")
 
 
 @lw.handle_ciao_errors(toolname, __revision__)

--- a/bin/regphystocel
+++ b/bin/regphystocel
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2020 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"Covert region from physical to celestial coordinates"
+
+import sys
+import ciao_contrib.logger_wrapper as lw
+
+toolname = "regphystocel"
+__revision__ = "05 Aug 2020"
+
+lw.initialize_logger(toolname)
+lgr = lw.get_logger(toolname)
+verb0 = lgr.verbose0
+verb1 = lgr.verbose1
+verb2 = lgr.verbose2
+
+
+class PhysicalRegion(object):
+    """Physical Region object"""
+
+    def __init__(self, infile, wcsfile):
+        """Load region and get wcs xfrom"""
+        self.read_region(infile)
+
+        if len(wcsfile)>0 and wcsfile.lower() != "none":
+            self.get_xform(wcsfile)
+        else:
+            self.get_xform(infile)
+
+    def read_region(self, infile):
+        "Load region"
+        from region import CXCRegion
+        self.physical_region = CXCRegion(infile)
+
+    def get_xform(self, infile):
+        "Get WCS transform: try eqpos then eqsrc, then barf"
+        from pycrates import read_file, get_transform
+        input_table = read_file(infile)
+
+        try:
+            self.xform = get_transform(input_table, "eqpos")
+        except ValueError as missing_col:
+            if 'does not exist' not in str(missing_col):
+                raise missing_col
+            try:
+                self.xform = get_transform(input_table, "eqsrc")
+            except ValueError as missing_col:
+                if 'does not exist' not in str(missing_col):
+                    raise missing_col
+                else:
+                    raise IOError("Could not find EQPOS nor EQSRC coordinate transform in '{}'".format(infile))
+
+        delta = [x.get_value() for x in self.xform.get_parameter_list()
+                 if "delt" in x.get_name().lower()]
+
+        if len(delta) == 0:
+            raise RuntimeError("Cannot find CDELT transform parameter in {}".format(infile))
+
+        if abs(delta[0][0]) != abs(delta[0][1]):
+            raise RuntimeError("Must have same X and Y pixel size (square pixels)")
+
+        self.delta = abs(delta[0][0])*3600.0      # arcsec
+
+    @staticmethod
+    def trim_coordinate(coord, digits=5):
+        """Remove excess precision"""
+        dot = coord.index(".")
+        return coord[:dot+digits]
+
+    @staticmethod
+    def write_shape(inc, shape, pos, rad, angle):
+        """Write string based on shape name"""
+        retval = "{}{}({}".format(inc, shape, pos)
+
+        if shape in ['point', 'polygon']:
+            retval = retval + ")"
+        elif shape in ['circle', 'box', 'annulus']:
+            retval = retval + ",{})".format(rad)
+        elif shape in ['ellipse', 'rotbox']:
+            retval = retval+",{},{})".format(rad, angle)
+        elif shape in ['field', 'pie', 'sector']:
+            verb0("Skipping {}".format(shape))
+            retval = None
+        else:
+            raise ValueError("Unsupported shape {}".format(shape))
+
+        return retval
+
+    def process_position(self, shape):
+        """Convert position from physical to celestial in HMS"""
+
+        from coords.format import deg2ra, deg2dec
+
+        pos = list(zip(shape.xpoints, shape.ypoints))
+        radec = self.xform.apply(pos)
+
+        cel = []
+        for rd in radec:
+            _r = deg2ra(rd[0], ":")
+            _r = self.trim_coordinate(_r)
+
+            _d = deg2dec(rd[1], ":")
+            _d = self.trim_coordinate(_d)
+
+            _c = "{},{}".format(_r, _d)
+            if _c.index(":") == 1:
+                _c = '0'+_c         # Add a leading 0, looks better IMO
+            cel.append(_c)
+
+        cel = ",".join(cel)
+        return cel
+
+    def process_radii(self, shape):
+        """Convert radii from phys pixels to arcsec"""
+        rr = shape.radii
+        if rr is not None:
+            rr = rr * self.delta
+            rr = ['{:g}"'.format(x) for x in rr]
+            rr = ",".join(rr)
+        return rr
+
+    def process_angles(self, shape):
+        """Process angles, just convert to str"""
+        aa = shape.angles
+        if aa is not None:
+            aa = ['{:g}'.format(x) for x in aa]
+            aa = ",".join(aa)
+        return aa
+
+    def process_shape(self, shape):
+        """Convert shape parameters to celestial notation"""
+
+        shape_name = shape.name.lower()
+        if shape_name not in ['circle', 'box', 'rotbox', 'ellipse',
+                              'polygon', 'rectangle', 'point']:
+            verb0("Skipping unsupported shape={}".format(shape_name))
+            return None
+
+        inc = "-" if shape.include.str == "!" else ""
+        cel = self.process_position(shape)
+        rr = self.process_radii(shape)
+        aa = self.process_angles(shape)
+
+        cel_region = self.write_shape(inc, shape_name, cel, rr, aa)
+        return cel_region
+
+    def run(self):
+        """Loop over all shapes in the region """
+        doit = map(self.process_shape, self.physical_region.shapes)
+        valid = [x for x in doit if x is not None]
+        self.cel_region_str = "\n".join(valid)
+
+    def write(self, outfile, clobber=True):
+        """Write output"""
+        from ciao_contrib._tools.fileio import outfile_clobber_checks
+        outfile_clobber_checks(clobber, outfile)
+
+        with open(outfile, "w") as fp:
+            fp.write('# Region file format: DS9 version 4.1\n')
+            fp.write('global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n')
+            fp.write('fk5\n')
+            fp.write(self.cel_region_str)
+            fp.write("\n")
+
+
+@lw.handle_ciao_errors(toolname, __revision__)
+def main():
+    'doit'
+
+    from ciao_contrib.param_soaker import get_params
+    pars = get_params(toolname, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
+
+    pr = PhysicalRegion(pars["infile"], pars["wcsfile"])
+    pr.run()
+    pr.write(pars["outfile"], pars["clobber"])
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/regphystocel
+++ b/bin/regphystocel
@@ -23,7 +23,7 @@ import sys
 import ciao_contrib.logger_wrapper as lw
 
 toolname = "regphystocel"
-__revision__ = "05 Aug 2020"
+__revision__ = "14 Aug 2020"
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -31,27 +31,94 @@ verb0 = lgr.verbose0
 verb1 = lgr.verbose1
 verb2 = lgr.verbose2
 
+from pycrates import read_file, get_transform
 
 class PhysicalRegion(object):
     """Physical Region object"""
 
-    def __init__(self, infile, wcsfile):
+    def __init__(self, infile, wcsfile, text, tags):
         """Load region and get wcs xfrom"""
-        self.read_region(infile)
+        self.read_region(infile, text, tags)
 
         if len(wcsfile)>0 and wcsfile.lower() != "none":
             self.get_xform(wcsfile)
         else:
             self.get_xform(infile)
 
-    def read_region(self, infile):
+    def read_region(self, infile, text, tags):
         "Load region"
         from region import CXCRegion
         self.physical_region = CXCRegion(infile)
+        self.load_tags_and_text( infile, text, tags )
+
+
+    def load_tags(self, tab, tags):
+        "Tags, aka groups in ds9"
+
+        num_shapes = len(self.physical_region.shapes)
+
+        self.tags = [""]*num_shapes
+        for tag in tags:
+            if tab.key_exists(tag):
+                tagvals = " tag={{{}={}}}".format(tag,tab.get_key_value(tag))
+                tagvals = [tagvals]*num_shapes
+            elif tab.column_exists(tag):
+                tagvals = [" tag={{{}={}}}".format(tag,x) for x in tab.get_column(tag).values]
+            else:
+                verb0("Could not find key or column '{}' for tags attribute".format(tag))
+                tagvals = [""]*num_shapes
+
+            for ii in range(num_shapes):
+                self.tags[ii] = self.tags[ii]+tagvals[ii]
+
+
+    def load_text(self, tab, text):
+        "Text to display above shapes"
+
+        num_shapes = len(self.physical_region.shapes)
+        if tab.key_exists(text):
+            self.text = "text={{{}}}".format(tab.get_key_value(text))
+            self.text = [self.text]*num_shapes
+        elif tab.column_exists(text):
+            self.text = [ "text={{{}}}".format(x) for x in tab.get_column(text).values ]
+        else:
+            verb0("Could not find key or column '{}' for text attribute".format(text))
+            self.text = None
+
+
+    def load_tags_and_text(self, infile, text, tags):
+        "Process tags and text requests"
+
+        if text == "" or text.lower() == "none":
+            if tags == "" or tags.lower() == "none":
+                self.tags = None
+                self.text = None
+                return
+
+        try:
+            tab = read_file(infile)
+        except OSError as ee:
+            if 'does not exist' in str(ee):
+                verb0("WARNING: text and tags can only be used with FITS region files.")
+                self.tags = None
+                self.text = None
+                return
+            raise ee
+
+        if text != "" and text.lower() != "none":
+            self.load_text( tab, text)
+        else:
+            self.text = None
+
+        if tags != "" and tags.lower() != "none":
+            import stk as stk
+            self.load_tags( tab, stk.build(tags))
+        else:
+            self.tags = None
+
 
     def get_xform(self, infile):
         "Get WCS transform: try eqpos then eqsrc, then barf"
-        from pycrates import read_file, get_transform
         input_table = read_file(infile)
 
         try:
@@ -163,7 +230,17 @@ class PhysicalRegion(object):
 
     def run(self):
         """Loop over all shapes in the region """
-        doit = map(self.process_shape, self.physical_region.shapes)
+
+        shapes = self.physical_region.shapes
+
+        doit = []
+        for ii in range(len(shapes)):
+            shape = self.process_shape(shapes[ii])
+            text = self.text[ii] if self.text else ""
+            tags = self.tags[ii] if self.tags else ""
+            line = "{} # {} {}".format(shape, text, tags)
+            doit.append(line)
+
         valid = [x for x in doit if x is not None]
         self.cel_region_str = "\n".join(valid)
 
@@ -188,7 +265,8 @@ def main():
     pars = get_params(toolname, "rw", sys.argv,
                       verbose={"set": lw.set_verbosity, "cmd": verb1})
 
-    pr = PhysicalRegion(pars["infile"], pars["wcsfile"])
+    pr = PhysicalRegion(pars["infile"], pars["wcsfile"],
+                        pars["text"], pars["tag"])
     pr.run()
     pr.write(pars["outfile"], pars["clobber"])
 

--- a/bin/regphystocel
+++ b/bin/regphystocel
@@ -23,7 +23,7 @@ import sys
 import ciao_contrib.logger_wrapper as lw
 
 toolname = "regphystocel"
-__revision__ = "14 Aug 2020"
+__revision__ = "19 Aug 2020"
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -216,7 +216,7 @@ class PhysicalRegion(object):
 
         shape_name = shape.name.lower()
         if shape_name not in ['circle', 'box', 'rotbox', 'ellipse',
-                              'polygon', 'rectangle', 'point']:
+                              'polygon', 'rectangle', 'point', 'annulus']:
             verb0("Skipping unsupported shape={}".format(shape_name))
             return None
 

--- a/param/rank_roi.par
+++ b/param/rank_roi.par
@@ -1,0 +1,7 @@
+infile,f,a,"",,,"Input image file"
+roifiles,f,a,"",,,"Stack of ROI files"
+outfile,f,a,"",,,"Output file name temple, must include {:04d}"
+method,s,h,"max","max|min|big|small|bright|faint",,"Metric to use to assign overlap area"
+clobber,b,h,no,,,"OK to overwrite existing output files?"
+verbose,i,h,1,0,5,"Amount of tool chatter"
+mode,s,h,"ql",,,

--- a/param/regphystocel.par
+++ b/param/regphystocel.par
@@ -1,6 +1,8 @@
 infile,f,a,"",,,"Input region file in physical coordinates"
 outfile,f,a,"",,,"Output ds9 format region file in celestial coordinates"
 wcsfile,f,h,"",,,"Image or event file with WCS if not in infile"
+text,s,h,"",,,"Column or keyword to use for region title"
+tag,s,h,"",,,"Columns or keywords to use for region tags"
 clobber,b,h,no,,,"Remove outfile if it already exists?"
 verbose,i,h,1,0,5,"Amount of tool chatter"
 mode,s,h,"ql",,,

--- a/param/regphystocel.par
+++ b/param/regphystocel.par
@@ -1,0 +1,6 @@
+infile,f,a,"",,,"Input region file in physical coordinates"
+outfile,f,a,"",,,"Output ds9 format region file in celestial coordinates"
+wcsfile,f,h,"",,,"Image or event file with WCS if not in infile"
+clobber,b,h,no,,,"Remove outfile if it already exists?"
+verbose,i,h,1,0,5,"Amount of tool chatter"
+mode,s,h,"ql",,,

--- a/share/doc/xml/rank_roi.xml
+++ b/share/doc/xml/rank_roi.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+  <ENTRY context="tools" key="rank_roi" refkeywords="roi region regions reg combine overlap exclude bright faint flux counts" seealsogroups="detecttools regiontools">
+    <SYNOPSIS>Assign overlapping region area to highest ranking source.
+    </SYNOPSIS>
+    <DESC>
+      <PARA>
+        The `roi' tool is typically run with the parameter group=exclude
+        which produces source regions with exclude any nearby overlapping
+        sources.  The issue is that the overlapping area is never assigned
+        to any source region so the data in that region are not included
+        any data analysis.
+      </PARA>
+      <PARA>
+      The `rank_roi' tool is a post processing step which takes the 
+      `roi' output files and assigns the overlapping area to the highest
+      ranking source region.  Source regions can be ranked based on
+      several criteria:  most flux, least flux, largest area, smallest
+      area, brightest pixel or faintest pixel.      
+      </PARA>
+      <PARA>
+      The output from `rank_roi' is a new stack of region files with
+      the overlapping area assigned to the highest ranking source.
+      The output root name must contain a Python string format token 
+      to represent the region number.
+      </PARA>
+      <PARA>
+      The `rank_roi` input file, infile, is used to calculate the 
+      ranking.  It will typically be an image of either the counts 
+      or flux.      
+      </PARA>
+      <PARA>
+      Note: For this algorithm to be useful, the `roi' tool had to have
+      been run with group=exclude. Otherwise, the output will always
+      be identical to the input.
+      </PARA>
+    </DESC>
+    <QEXAMPLELIST>
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% roi infile=wav_src.fits outsrc="src_%04d.reg" group=exclude target=target mode=h clob+
+</LINE>
+          <LINE>
+% rank_roi infile=broad_thresh.img roifile="src_*.reg" outfile="rank_src_{:04d}.reg" method=max
+</LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+            This example shows the `roi' tool being run on a source list file using
+            group=exclude.  This will produce region that will exclude nearby overlapping
+            source regions.  The `roi' output root contains the C-formatting style
+            '%04d' which gets replaced with the region number (4-digits with leading
+            zeros).
+          </PARA>
+          <PARA>
+            The `rank_roi' tool is then used to assign the overlapping area to one of
+            the source regions.  The source with the maximum counts, obtained from
+            the input image, broad_thresh.img, is given the highest ranking and
+            assigned the overlapping area.
+          </PARA>
+        </DESC>
+      </QEXAMPLE>
+      <QEXAMPLE>
+        <DESC>
+          <PARA>
+In this example we show an longer example with actual numbers.  We start
+by creating a region file with 2 overlapping source regions (ellipses):
+</PARA>
+          <VERBATIM>
+$ cat &lt;&lt; EOM &gt; ciao.reg
+ellipse(3972,4444,43,38,175)
+ellipse(3945,4501,46,40,128)
+EOM
+$ dmmakereg region="region(ciao.reg)" out=ciao.fits ker=fits clob+
+</VERBATIM>
+          <PARA>
+We then run the `roi' tool with group=exclude
+</PARA>
+          <VERBATIM>
+$ roi ciao.fits outsrc="ciao_%d.src" group=exclude clob+ mode=h
+</VERBATIM>
+          <PARA>
+`roi' writes out each source to a separate file based on the 
+outsrcfile name template; the "%" is replaced by the source number.
+We can look at each file to verify the regions overlap and that each 
+region is excluded from the other
+</PARA>
+          <VERBATIM>
+$ dmlist ciao_1.src data,clean
+Region Block: Ellipse(3972,4444,43,38,175)&amp;!Ellipse(3945,4501,46,40,128)
+#  POS(X,Y)                                 SHAPE              R[2]                                     ROTANG[2]                                COMPONENT
+                       3972.0      4444.0 Ellipse                                    43.0        38.0                                175.0 NaN          1
+                       3945.0      4501.0 !Ellipse                                   46.0        40.0                                128.0 NaN          1
+</VERBATIM>
+          <PARA>and</PARA>
+          <VERBATIM>
+$ dmlist ciao_2.src data,clean
+Region Block: Ellipse(3945,4501,46,40,128)&amp;!Ellipse(3972,4444,43,38,175)
+#  POS(X,Y)                                 SHAPE              R[2]                                     ROTANG[2]                                COMPONENT
+                       3945.0      4501.0 Ellipse                                    46.0        40.0                                128.0 NaN          1
+                       3972.0      4444.0 !Ellipse                                   43.0        38.0                                175.0 NaN          1
+</VERBATIM>
+          <PARA>
+Since the regions exclude each other, the area inbetween them is not assigned 
+to any source region.  Data in that overlapping area is not used in 
+later data analysis. 
+</PARA>
+          <PARA>
+We now use the `rank_roi` tool to assign the area to the source with 
+the most counts based on the input image: broad_thresh.img.
+</PARA>
+          <VERBATIM>
+$ rank_roi infile=broad_thresh.img roi="ciao_?.src" out="rank_ciao_{}.src" method=max clob+
+rank_roi
+          infile = Test/sim/sim.img.gz
+        roifiles = ciao_?.src
+         outfile = rank_ciao_{}.src
+          method = max
+         clobber = yes
+         verbose = 1
+            mode = ql
+
+Loading ROI files
+2 ROI files parsed
+Checking clobber
+Checking infile (image v. table)
+Computing metric for all ROIs
+Determining which ROIs should get overlap area
+Writing out new roi files
+</VERBATIM>
+          <PARA>
+            The stack of roi input files, roifiles, is processed and ranked based
+            on the method parameter; max means maximum counts|flux based on the infile
+            image.  The file names for the output files are generated based 
+            on the outfile name template.  Note: the outfile must include a Python
+            string format token, ie something inside of curly brackets, eg {} or {:04d}.
+          </PARA>
+          <PARA>
+We can then check the output files and we see that the 1st region
+</PARA>
+          <VERBATIM>
+$ dmlist rank_ciao_1.src data,clean
+Region Block: Ellipse(3972,4444,43,38,175)&amp;!Ellipse(3945,4501,46,40,128)
+#  POS(X,Y)                                 SHAPE              R[2]                                     ROTANG[2]                                COMPONENT
+                       3972.0      4444.0 Ellipse                                    43.0        38.0                                175.0 NaN          1
+                       3945.0      4501.0 !Ellipse                                   46.0        40.0                                128.0 NaN          1
+</VERBATIM>
+          <PARA>
+still has the 2nd region excluded from it.  It has a lower rank than 
+the 2nd region.  The 2nd region looks like
+</PARA>
+          <VERBATIM>
+$ dmlist rank_ciao_2.src data,clean
+Region Block: Ellipse(3945,4501,46,40,128)
+#  POS(X,Y)                                 SHAPE              R[2]                                     ROTANG[2]                                COMPONENT
+                       3945.0      4501.0 Ellipse                                    46.0        40.0                                128.0 NaN          1
+</VERBATIM>
+          <PARA>
+Since this region has the highest rank it has claimed the overlapping
+region area (thus no regions are excluded from it).
+</PARA>
+        </DESC>
+      </QEXAMPLE>
+    </QEXAMPLELIST>
+    <PARAMLIST>
+      <PARAM filetype="input" name="infile" reqd="yes" stacks="no" type="file">
+        <SYNOPSIS>
+        An image or event list. 
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+        The infile is filtered by each region and statistics are gathered
+        to compute the regions' rank.        
+         </PARA>
+        </DESC>
+      </PARAM>
+      <PARAM filetype="input" name="roifiles" reqd="yes" stacks="yes" type="file">
+        <SYNOPSIS>
+    The stack of roi region files.
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+        Users can use any standard CIAO stack syntax to provide the
+        list of roi region files:  "@file.lis", wildcards (*, ?), etc.
+        All the regions must be supplied ; if they are not then overlaps
+        involving any omitted regions will not be checked.
+         </PARA>
+          <PARA>
+        The regions should have been created using roi's group=exclude 
+        parameter setting.  Using any of the other methods results
+        in the output files just being copies of the input files.
+        </PARA>
+        </DESC>
+      </PARAM>
+      <PARAM filetype="output" name="outfile" reqd="yes" stacks="no" type="file">
+        <SYNOPSIS>
+        The output file name template.
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+        The outfile template value must contain a Python string 
+        formatting token.  The token is replaced by the region number
+        when the files are written.  Typically the value will be "{}" or "{:04d}".
+         </PARA>
+        </DESC>
+      </PARAM>
+      <PARAM def="max" name="method" reqd="no" stacks="no" type="string">
+        <SYNOPSIS>
+        The metric used to determine the regions' ranks.
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+        The overlapping region area is assigned based on the method
+        parameter:
+        </PARA>
+          <LIST>
+            <ITEM>max : the region with the largest flux</ITEM>
+            <ITEM>min : the region with the least flux</ITEM>
+            <ITEM>bright : the region with the brightest  pixel (maximum, maximum pixel value)</ITEM>
+            <ITEM>faint : the region with the faintest pixel (minimum, maximum pixel value)</ITEM>
+            <ITEM>big : the region with the largest area</ITEM>
+            <ITEM>small : the region with the smallest area</ITEM>
+          </LIST>
+        </DESC>
+      </PARAM>
+      <PARAM def="1" max="5" min="0" name="verbose" type="integer">
+        <SYNOPSIS>
+        Amount of tool chatter level.
+       </SYNOPSIS>
+        <DESC>
+          <PARA>Running with verbose=2 or higher will print the metric
+      for each region.</PARA>
+        </DESC>
+      </PARAM>
+      <PARAM def="no" name="clobber" type="boolean">
+        <SYNOPSIS>
+            Overwrite output files if they already exist?
+        </SYNOPSIS>
+      </PARAM>
+    </PARAMLIST>
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+    <LASTMODIFIED>June 2020</LASTMODIFIED>
+  </ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/regphystocel.xml
+++ b/share/doc/xml/regphystocel.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+  <ENTRY context="tools" key="regphystocel" 
+   refkeywords="region coordinates physical celestial ds9 fk5 wcs world coordinate convert ascii" 
+   seealsogroups="detecttools regiontools"
+   >
+    <SYNOPSIS>Convert regions in physical coordinates to ds9 format regions in
+    celestial (fk5) coordinates.
+    </SYNOPSIS>
+    <DESC>
+      <PARA>`regphystocel' will convert a region file stored in physical coordinates
+      into a ds9-format region file using celestial coordinates.  Most 
+      CIAO tools can make use of regions in either physical or celestial
+      coordinates.  However, when working with multiple observations with
+      possibly different tangent plane projection parameters, using 
+      celestial coordinates may be necessary.  This is the case when using
+      the srcflux script with multiple observations.
+      </PARA>
+      <PARA>
+      The input region file can be either a FITS region file 
+      or an CIAO ASCII region file.  The infile can also just be
+      a region string.      
+      </PARA>
+      <PARA>
+      The tool takes position and radius (in physical pixels) of each 
+      shape and applies the world coordinate system (WCS) transform.      
+      The angle is not modified (always measured counter-clockwise from the
+      +X axis).  If using a FITS region file, it may contain the WCS
+      necessary to do the conversion to celestial coordinates; otherwise
+      users can supply an image or event file as the wcsfile parameter.
+      </PARA>
+      <PARA title="Limitations">
+      CIAO regions support complex region logic using logical AND and logical
+      OR operations; the ds9 format does not support this.  The following
+      shapes are not supported:  'field', 'pie', and 'sector'.      
+      </PARA>
+
+
+    </DESC>
+    <QEXAMPLELIST>
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% regphystocel ciao.reg ds9.reg wcsfile=img.fits
+           </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+The ASCII region stored in the file "ciao.reg" is converted to celestial 
+coordinates using the WCS from the "img.fits" file.  The output is
+written to "ds9.reg" which will look similar to this:
+</PARA>
+<VERBATIM>
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+ellipse(01:13:51.0473,13:16:17.8925,1.26168",1.17667",25.8786)
+</VERBATIM>
+
+        </DESC>
+      </QEXAMPLE>
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% regphystocel fov.fits fov.reg
+           </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+              The FITS region file "fov.fits" is converted to celestial
+              coordinates using the WCS provided in the file itself.
+              Most FITS region files will have a WCS.  To determine
+              if the file has a WCS just
+</PARA>
+<VERBATIM>
+% dmlist fov.fits cols
+...
+--------------------------------------------------------------------------------
+World Coord Transforms for Columns in Table Block FOV
+--------------------------------------------------------------------------------
+ 
+ColNo    Name
+1:    EQPOS(RA ) = (+18.4654)[degree] +TAN[(-0.000136667)* (POS(X)-(+4096.50))]
+           (DEC)   (+13.2705)              (+0.000136667)  (   (Y) (+4096.50)) 
+</VERBATIM>
+
+<PARA>
+and in the "World Coord Transforms" section look for either "EQPOS" or "EQSRC".
+If neither is present, then a wcsfile which does have one of those two
+transforms must be supplied.
+</PARA>
+        </DESC>
+      </QEXAMPLE>
+
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% regphystocel "circle(4096.5,4096.5,100)-box(4096.5,4096.5,100,100)" ds9.reg wcsfile=img.fits
+           </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+In this example the region is provided directly in the infile parameter.
+While the ds9 format does not support the full CIAO logical AND and logical OR
+expressions, it does supported include and excluded shapes as shown here:
+</PARA>
+<VERBATIM>
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+circle(01:13:51.6855,13:16:13.8493,49.2")
+-box(01:13:51.6855,13:16:13.8493,49.2",49.2")
+</VERBATIM>
+        </DESC>
+      </QEXAMPLE>
+    </QEXAMPLELIST>
+
+    <PARAMLIST>
+      <PARAM filetype="input" name="infile" reqd="yes" type="file">
+        <SYNOPSIS>
+            The input region.
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+            The infile can be either an ASCII CIAO region file (using
+            physical coordinates) 
+            or a FITS format region file (always assumed to be using
+            physical coordinates).  Users can also supply a 
+            simple region expression.
+         </PARA>
+        </DESC>
+      </PARAM>
+      <PARAM filetype="output" name="outfile" reqd="yes" type="file">
+        <SYNOPSIS>
+            Output file name.
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+            The output is a ds9 format region file using celestial coordinates.
+         </PARA>
+        </DESC>
+      </PARAM>
+      <PARAM filetype="input" name="wcsfile" reqd="no" type="file">
+        <SYNOPSIS>
+           File used to obtain world coordinate system transformation.
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+        If the infile does not contain a recognized WCS, then users must
+        supply a wcsfile which does.  The infile or wcsfile must contain
+        either an EQPOS or EQSRC coordinate transform.  If the 
+        wcsfile is specified and the infile also has a WCS, the wcsfile
+        parameters are used.
+         </PARA>
+        </DESC>
+      </PARAM>
+      <PARAM def="1" max="5" min="0" name="verbose" type="integer">
+        <SYNOPSIS>
+        Amount of tool chatter level.
+       </SYNOPSIS>
+      </PARAM>
+      <PARAM def="no" name="clobber" type="boolean">
+        <SYNOPSIS>
+            Overwrite output files if they already exist?
+        </SYNOPSIS>
+      </PARAM>
+    </PARAMLIST>
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+    <LASTMODIFIED>August 2020</LASTMODIFIED>
+  </ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/regphystocel.xml
+++ b/share/doc/xml/regphystocel.xml
@@ -35,6 +35,16 @@
       OR operations; the ds9 format does not support this.  The following
       shapes are not supported:  'field', 'pie', and 'sector'.      
       </PARA>
+      <PARA title="Text and Tags">
+      Regions stored in the ds9 format can have a title that will
+      optionally be displayed above the region.  They can also have 
+      one or more "tags" which allows the user to group 
+      sources together; users can access the list of groups by 
+      going to Region -&gt; Groups ... from the ds9 main menu.
+      When using a FITS region file regphystocel can take values from
+      columns or keywords and populate the title or tags properties.        
+      </PARA>
+
 
 
     </DESC>
@@ -116,6 +126,53 @@ circle(01:13:51.6855,13:16:13.8493,49.2")
 </VERBATIM>
         </DESC>
       </QEXAMPLE>
+
+
+<QEXAMPLE>
+<SYNTAX>
+<LINE>
+% regphystocel cell.src ds9.reg text=component tag=double,double_id,obs_id
+</LINE>
+</SYNTAX>
+<DESC>
+<PARA>
+In this example we use the text and tag parameters to specify additional
+metadata to extract from the FITS region file (cell.src) and store in 
+the ds9 region file.  The value of the COMPONENT column are stored in
+the text field and will be displayed above the regions.  The values
+for the double and double_id columns as well as the obs_id keyword are
+stored as tags.  The output will look something like this:
+</PARA>
+<VERBATIM>
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+ellipse(05:23:0.8521,33:28:17.0340,1.50728",1.38265",175.227) # text={1}  tag={double=False} tag={double_id=0} tag={obs_id=4396}
+ellipse(05:23:0.6545,33:28:6.6130,1.4234",1.28935",39.5983) # text={2}  tag={double=False} tag={double_id=0} tag={obs_id=4396}
+ellipse(05:22:40.0080,33:28:31.1923,1.49205",1.23199",22.1857) # text={130}  tag={double=False} tag={double_id=0} tag={obs_id=4396}
+ellipse(05:23:6.6306,33:28:8.8049,2.28348",1.86101",156.246) # text={131}  tag={double=True} tag={double_id=343} tag={obs_id=4396}
+ellipse(05:23:5.3125,33:28:36.8242,3.32145",2.22307",115.958) # text={137}  tag={double=True} tag={double_id=139} tag={obs_id=4396}
+</VERBATIM>
+
+<PARA>
+In ds9, the user will see following groups:  double=False, double=True, 
+double_id=0, double_id=343, double_id=139, and obs_id=4396.  The user
+can select the source in these groups for additional analysis.
+</PARA>
+
+<PARA>
+Only a single column or keyword can be used for the text parameter.
+The tag parameter is a stack of column or keyword names.
+</PARA>
+
+</DESC>
+
+
+</QEXAMPLE>  
+
+
+
+
     </QEXAMPLELIST>
 
     <PARAMLIST>
@@ -157,6 +214,36 @@ circle(01:13:51.6855,13:16:13.8493,49.2")
          </PARA>
         </DESC>
       </PARAM>
+      <PARAM name="text" reqd="no" type="string" stacks="no">
+        <SYNOPSIS>
+        The column value or keyword name to use for the region's text label.
+        </SYNOPSIS>
+        <DESC>
+          <PARA>
+          When the infile is a FITS region file, the user can specify
+          a column or keyword to use for the text label associated
+          with each region.
+          </PARA>        
+        </DESC>
+      </PARAM>
+      <PARAM name="tag" reqd="no" type="string" stacks="yes">
+        <SYNOPSIS>
+        The column values or keyword names to use to tag each region.
+        </SYNOPSIS>
+        <DESC>
+          <PARA>
+          When the infile is a FITS region file, the user can specify
+          a stack columns and/or keywords to use for as grouping
+          tags.  Groups can be used to attach additional information 
+          to a region such as which source is associated with which
+          background; which sources are extended, adding properties
+          like number of counts, etc.
+          </PARA>        
+        </DESC>
+      </PARAM>
+
+
+
       <PARAM def="1" max="5" min="0" name="verbose" type="integer">
         <SYNOPSIS>
         Amount of tool chatter level.


### PR DESCRIPTION
These are some utilities for the `roi` output.  They should be released with the multi-obsid `srcflux` update.

- `rank_roi` : assigns the overlapping area of the `roi` output files to the "best" source.  Users can select the metric used to determine the "best" source (most counts, largest area, brighest pixel, etc).
- `regphystocel` (blame JCM for the name) converts a region in physical coordinates to celestial coords.