### PR TITLE
CDA http changes

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -8,12 +8,17 @@ Updated scripts
     Updated for changes to hrc_process_events and tg_resolve_events
     parameter files (several defunct parameters have been removed).
 
+  download_chandra_obsid, find_chandra_obsid
+
+    These scripts should be more robust to future changes to the
+    Chandra Data Archive.
+
 Updated Python modules
 
   ciao_contrib.runtool
 
-    The runtool module has been updated to reflect changes to the
-    tools in the CIAO 4.13 release.
+    The runtool module has been updated to reflect new tools and changes
+    to the parameters of tools in the CIAO 4.13 release.
 
 Removed
 

--- a/bin/download_chandra_obsid
+++ b/bin/download_chandra_obsid
@@ -71,7 +71,7 @@ import ciao_contrib.logger_wrapper as lw
 import ciao_contrib.cda.data as data
 
 TOOLNAME = "download_chandra_obsid"
-VERSION = "6 February 2020"
+VERSION = "02 November 2020"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)

--- a/bin/find_chandra_obsid
+++ b/bin/find_chandra_obsid
@@ -92,7 +92,7 @@ import coords.format as coords
 from coords import resolver
 
 toolname = "find_chandra_obsid"
-version = "31 Mar 2020"
+version = "02 November 2020"
 
 lw.initialize_logger(toolname)
 
@@ -110,11 +110,10 @@ def protect_string(s):
     if " " in s:
         if '"' in s:
             return '"{}"'.format(s.replace('"', '\"'))
-        else:
-            return '"{}"'.format(s)
 
-    else:
-        return s
+        return '"{}"'.format(s)
+
+    return s
 
 
 def protect_strings(array):

--- a/ciao_contrib/cda/data.py
+++ b/ciao_contrib/cda/data.py
@@ -239,6 +239,10 @@ class ObsIdFile:
 
         The hdr value is added to the request header to enable the
         user-agent to be changed (or any other header).
+
+        This approach is left-over from the previous FTP code,
+        where we could get the size easily. This should now
+        probably just be folded into the download code.
         """
 
         if self.filesize is not None:
@@ -390,6 +394,10 @@ class ObsId:
         The screen output is determined by the logger instance.
 
         The downloads are done in order of decreasing file size.
+
+        Files we can not download (e.g. doesn't exist or some other
+        reason) are skipped. This is to support possible future
+        changes in the HTML response from the archive.
         """
 
         V3("Downloading {} files".format(len(self.files)))
@@ -415,7 +423,13 @@ class ObsId:
 
         for oelem in order:
             fileobj = itemgetter(1)(oelem)
-            (a, b) = fileobj.download(self.header)
+
+            try:
+                (a, b) = fileobj.download(self.header)
+            except urllib.error.URLError as uerr:
+                V1(f"SKIPPING {fileobj.filename} as {uerr}")
+                continue
+
             nbytes += a
             dtime += b
 

--- a/ciao_contrib/cda/data.py
+++ b/ciao_contrib/cda/data.py
@@ -21,7 +21,7 @@
 Download publically-available data from the Chandra Data Archive (CDA).
 
 Routines that wrap up HTTPS access to the Chandra Data Archive -
-https://cxc.harvard.edu/cda/ - supporting mirror sites under the
+https://cxc.harvard.edu/cdaftp/ - supporting mirror sites under the
 assumption that they have the same directory structure and login
 support as the CDA.
 

--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -269,7 +269,7 @@ class DirectoryContents(HTMLParser):
         if data.lower() == 'parent directory':
             self.current = None
         elif self.current != data:
-            v3(f"Dropping link={self.current} as test={data}")
+            v4(f"Dropping link={self.current} as test={data}")
             self.current = None
 
 

--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -203,9 +203,13 @@ class DirectoryContents(HTMLParser):
     """Extract the output of the mod_autoindex Apache directive.
 
     Limited testing. It assumes that the files are given as links,
-    there's no other links on the page, and the parent directory
-    is listed as 'parent directory' (after removing the white space
-    and converting to lower case).
+    there's no other links on the page, and the parent directory is
+    listed as 'parent directory' (after removing the white space and
+    converting to lower case). There is special casing to remove links
+    where the text does not match the name of the link. This is to
+    handle query fragments, which are used to change the ordering of
+    the table display rather than be an actual link.
+
     """
 
     def __init__(self, *args, **kwargs):
