### PR TITLE
Tweak warning message from merging event files

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -13,6 +13,13 @@ Updated scripts
     These scripts should be more robust to future changes to the
     Chandra Data Archive.
 
+  merge_obs, reproject_obs
+
+    The warning to not use the merged event file for calculating the
+    instrument response no-longer displays the difference in all its
+    numerical glory, but instead limits to the number of decimal
+    places of the limit.
+
 Updated Python modules
 
   ciao_contrib.runtool

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -28,6 +28,12 @@ Updated Python modules
     The runtool module has been updated to reflect new tools and changes
     to the parameters of tools in the CIAO 4.13 release.
 
+  coords.format
+
+    The deg2ra() and deg2dec() functions have gained an optional ndp
+    parameter to restrict the number of decimal places used in the
+    output.
+
 Removed
 
   sherpa_contrib.xspec.xsconvolve module

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -15,10 +15,11 @@ Updated scripts
 
   merge_obs, reproject_obs
 
-    The warning to not use the merged event file for calculating the
-    instrument response no-longer displays the difference in all its
-    numerical glory, but instead limits to the number of decimal
-    places of the limit.
+    The warning message about not using the merged event file for
+    calculating instrument responses now restricts the message so that
+    the value does not include excess precision, but is limited to the
+    limit value. The tangent point in the screen output has also seen
+    its accuracy reduced (this only affects the screen output).
 
 Updated Python modules
 

--- a/bin/merge_obs
+++ b/bin/merge_obs
@@ -49,7 +49,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'merge_obs'
-__revision__ = '01 April 2020'
+__revision__ = '05 November 2020'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -67,7 +67,7 @@ def handle_background_override(argv):
 
     If there are multiple entries then the last one is used.
 
