### PR TITLE
mktgresp fix for hrc-i+letg

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -21,6 +21,12 @@ Updated scripts
     limit value. The tangent point in the screen output has also seen
     its accuracy reduced (this only affects the screen output).
 
+  mktgresp
+  
+    Fix for HRC-I + LETG combination.  The channel grid was mismatched
+    between the RMF and the PHA files. Note: there are no calibrations
+    for gratings used with HRC-I, so a diagonal RMF is created.    
+
 Updated Python modules
 
   ciao_contrib.runtool

--- a/bin/mktgresp
+++ b/bin/mktgresp
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # 
-# Copyright (C) 2013,2016-2018 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013,2016-2018, 2020 Smithsonian Astrophysical Observatory
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 from __future__ import print_function
 
 toolname = "mktgresp"
-__revision__ = "01 August 2018"
+__revision__ = "13 November 2020"
 
 
 import os
@@ -217,10 +217,12 @@ def make_tg_rmf( obsinfo, pha, spectrum, outroot, wvgrid_arf, wvgrid_chan):
 
     mkgrmf = make_tool("mkgrmf")
     det = determine_src_chip( spectrum.xx, spectrum.yy, obsinfo )
+    part = map_part_to_name( spectrum.part )
     if det == "HRC-I":
         verb0("WARNING: There are no grating RMF calibration products for HRC-I.  Will create a diagonal RMF")
         mkgrmf.diagonalrmf = True
-        det="ACIS-7"  # ACIS-7 is flat so that is kinda like HRC
+        if part.lower() != "leg":
+            det="ACIS-7"  # ACIS-7 for HETG
 
     mkgrmf.outfile     = get_outfile_name( outroot, spectrum, "rmf" )
     mkgrmf.obsfile     = obsinfo.evt
@@ -230,7 +232,7 @@ def make_tg_rmf( obsinfo, pha, spectrum, outroot, wvgrid_arf, wvgrid_chan):
     mkgrmf.order       = spectrum.order
     mkgrmf.srcid       = spectrum.tgid
     mkgrmf.detsubsys   = det
-    mkgrmf.grating_arm = map_part_to_name( spectrum.part )
+    mkgrmf.grating_arm = part
     mkgrmf.clobber     = True
     oo = mkgrmf()
     if oo:

--- a/share/doc/xml/mktgresp.xml
+++ b/share/doc/xml/mktgresp.xml
@@ -403,6 +403,19 @@ parameter is angstroms.
     </PARAM>
     </PARAMLIST>
 
+
+    <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
+      <PARA>
+        Fix for HRC-I + LETG data sets.  There was a mismatch between
+        the channel grid used in the PHA files and the grid used 
+        to create the RMF.  As of CALDB 4.9.3, there are no grating RMF
+        calibrations for HRC-I so the output is a diagonal RMF.
+      </PARA>
+    </ADESC>
+
+
+
+
     <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
       <PARA>
       Fix for the Python3 version where it fails to create responses 


### PR DESCRIPTION
use detsubsys=hrc-i for LETG case.  HETG still requires using acis.