@@ -256,9 +260,16 @@ class DirectoryContents(HTMLParser):
         if self.current is None:
             return
 
-        # Skip the link to the parent directory
+        # Skip the link to the parent directory, and skip any where
+        # the text is different to the href (e.g. to catch query-only
+        # links which are used to change the display rather than being
+        # a link).
+        #
         data = data.strip()
         if data.lower() == 'parent directory':
+            self.current = None
+        elif self.current != data:
+            v3(f"Dropping link={self.current} as test={data}")
             self.current = None
 
 

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -261,6 +261,13 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 	-->
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.1 (December 2020) release">
+      <PARA>
+	The script should be more robust to changes made to the
+	Chandra Data Archive web site.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
       <PARA title="Archive has moved">
 	The script now uses the HTTPS service provided by the
@@ -336,6 +343,6 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>February 2020</LASTMODIFIED>
+    <LASTMODIFIED>December 2020</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/find_chandra_obsid.xml
+++ b/share/doc/xml/find_chandra_obsid.xml
@@ -43,7 +43,7 @@
 	value (that is, an integer between 1 and 65535),
 	otherwise it is treated as an object name.
       </PARA>
-      
+
       <PARA title="ObsId">
 	If an integer value is given, then the Chandra Data Archive is
 	searched to find the location of the observation, and this
@@ -58,7 +58,7 @@
 
       <PARA title="Object names">
 	The name resolver at the CADC is used to convert names to
-	a position. If the name contains a space then it must be given 
+	a position. If the name contains a space then it must be given
 	surrounded by quotes - e.g. "NGC 1333" - to ensure that the script
 	recognizes it as a single argument.
       </PARA>
@@ -124,7 +124,7 @@
 	values for the matching observations are displayed. If set to "all" then
 	the matching ObsIds are downloaded to the working directory; in this case
 	the information on the matching ObsIds is not given.
-	When set to "ask", you are queried whether to download each ObsId 
+	When set to "ask", you are queried whether to download each ObsId
 	and then the download will take place for the chosen observations.
       </PARA>
 
@@ -143,14 +143,14 @@
 	This script provides limited capabilities for filtering the data,
 	by using the instrument and grating parameters. More complicated
 	filtering can be done by taking advantage of the fact that the
-	screen output of the script can be manipulated using the 
+	screen output of the script can be manipulated using the
 	CIAO command-line tools. For example
       </PARA>
 <VERBATIM>
 &pr; find_chandra_obsid 350.86 58.81 > matches.dat
 &pr; dmlist matches.dat counts
 115
-&pr; dmlist "matches.dat[time>20,inst=HRC-I][cols obsid]" data,raw 
+&pr; dmlist "matches.dat[time>20,inst=HRC-I][cols obsid]" data,raw
 #  obsid
                1505.0
 &pr; download_chandra_obsid 1505
@@ -421,8 +421,8 @@ Download [y, n, q, a, h]: y
 	  <PARA>
 	    If the Dec argument is empty than the value is taken to
 	    be wither be an ObsId (if an integer in the range 1 to
-	    65535), or the name of the source and sent to the 
-	    CADC name resolver. Set verbose to 2 to see the 
+	    65535), or the name of the source and sent to the
+	    CADC name resolver. Set verbose to 2 to see the
 	    position that is returned.
 	  </PARA>
 	  <PARA>
@@ -495,10 +495,10 @@ Download [y, n, q, a, h]: y
 	      </DATA>
 	    </ROW>
 	  </TABLE>
-	  
+
 	  <PARA>
 	    Note that there is no way to restrict the data being downloaded. If you
-	    only want a subset of files for each ObsID then use the 
+	    only want a subset of files for each ObsID then use the
 	    &dco; script once you have
 	    found the list of matching ObsID values.
 	  </PARA>
@@ -547,7 +547,7 @@ Download [y, n, q, a, h]: y
 	  </TABLE>
 	</DESC>
       </PARAM>
-      
+
       <PARAM name="grating" type="string" def="all">
 	<SYNOPSIS>Choice of grating</SYNOPSIS>
 	<DESC>
@@ -582,7 +582,7 @@ Download [y, n, q, a, h]: y
 	  </TABLE>
 	</DESC>
       </PARAM>
-      
+
       <PARAM name="detail" type="string" def="basic">
 	<SYNOPSIS>Columns to display</SYNOPSIS>
 	<DESC>