-    The backfround map file should be an ascii file with two columns;
+    The background map file should be an ascii file with two columns;
     the first is the event file name (no path) and the second the
     full path to the HRC-I background file to use.
     """
@@ -79,7 +79,8 @@ def handle_background_override(argv):
     mapname = None
     for arg in argv:
         if arg == marker:
-            raise IOError("The {} option must be followed by a file name!")
+            raise IOError(f"The {marker} option must be followed by a " +
+                          "file name!")
 
         if arg.startswith(marker):
             mapname = arg[len(marker):]
@@ -90,8 +91,8 @@ def handle_background_override(argv):
     if mapname is not None:
         cr = pycrates.read_file(mapname)
         if cr.get_ncols() != 2:
-            raise IOError("Expected 2 columns in {}".format(mapname) +
-                          ", found {}".format(cr.get_ncols()))
+            raise IOError(f"Expected 2 columns in {mapname}, " +
+                          f"found {cr.get_ncols()}")
 
         # convert from np.string_ to string to avoid later oddities
         keys = map(str, cr.get_column(0).values.copy())
@@ -100,15 +101,15 @@ def handle_background_override(argv):
 
         _background_override = {}
         for (k, v) in zip(keys, vals):
-            v3("Storing map from {} to {}".format(k, v))
+            v3(f"Storing map from {k} to {v}")
             (dmname, dmfilter) = fileio.get_file_filter(v)
             v = os.path.abspath(dmname) + dmfilter
             try:
                 pycrates.read_file(v + "[#row=1]")
                 _background_override[k] = v
             except IOError:
-                v1("WARNING: skipping map from {}".format(k) +
-                   " to {} as the latter is missing".format(v))
+                v1(f"WARNING: skipping map from {k} to {v} " +
+                   "as the latter is missing")
 
     return out
 
@@ -236,7 +237,7 @@ def get_par(argv):
     elif instrume == 'HRC':
         pars['dtffiles'] = paramio.pgetstr(pfile, 'dtffiles')
     else:
-        raise ValueError("Internal error: unrecognized INSTRUME keyword {}".format(instrume))
+        raise ValueError(f"Internal error: unrecognized INSTRUME keyword {instrume}")
 
     pars['refcoord'] = params['refcoord'] = paramio.pgetstr(pfile, 'refcoord')
 
@@ -348,20 +349,23 @@ def data_products(taskrunner,
     nargs = len(args)
 
     if nargs == 1:
-        v1("\nCreating the fluxed image.")
+        msg = "\nCreating the fluxed image."
 
     elif parallel:
-        v1("\nCreating the fluxed images for {} observations in parallel.".format(nargs))
+        msg = f"\nCreating the fluxed images for {nargs} observations in " + \
+            "parallel."
 
     else:
-        v1("\nCreating the fluxed images for {} observations.".format(nargs))
+        msg = f"\nCreating the fluxed images for {nargs} observations."
+
+    v1(msg)
 
     for (obs, bkgfile, chips, xygrid) in args:
 
-        outroot = "{}{}{}_".format(outdir, outhead, obs.obsid)
+        outroot = f"{outdir}{outhead}{obs.obsid}_"
 
         (xrng, yrng) = xygrid
-        grid = "x={},y={}".format(xrng, yrng)
+        grid = f"x={xrng},y={yrng}"
         # ox = xrng.nbins
         # oy = yrng.nbins
         binsize = xrng.size
@@ -374,7 +378,7 @@ def data_products(taskrunner,
         asolobj = AspectSolution(obs.get_asol(), tmpdir=tmpdir)
 
         fi.run_fluximage_tasks(taskrunner,
-                               lambda s: "{}-obsid{}".format(s, obs.obsid),
+                               lambda s: f"{s}-obsid{obs.obsid}",
                                obs,
                                bkginfo,
                                chips,

--- a/bin/reproject_obs
+++ b/bin/reproject_obs
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2019
+# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2019, 2020
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -43,25 +43,6 @@ import tempfile
 
 import paramio
 
-# path HACK
-try:
-    if not __file__.startswith(os.environ['ASCDS_INSTALL']):
-        _thisdir = os.path.dirname(__file__)
-        _libname = "python{}.{}".format(sys.version_info.major,
-                                        sys.version_info.minor)
-        _pathdir = os.path.normpath(os.path.join(_thisdir, '../lib', _libname, 'site-packages'))
-        if os.path.isdir(_pathdir):
-            os.sys.path.insert(1, _pathdir)
-        else:
-            print("*** WARNING: no {}".format(_pathdir))
-
-        del _libname
-        del _pathdir
-        del _thisdir
-
-except KeyError:
-    raise IOError('Unable to find ASCDS_INSTALL environment variable.\nHas CIAO been started?')
-
 import ciao_contrib.logger_wrapper as lw
 
 from ciao_contrib.param_wrapper import open_param_file
@@ -75,7 +56,7 @@ import ciao_contrib._tools.utils as utils
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'reproject_obs'
-__revision__ = '11 June 2019'
+__revision__ = '05 November 2020'
 
 lgr = lw.initialize_logger(toolname)
 v1 = lgr.verbose1
@@ -180,7 +161,7 @@ def link_or_copy_file(infile, outfile, linkfile=True):
     if _link_or_copy_file(infile + '.gz', outfile + '.gz', linkfile=linkfile):
         return
 
-    raise IOError("Input file {} not found (also tried .gz)".format(infile))
+    raise IOError(f"Input file {infile} not found (also tried .gz)")
 
 
 def _link_or_copy_file(infile, outfile, linkfile=True):
@@ -190,7 +171,7 @@ def _link_or_copy_file(infile, outfile, linkfile=True):
         return False
 
     if os.path.exists(outfile):
-        v3("File already exists at {}".format(outfile))
+        v3(f"File already exists at {outfile}")
         return True
 
     cwd = os.getcwd()
@@ -198,15 +179,15 @@ def _link_or_copy_file(infile, outfile, linkfile=True):
     ofile = os.path.join(cwd, outfile)
 
     if linkfile:
-        v3("Soft linking {} to {}".format(outfile, infile))
+        v3(f"Soft linking {outfile} to {infile}")
         try:
             os.symlink(ifile, ofile)
         except Exception:
-            v3("Soft link failed; copying file to {}".format(ofile))
+            v3(f"Soft link failed; copying file to {ofile}")
             shutil.copyfile(ifile, ofile)
 
     else:
-        v3("Copying {} to {}".format(infile, outfile))
+        v3(f"Copying {infile} to {outfile}")
         shutil.copyfile(ifile, ofile)
 
     return True
@@ -217,7 +198,7 @@ def dmhedit_line(key, value):
     file sent to dmhedit to change key to value.
     """
 
-    out = "{} = ".format(key)
+    out = f"{key} = "
     if isinstance(value, bool):
         if bool:
             out += "T"
@@ -226,7 +207,7 @@ def dmhedit_line(key, value):
 
     elif isinstance(value, str):
         if '/' in value:
-            out += "'{}'".format(value)
+            out += f"'{value}'"
         else:
             out += value
 
@@ -247,13 +228,13 @@ def update_ancillary_header(infile, adict, tmpdir="/tmp/"):
     if len(adict) == 0:
         return
 
-    v3("Updating ancillary file keywords of {}".format(infile))
+    v3(f"Updating ancillary file keywords of {infile}")
     tfile = tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+',
                                         suffix=".dmhedit")
     try:
         tfile.write("#add\n")
         for (k, v) in adict.items():
-            tfile.write(dmhedit_line("{}FILE".format(k), v))
+            tfile.write(dmhedit_line(f"{k}FILE", v))
 
         tfile.flush()
         run.dmhedit_file(infile, tfile.name)