@@ -609,8 +609,8 @@ Download [y, n, q, a, h]: y
 	    <ROW>
 	      <DATA>all</DATA>
 	      <DATA>
-		obsid, sepn, inst, grat, time, 
-		rastr, decstr, 
+		obsid, sepn, inst, grat, time,
+		rastr, decstr,
 		obsdate, piname, target, ra, dec
 	      </DATA>
 	    </ROW>
@@ -625,7 +625,7 @@ Download [y, n, q, a, h]: y
 	    <ROW>
 	      <DATA>obsid</DATA>
 	      <DATA>
-		The 
+		The
 		<!--
 		    <HREF link="https://cxc.harvard.edu/ciao/dictionary/obsid.html">Observation Id</HREF>
 		-->
@@ -713,13 +713,13 @@ Download [y, n, q, a, h]: y
 	  </TABLE>
 	</DESC>
       </PARAM>
-      
+
       <PARAM name="mirror" type="string" def="">
 	<SYNOPSIS>Use this instead of the CDA FTP site</SYNOPSIS>
 	<DESC>
 	  <PARA>
 	    The default FTP site used to download data is the Chandra
-	    Data Archive. 
+	    Data Archive.
 	    If the mirror parameter site is set then this is taken
 	    to be the address of the mirror site to use,
 	    otherwise if the &cdaenv; environment
@@ -742,7 +742,7 @@ Download [y, n, q, a, h]: y
           </PARA>
           <PARA>
             If needed, you can include a username and password in the mirror
-            setting, following 
+            setting, following
             <HREF link="https://tools.ietf.org/html/rfc3986">RFC3986</HREF>,
             for instance
             <EQUATION>ftp://anonymous:foo@bar.com@cda.cfa.harvard.edu/pub</EQUATION>
@@ -767,7 +767,7 @@ Download [y, n, q, a, h]: y
 	  </PARA>
 	</DESC>
       </PARAM>
-      
+
     </PARAMLIST>
 
     <ADESC title="Parameter handling">
@@ -789,9 +789,16 @@ Download [y, n, q, a, h]: y
 	for these arguments).
       </PARA>
       <PARA>
-	Use pset 
-        if you wish to permanently set options, for instance to set 
+	Use pset
+        if you wish to permanently set options, for instance to set
         instrument to acis to exclude HRC observations.
+      </PARA>
+    </ADESC>
+
+    <ADESC title="Changes in the scripts 4.13.1 (December 2020) release">
+      <PARA>
+	The script should be more robust to changes made to the
+	Chandra Data Archive web site.
       </PARA>
     </ADESC>
 
@@ -802,7 +809,7 @@ Download [y, n, q, a, h]: y
 	or wget in these cases.
       </PARA>
     </ADESC>
-    
+
     <ADESC title="Changes in the scripts 4.10.3 (November 2018) release">
       <PARA>
 	Fall through to curl or wget for https access to the
@@ -839,7 +846,7 @@ Download [y, n, q, a, h]: y
     <ADESC title="Changes in the scripts 4.7.1 (December 2014) release">
       <PARA title="Support for searching by ObsId">
 	If a single argument is given and it is an integer in the
-	range 1 to 65535, then it is first checked against the 
+	range 1 to 65535, then it is first checked against the
 	Chandra Data Archive and, if it matches an existing ObsId,
 	then its position is used, otherwise it is passed to the
 	name server.
@@ -849,7 +856,7 @@ Download [y, n, q, a, h]: y
     <ADESC title="Changes in the scripts 4.5.4 (August 2013) release">
       <PARA title="Support for CDA mirror sites">
 	The mirror parameter and support for the
-	&cdaenv; environment variable 
+	&cdaenv; environment variable
 	has been added to allow data access from a
 	mirror of the Chandra Data Archive site.
       </PARA>
@@ -874,10 +881,10 @@ Download [y, n, q, a, h]: y
 	See the
 	<HREF link="https://cxc.harvard.edu/ciao/bugs/find_chandra_obsid.html">bugs page
 	for this script</HREF> on the CIAO website for an up-to-date
-	listing of known bugs. 
+	listing of known bugs.
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>April 2019</LASTMODIFIED>
+    <LASTMODIFIED>December 2020</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
We now skip any URL where the href doesn't match the text of the link, which catches the changes that caused problems before. I've tried to make download/find_chandra_obsid more robust to changes, but it's hard to really check this out without having changes to test against.