@@ -308,11 +289,10 @@ def link_ancillary_files(taskrunner,
         """
 
         if obsid.is_multi_obi:
-            key = (obsid.obsid, obsid.obi)
-            label = "{}_{:03d}".format(*key)
+            label = f"{obsid.obsid}_{obsid.obi:03d}"
         else:
             key = obsid.obsid
-            label = "{}".format(key)
+            label = f"{key}"
 
         return (key, label)
 
@@ -345,8 +325,8 @@ def link_ancillary_files(taskrunner,
                 raise IOError("*Internal error* ObsId {} has no aspect solution.".format(obsid))
 
             elif nfiles == 1:
-                newname = "{}{}.asol".format(outroot, label)
-                taskname = "link-asol-{}".format(label)
+                newname = f"{outroot}{label}.asol"
+                taskname = f"link-asol-{label}"
                 taskrunner.add_task(taskname, [stask],
                                     link_or_copy_file,
                                     afiles[0],
@@ -360,17 +340,17 @@ def link_ancillary_files(taskrunner,
                 # what the code should do here since continue is a bit
                 # dangerous. Really it should error out
                 #
-                v1("WARNING: too many aspect solutions" +
-                   " ({}) for obsid {}".format(nfiles, obsid))
+                v1("WARNING: too many aspect solutions " +
+                   f"({nfiles}) for obsid {obsid}")
                 continue
 
             else:
                 newnames = []
                 for (idx, afile) in enumerate(afiles):
                     idval = chr(97 + idx)
-                    newname = "{}{}{}.asol".format(outroot, label, idval)
+                    newname = f"{outroot}{label}{idval}.asol"
                     newnames.append(os.path.basename(newname))
-                    taskname = "link-asol-{}-{}".format(label, idval)
+                    taskname = f"link-asol-{label}-{idval}"
                     taskrunner.add_task(taskname, [stask],
                                         link_or_copy_file,
                                         afile,
@@ -418,8 +398,8 @@ def link_ancillary_files(taskrunner,
             newname = instcache[key]
 
         except KeyError:
-            newname = "{}{}.{}".format(outroot, label, filetype)
-            taskname = labelconv("link-{}-{}".format(filetype, label))
+            newname = f"{outroot}{label}.{filetype}"
+            taskname = labelconv(f"link-{filetype}-{label}")
             taskrunner.add_task(taskname, [stask],
                                 link_or_copy_file,
                                 filename,
@@ -468,10 +448,10 @@ def link_ancillary_files(taskrunner,
     for (filetype, mobsids) in missing.items():
         nmiss += len(mobsids)
         if len(mobsids) == 1:
-            v1("Unable to find {} file for ObsId ".format(filetype) +
-               "{}.".format(mobsids[0]))
+            v1(f"Unable to find {filetype} file for ObsId " +
+               f"{mobsids[0]}.")
         else:
-            v1("Unable to find {} file for ObsIds ".format(filetype) +
+            v1(f"Unable to find {filetype} file for ObsIds " +
                "{}.".format(" ".join([str(mobsid) for mobsid in mobsids])))
 
     if nmiss > 0:
@@ -481,7 +461,7 @@ def link_ancillary_files(taskrunner,
             mlabel = "files"
 
         v1("")
-        v1("NOTE: The missing ancillary {} may affect the ".format(mlabel) +
+        v1(f"NOTE: The missing ancillary {mlabel} may affect the " +
            "reliability of further")
         v1("      analysis, such as the output of flux_obs.\n")
 
@@ -496,7 +476,7 @@ def link_ancillary_files(taskrunner,
             raise IOError("*Internal error* no header updates for " +
                           "ObsId {} ({})".format(obsid, reprofile))
 
-        taskname = labelconv("update-header-{}".format(obsid))
+        taskname = labelconv(f"update-header-{obsid}")
         taskrunner.add_task(taskname, [etask],
                             update_ancillary_header, reprofile, adict,
                             tmpdir=tmpdir)
@@ -654,7 +634,7 @@ def reproject_obsids():
 
     if params['evtmerge']:
         v1("The merged event file:")
-        v1("{}{}\n".format(spacer, mevtfile))
+        v1(f"{spacer}{mevtfile}\n")
         merging.display_merging_warnings(warnings,
                                          mevtfile,
                                          params['obsinfos'])

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -24,7 +24,6 @@ Routines used when merging and combining data.
 
 import os
 import tempfile
-import math
 
 import numpy as np
 
@@ -1551,36 +1550,10 @@ def merge_event_files(infiles,
     run.dmhedit_file(outfile, tfile.name)
 
 
-def normalize_value(ival, ndp=None):
-    """If ndp is not None then limit ival to ndp
-    decimal places.
-    """
-
-    if ndp is None:
-        return ival
-
-    if ndp < 0:
-        raise ValueError("ndp must be None or >= 0, but sent {}".format(ndp))
-
-    norm = math.pow(10, ndp)
-    if ival >= 0:
-        sgn = 1.0
-    else:
-        sgn = -1.0
-
-    return int(math.fabs(ival) * norm + 0.5) * sgn / norm
-
-
-def process_reference_position(refpos, obsinfos,
-                               rdp=4, ddp=5):
+def process_reference_position(refpos, obsinfos):
     """If refpos is given, extract the reference position from it,
     otherwise use the tangent points of the observations to calculate a
     "mean" location.
-
-    When *displaying* the position, the ra is limited to rdp decimal
-    places (unless set to None) and dec is limited to ddp decimal
-    places (unless set to None). The return values are *not* limited
-    to the rdp/ddp settings.
 
     The return value is the tuple
         (refcoordval, ra, dec)
@@ -1619,16 +1592,9 @@ def process_reference_position(refpos, obsinfos,
     if ra < 0:
         ra += 360.0
 
-    # TODO: it would be nice to restrict the accuracy of the seconds
-    #  conversion here. The simplest way is to restrict the
-    #  number of decimal places in the input. This is *only* for
-    #  the screen view.
-    #
-    ra2 = normalize_value(ra, rdp)
-    dec2 = normalize_value(dec, ddp)
-    rastr = coords.format.deg2ra(ra2, 'hms')
-    decstr = coords.format.deg2dec(dec2, 'dms')
-    v1("New tangent point: RA={} Dec={}".format(rastr, decstr))
+    rastr = coords.format.deg2ra(ra, 'hms', ndp=3)
+    decstr = coords.format.deg2dec(dec, 'dms', ndp=2)
+    v1(f"New tangent point: RA={rastr} Dec={decstr}")
 
     if rval is None:
         rval = "{0} {1}".format(ra, dec)

--- a/coords/format.py
+++ b/coords/format.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2011, 2013, 2015, 2016,2019
+#  Copyright (C) 2011, 2013, 2015, 2016, 2019
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -191,7 +191,7 @@ def dec2deg(dec):
     return deg
 
 
-def deg2ra(deg, format):
+def deg2ra(deg, format, ndp=None):
     """
     Converts degrees to an RA format. Optional formats include:
        space or ' ' -- 1 2 3
@@ -199,16 +199,27 @@ def deg2ra(deg, format):
        hms          -- 1h 2m 3s
        HMS          -- 1H 2M 3S
        hour         -- 23.5h
+
+    If ndp is not None then it is used to limit the number of decimal
+    places in the last token
     """
 
     # a dictionary of supported formats
-    formats = {"space": "{0} {1} {2}",
-               " ": "{0} {1} {2}",
-               "colon": "{0}:{1}:{2}",
-               ":": "{0}:{1}:{2}",
-               "hms": "{0}h {1}m {2}s",
-               "HMS": "{0}H {1}M {2}S",
-               "hour": "{0}h"}
+    #
+    if ndp is None or ndp == 0:
+        lval = ""
+    elif ndp > 0:
+        lval = f":.{ndp}f"
+    else:
+        raise ValueError("ndp must be None or >= 0")
+
+    formats = {"space": "{0} {1} {2" + lval + "}",
+               " ": "{0} {1} {2" + lval + "}",
+               "colon": "{0}:{1}:{2" + lval + "}",
+               ":": "{0}:{1}:{2" + lval + "}",
+               "hms": "{0}h {1}m {2" + lval + "}s",
+               "HMS": "{0}H {1}M {2" + lval + "}S",
+               "hour": "{0" + lval + "}h"}
 
     # verify the format is an expected format
     if format not in formats.keys():
@@ -250,24 +261,35 @@ def deg2ra(deg, format):
     return ra
 
 
-def deg2dec(deg, format):
+def deg2dec(deg, format, ndp=None):
     """
     Converts degrees to a Dec format. Optional formats include:
        space or ' ' -- 1 2 3
        colon or :   -- 1:2:3
        dms          -- 1d 2' 3"
        degree       -- 89.99d
+
+    If ndp is not None then it is used to limit the number of decimal
+    places in the last token
     """
 
     # TODO: there should be some way to force a sign character.
 
     # a dictionary of supported formats
-    formats = {"space": "{0} {1} {2}",
-               " ": "{0} {1} {2}",
-               "colon": "{0}:{1}:{2}",
-               ":": "{0}:{1}:{2}",
-               "dms": "{0}d {1}' {2}\"",
-               "degree": "{0}d"}
+    #
+    if ndp is None or ndp == 0:
+        lval = ""
+    elif ndp > 0:
+        lval = f":.{ndp}f"
+    else:
+        raise ValueError("ndp must be None or >= 0")
+
+    formats = {"space": "{0} {1} {2" + lval + "}",
+               " ": "{0} {1} {2" + lval + "}",
+               "colon": "{0}:{1}:{2" + lval + "}",
+               ":": "{0}:{1}:{2" + lval + "}",
+               "dms": "{0}d {1}' {2" + lval + "}\"",
+               "degree": "{0" + lval + "}d"}
 
     # format the hours minutes and seconds as requested
     if format not in formats.keys():

--- a/share/doc/xml/coords_format.xml
+++ b/share/doc/xml/coords_format.xml
@@ -25,13 +25,14 @@
       <LINE>(rad, decd) = sex2deg(ras, decs)</LINE>
       <LINE>rad = ra2deg(ras)</LINE>
       <LINE>decd = dec2deg(decs)</LINE>
-      <LINE>ras = deg2ra(rad, fmt)</LINE>
-      <LINE>decs = deg2dec(decd, fmt)</LINE>
+      <LINE>ras = deg2ra(rad, fmt, ndp=None)</LINE>
+      <LINE>decs = deg2dec(decd, fmt, ndp=None)</LINE>
       <LINE/>
       <LINE>rad and decd are in decimal degrees, ras and decs are strings.</LINE>
       <LINE>fmt is a string and can be one of: " ", "space", ":", "colon", and then
             either "hms", "HMS", "hour" or "dms", "degree" for deg2ra() and deg2dec()
             respectively</LINE>
+      <LINE>ndp gives the number of decimal places, if not None.</LINE>
       <LINE/>
       <LINE>The Python help command - e.g. help(deg2ra) - can be used.</LINE>
     </SYNTAX>
@@ -57,24 +58,39 @@ from coords.format import *
 	<SYNTAX>
 	  <LINE>&pr; from coords.format import *</LINE>
 	  <LINE>&pr; (ra, dec) = (101.28854, -16.71314)</LINE>
-          <LINE>&pr; def doit1(fmt): print("Format={} ra={}".format(fmt, deg2ra(ra,fmt)))</LINE>
+          <LINE>&pr; def doit1(fmt): print(f"Format={fmt:6s} ra={deg2ra(ra,fmt)}")</LINE>
           <LINE>&pr; for fmt in [" ", ":", "hms", "HMS", "hour"]: doit1(fmt)</LINE>
-          <LINE>Format=  ra=6 45 9.2496</LINE>
-          <LINE>Format=: ra=6:45:9.2496</LINE>
-          <LINE>Format=hms ra=6h 45m 9.2496s</LINE>
-          <LINE>Format=HMS ra=6H 45M 9.2496S</LINE>
-          <LINE>Format=hour ra=6.75256933333h</LINE>
-          <LINE>&pr; def doit2(fmt): print("Format={} dec={}".format(fmt, deg2dec(dec,fmt)))</LINE>
+          <LINE>Format=       ra=6 45 9.249599999997713</LINE>
+          <LINE>Format=:      ra=6:45:9.249599999997713</LINE>
+          <LINE>Format=hms    ra=6h 45m 9.249599999997713s</LINE>
+          <LINE>Format=HMS    ra=6H 45M 9.249599999997713S</LINE>
+          <LINE>Format=hour   ra=6.752569333333333h</LINE>
+          <LINE>&pr; def doit2(fmt): print(f"Format={fmt:6s} dec={deg2dec(dec,fmt)}")</LINE>
           <LINE>&pr; for fmt in [" ", ":", "dms", "degree"]: doit2(fmt)</LINE>
-          <LINE>Format=  dec=-16 42 47.304</LINE>
-          <LINE>Format=: dec=-16:42:47.304</LINE>
-          <LINE>Format=dms dec=-16d 42' 47.304"</LINE>
+          <LINE>Format=       dec=-16 42 47.30399999999719</LINE>
+          <LINE>Format=:      dec=-16:42:47.30399999999719</LINE>
+          <LINE>Format=dms    dec=-16d 42' 47.30399999999719"</LINE>
           <LINE>Format=degree dec=-16.71314d</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
             The deg2ra() and deg2dec() routines are used to convert decimal values
             into strings, showing the various different formatting options.
+	  </PARA>
+	</DESC>
+      </QEXAMPLE>
+
+      <QEXAMPLE>
+	<SYNTAX>
+          <LINE>&pr; print(deg2ra(ra, 'hms', ndp=3))</LINE>
+	  <LINE>6h 45m 9.250s</LINE>
+          <LINE>&pr; print(deg2dec(dec, 'dms', ndp=2))</LINE>
+	  <LINE>-16d 42' 47.30"</LINE>
+	</SYNTAX>
+	<DESC>
+	  <PARA>
+	    Here we use the oprional ndp argument to deg2ra() and deg2dec() to
+	    restrict the number of decimal places in the output.
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
@@ -95,6 +111,13 @@ from coords.format import *
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
+      <PARA>
+	The optional argument ndp has been added to the deg2ra and deg2dec
+	routines.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.8.1 (December 2015) release">
       <PARA>
         The code has been updated to avoid warning messages from
@@ -102,7 +125,7 @@ from coords.format import *
         script behaves.
       </PARA>
     </ADESC>
-    
+
     <ADESC title="Changes in the scripts 4.5.5 (October 2013) release">
       <PARA>
 	The deg2dec routine now correctly handles small negative declinations;
@@ -131,7 +154,7 @@ from coords.format import *
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>November 2015</LASTMODIFIED>
+    <LASTMODIFIED>December 2020</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/merge_obs.xml
+++ b/share/doc/xml/merge_obs.xml
@@ -2066,11 +2066,14 @@
 
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.13.1 (December 2020) release">
+    <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
       <PARA>
 	The warning message about not using the merged event file for
-	calculating instrument responses now just limits the differences
-	to the number of decimal places in the limit value.
+	calculating instrument responses now restricts the message so
+	that the value does not include excess precision, but is
+	limited to the limit value. The tangent point in the screen
+	output has also seen its accuracy reduced (this only affects
+	the screen output).
       </PARA>
     </ADESC>
 

--- a/share/doc/xml/merge_obs.xml
+++ b/share/doc/xml/merge_obs.xml
@@ -1548,7 +1548,7 @@
 	contamination layer can affect the analysis when using
 	a mono-chromatic energy for calculating exposure maps,
 	such as setting the bands parameter to one of the CSC
-	bands (in particular the soft band).	
+	bands (in particular the soft band).
       </PARA>
     </ADESC>
 
@@ -2066,6 +2066,14 @@
 
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.1 (December 2020) release">
+      <PARA>
+	The warning message about not using the merged event file for
+	calculating instrument responses now just limits the differences
+	to the number of decimal places in the limit value.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
       <PARA>
 	The script has been updated to support aspect solutions produced
@@ -2297,6 +2305,6 @@
 	listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>April 2020</LASTMODIFIED>
+    <LASTMODIFIED>December 2020</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/reproject_obs.xml
+++ b/share/doc/xml/reproject_obs.xml
@@ -19,7 +19,7 @@
       Reproject a set of observations to a common tangent point and
       create a merged event file.
     </SYNOPSIS>
-    
+
     <DESC>
       <PARA>
         Given a set of observations (event files and, optionally, aspect
@@ -39,7 +39,7 @@
       <PARA>
 	By default the event files will also be merged together to form
 	a single event file which can be used in ds9 or to create
-	images, time series, or spectra. Care should be taken 
+	images, time series, or spectra. Care should be taken
 	when using this merged product with other CIAO tools since
 	some information may have been lost (e.g. if observations have
 	different response files in the CALDB); the preference is to use
@@ -66,9 +66,9 @@
 	but no attempt is made to align the observations. If you find that
 	the WCS of the individual observations are not aligned - e.g. you
 	can see "double" sources in the reprojected, merged data - then
-	you need to update the WCS before running &rname;. An 
-	example is the 
-	<HREF link="https://cxc.harvard.edu/ciao/threads/reproject_aspect/">Correcting 
+	you need to update the WCS before running &rname;. An
+	example is the
+	<HREF link="https://cxc.harvard.edu/ciao/threads/reproject_aspect/">Correcting
 	Absolute Astrometry</HREF> thread.
       </PARA>
     </DESC>
@@ -90,7 +90,7 @@
 	    <ITEM>dirname/primary/*evt*</ITEM>
 	    <ITEM>dirname/*evt*</ITEM>
 	  </LIST>
-	  
+
 	  <PARA>
 	    where the search stops once a match is made.
 	  </PARA>
@@ -114,7 +114,7 @@
 	  </PARA>
 	</DESC>
       </QEXAMPLE>
-	  
+
 
       <QEXAMPLE>
 	<SYNTAX>
@@ -124,7 +124,7 @@
 	<DESC>
 	  <PARA>
 	    All the "evt2" files in the repro sub-directories
-	    are reprojected to create files called 
+	    are reprojected to create files called
 	    "reproj/&lt;obsid&gt;_reproj_evt.fits".
 	  </PARA>
 	</DESC>
@@ -150,11 +150,11 @@
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    This is similar to the first example except that 
+	    This is similar to the first example except that
 	    a stack file is used to list the files to be processed
 	    (see "ahelp stack" for more information).
 	    The UNIX find command is used to list all files that end in the
-	    text repro_evt2.fits that are in the current directory or any subdirectories, 
+	    text repro_evt2.fits that are in the current directory or any subdirectories,
 	    and this list is passed to &rname; using the "@" syntax.
 	  </PARA>
 	</DESC>
@@ -166,7 +166,7 @@
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-	    Here we apply a DataModel filter to the stack so that only 
+	    Here we apply a DataModel filter to the stack so that only
 	    the ACIS-I chips (ie those with ccd_id between 0 and 3 inclusive),
 	    will be reprojected and merged.
 	  </PARA>
@@ -319,7 +319,7 @@
 	    the output files will be named
 	    <EQUATION>&lt;obsid&gt;_reproj_evt.fits</EQUATION>
 	    in the specified directory.  Otherwise, the filename will
-	    be  
+	    be
 	    <EQUATION>&lt;outroot&gt;_&lt;obsid&gt;_reproj_evt.fits</EQUATION>
 	    where &lt;obsid&gt; is the value of the OBS_ID header
 	    keyword for each events file.
@@ -330,7 +330,7 @@
 	    <EQUATION>&lt;outroot&gt;/merged_evt.fits</EQUATION>
 	    or
 	    <EQUATION>&lt;outroot&gt;_merged_evt.fits</EQUATION>
-	    depending on whether the outroot parameter ends in 
+	    depending on whether the outroot parameter ends in
 	    "/" or not.
 	  </PARA>
 	  <PARA title="Interleaved mode">
@@ -352,7 +352,7 @@
 	  <PARA>
 	    If the value is empty then the ASOLFILE keyword from
 	    the events files will be used to find the
-	    files to use. 
+	    files to use.
 	  </PARA>
 	  <PARA>
 	    The aspect solution files have names like
@@ -384,7 +384,7 @@
 	  </PARA>
 	</DESC>
       </PARAM>
-      
+
       <PARAM name="merge" type="boolean" def="yes">
         <SYNOPSIS>
 	  Merge event files?
@@ -476,7 +476,7 @@
 	  </PARA>
 	</DESC>
       </PARAM>
-      
+
       <PARAM name="nproc" type="integer" def="INDEF">
 	<SYNOPSIS>
 	  Number of processors to use
@@ -568,7 +568,7 @@
 	  -->
 	</DESC>
       </PARAM>
-      
+
       <PARAM name="linkfiles" type="boolean" def="yes">
         <SYNOPSIS>
 	  Link (rather than copy) files?
@@ -591,7 +591,7 @@
 
       <PARAM name="tmpdir" type="string" def="${ASCDS_WORK_PATH}">
 	<SYNOPSIS>
-	  Directory for temporary files. 
+	  Directory for temporary files.
 	</SYNOPSIS>
 	<DESC>
 	  <PARA>
@@ -602,18 +602,18 @@
 	  </PARA>
 	</DESC>
       </PARAM>
-      
+
       <PARAM name="clobber" type="boolean" def="no">
 	<SYNOPSIS>
 	  Overwrite existing files?
 	</SYNOPSIS>
       </PARAM>
-      
+
       <PARAM name="verbose" type="integer" def="1">
 	<SYNOPSIS>
 	  Output verbosity.
 	</SYNOPSIS>
-	
+
 	<DESC>
 	  <PARA>
 	    The default verbosity value of 1 prints status
@@ -623,9 +623,9 @@
 	  </PARA>
 	</DESC>
       </PARAM>
-      
+
     </PARAMLIST>
-    
+
     <ADESC title="Ancillary files">
       <PARA>
         The reprojected event file for an observation is
@@ -674,12 +674,12 @@
 	If the linkfiles parameter is set to yes then
         these files are soft links to the files in the input
 	directory structure (i.e. the location of the input event files).
-        If the file system does not support soft links, 
+        If the file system does not support soft links,
 	or linkfiles is no, then a copy of the
 	file will be used instead.
       </PARA>
       <PARA>
-        The headers of the reprojected event files are updated so that 
+        The headers of the reprojected event files are updated so that
 	they reference the new file names. This allows tools like
 	&fname; and fluximage to pick the files up automatically when given just
 	the name of the reprojected event file.
@@ -693,9 +693,9 @@
 	shared between the two cycles, so do not get this extra label.
       </PARA>
       <PARA title="Multi-OBI datasets">
-	A small number of Chandra data sets contain 
+	A small number of Chandra data sets contain
 	<HREF link="https://cxc.harvard.edu/ciao/why/multiobi.html">multiple-OBI
-	  blocks</HREF>. For these cases, the 
+	  blocks</HREF>. For these cases, the
 	<HREF link="https://cxc.harvard.edu/ciao/ahelp/splitobs.html">splitobs</HREF>
 	script will create multiple directories, one for each OBI, and then
 	they can be analysed separately. To identify these observations, the
@@ -703,7 +703,7 @@
 	integer; for example: 3057_001 and 3057_002.
       </PARA>
     </ADESC>
-    
+
     <ADESC title="Processing steps">
       <PARA>
 	An overview of how &rname; works:
@@ -711,9 +711,9 @@
 
       <LIST>
 	<ITEM>
-	  The event files are checked to ensure they are all 
+	  The event files are checked to ensure they are all
 	  for the same instrument (ACIS-I and ACIS-S, HRC-I, or HRC-S).
-	  Event files with no data - perhaps because of a ccd_id filter - 
+	  Event files with no data - perhaps because of a ccd_id filter -
 	  or that are for CC-mode observations are ignored.
 	</ITEM>
 
@@ -728,7 +728,7 @@
 	  length, and several other useful details such as the focal-plane temperature (for ACIS),
 	  SIM position, and separation from the reference position.
 	</ITEM>
-	
+
 	<ITEM>
 	  The event files are reprojected to the new reference position,
 	  or copied if no reprojection is needed.
@@ -752,6 +752,14 @@
       </LIST>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.1 (December 2020) release">
+      <PARA>
+	The warning message about not using the merged event file for
+	calculating instrument responses now just limits the differences
+	to the number of decimal places in the limit value.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.9.2 (April 2017) release">
       <PARA>
 	The script now works when one (or more) of the ObsIds to be
@@ -771,11 +779,11 @@
 
     <ADESC title="Changes in the scripts 4.7.3 (June 2015) release">
       <PARA title="Improved support for multi-obi datasets">
-	The script is now able to work with 
+	The script is now able to work with
 	<HREF link="https://cxc.harvard.edu/ciao/why/multiobi.html">multi-obi datasets</HREF>
 	that have been processed by
 	<HREF link="https://cxc.harvard.edu/ciao/ahelp/splitobs.html">splitobs</HREF>
-	and then 
+	and then
 	<HREF link="https://cxc.harvard.edu/ciao/ahelp/chandra_repro.html">chandra_repro</HREF>.
       </PARA>
     </ADESC>
@@ -798,7 +806,7 @@
 
     <ADESC title="Changes in the scripts 4.5.2 (April 2013) release">
       <PARA title="Handling HRC data">
-	When merging HRC files, the sub-spaces of 
+	When merging HRC files, the sub-spaces of
 	several columns - including CLKTICKS, AV1, and AU1 -
 	have been removed to avoid the possibility of creating
 	multiple GTI blocks. See the
@@ -824,7 +832,7 @@
 	cycles then use an explicit list of observations.
 	When processing interleaved-mode data, file names are labelled as
 	"&lt;obsid&gt;e1"
-	or 
+	or
 	"&lt;obsid&gt;e2".
       </PARA>
       <PARA title="Aspect solutions">
@@ -861,11 +869,11 @@
 	See the
 	<HREF link="https://cxc.harvard.edu/ciao/bugs/&rname;.html">bugs page
 	for this script</HREF> on the CIAO website for an up-to-date
-	listing of known bugs. 
+	listing of known bugs.
       </PARA>
     </BUGS>
-    
-    <LASTMODIFIED>March 2017</LASTMODIFIED>
-    
+
+    <LASTMODIFIED>December 2020</LASTMODIFIED>
+
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/reproject_obs.xml
+++ b/share/doc/xml/reproject_obs.xml
@@ -752,11 +752,14 @@
       </LIST>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.13.1 (December 2020) release">
+    <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
       <PARA>
 	The warning message about not using the merged event file for
-	calculating instrument responses now just limits the differences
-	to the number of decimal places in the limit value.
+	calculating instrument responses now restricts the message so
+	that the value does not include excess precision, but is
+	limited to the limit value. The tangent point in the screen
+	output has also seen its accuracy reduced (this only affects
+	the screen output).
       </PARA>
     </ADESC>
 


### PR DESCRIPTION
For `merge_obs` and `reproject_obs`:

The warning message no-longer display the full difference, instead limiting to the number of decimal places in the limit (this means that values right at the limit will look to equal the limit but let's not worry about that as these limits are in some sense "made up" anyway).

We now also restrict the "accuracy" of the calculated tangent point (only for screen output, which @kglotfelty asked me about a **long** time ago). There's an interesting tweak there which leads to 36.92400... appear to be displayed as 36.83 but there's hysterical-raisons for this (the old version was trying to get "nice" output but doing it in an "interesting" way).

As an example:

# OLD

```
New tangent point: RA=7h 44m 16.703999999997734s Dec=37d 53' 36.924000000011574"
```

```
Warning: the merged event file x/merged_evt.fits
   should not be used to create ARF/RMF/exposure maps because
      the RA_NOM keyword varies by 0.002569232860011539 (limit is 0.0003)
      the DEC_NOM keyword varies by 0.030147682741002768 (limit is 0.0003)
      the ROLL_NOM keyword varies by 166.86669904322002 (limit is 1.0)
      the EXPTIME keyword contains: 0.4 3.1
        which means that the DTCOR value, and hence LIVETIME/EXPOSURE
        keywords are wrong
```

# NEW

```
New tangent point: RA=7h 44m 16.704s Dec=37d 53' 36.93"
```

```
Warning: the merged event file x/merged_evt.fits
   should not be used to create ARF/RMF/exposure maps because
      the RA_NOM keyword varies by 0.0026 (limit is 0.0003)
      the DEC_NOM keyword varies by 0.0301 (limit is 0.0003)
      the ROLL_NOM keyword varies by 166.9 (limit is 1.0)
      the EXPTIME keyword contains: 0.4 3.1
        which means that the DTCOR value, and hence LIVETIME/EXPOSURE
        keywords are wrong
```