### PR TITLE
Mktgresp shadow bpix

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -28,6 +28,17 @@ Updated scripts
     
     Added button to run `conf` to the Model Editor GUI. 
 
+  mktgresp
+    The frame-store shadow is now included when calculating the
+    grating ARFs for ACIS observations. This means that there will
+    a change to the effective area at wavelengths which intersect the
+    bottom edge of the CCD (if any).  For more information see
+    https://cxc.cfa.harvard.edu/ciao4.13/caveats/acis_shadow_badpix.html
+
+    Updated to support HRC-I+LETG LSFPARM files if they are available
+    in the CALDB.  They are expected to be released in March 2021 with 
+    the Chandra CALDB 4.9.5 release.
+
 ## 4.13.0 - December 2020
 
 Updated scripts

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,14 +1,32 @@
 
-## 4.13.1 - January 2021
+## 4.13.1 - March 2020
 
-  mktgresp
+Updated scripts
+
+  download_obsid_caldb
   
-    Updated detsubsys parameter to recognize the new ACIS frame store 
-    shadow bit (17).
+    The script will now skip downloading CALDB files associated with
+    the transmission gratings (TG) if neither of the gratings
+    were inserted during the observation.
 
-    Updated to support HRC-I+LETG LSFPARM files if they are available
-    in the CALDB.
+  fluximage, flux_obs, merge_obs
 
+    The frame-store shadow is now included when calculating the
+    instrument map for ACIS observations. This means that a small
+    number of rows of the instrument and exposure maps are now
+    excluded, to match the data processing. Please see the ACIS
+    frane-store caveat for more information:
+    https://cxc.cfa.harvard.edu/ciao4.13/caveats/acis_shadow_badpix.html
+
+  dax
+  
+    Added additional redshifted absorption spectral models.
+    
+    Added energy limits to the photon and energy flux calculations.
+    Previously, the fluxes were computed for the entire energy range
+    rather than for just the noticed energy range.
+    
+    Added button to run `conf` to the Model Editor GUI. 
 
 ## 4.13.0 - December 2020
 

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -6,6 +6,9 @@
     Updated detsubsys parameter to recognize the new ACIS frame store 
     shadow bit (17).
 
+    Updated to support HRC-I+LETG LSFPARM files if they are available
+    in the CALDB.
+
 
 ## 4.13.0 - December 2020
 

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,4 +1,12 @@
 
+## 4.13.1 - January 2021
+
+  mktgresp
+  
+    Updated detsubsys parameter to recognize the new ACIS frame store 
+    shadow bit (17).
+
+
 ## 4.13.0 - December 2020
 
 Updated scripts

--- a/bin/mktgresp
+++ b/bin/mktgresp
@@ -241,8 +241,6 @@ def make_tg_rmf( obsinfo, pha, spectrum, outroot, wvgrid_arf, wvgrid_chan):
                 msg="""WARNING: Please consider upgrading CALDB versions. 
                 There are no grating RMF calibration products for HRC-I.  
                 Will create a diagonal RMF"""
-                msg = " ".join(msg.split())    # remove xtra whitespace
-                verb0(msg)
             else:
                 msg="""WARNING: There are no grating RMF calibration 
                 products for HRC-I. An RMF will be created using 
@@ -252,9 +250,10 @@ def make_tg_rmf( obsinfo, pha, spectrum, outroot, wvgrid_arf, wvgrid_chan):
                 broad compared with the RMF generated here owing to the 
                 flat HRC-I detector not following the geometry of the 
                 LETG Rowland torus."""                
-                msg = " ".join(msg.split())
-                verb0(msg)
 
+            # remove white spaces
+            msg = " ".join([x.strip() for x in msg.split("\n")])
+            verb0(msg)
 
     mkgrmf.outfile     = get_outfile_name( outroot, spectrum, "rmf" )
     mkgrmf.obsfile     = obsinfo.evt

--- a/bin/mktgresp
+++ b/bin/mktgresp
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # 
-# Copyright (C) 2013,2016-2018, 2020 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013,2016-2018, 2020, 2021 
+# Smithsonian Astrophysical Observatory
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 # 
 # This program is distributed in the hope that it will be useful,
@@ -20,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "mktgresp"
-__revision__ = "13 November 2020"
+__revision__ = "25 January 2021"
 
 
 import os

--- a/bin/mktgresp
+++ b/bin/mktgresp
@@ -333,6 +333,11 @@ def run_fullgarf( obsinfo, spectrum, outroot, dafile, osipfile ):
             mkgarf.asphistfile = outroot+"{}.asphist".format(ccd)
             mkgarf.outfile = get_outfile_name( outroot, spectrum, "{}.arf".format(ccd))
             mkgarf.detsubsys = "ACIS-{}".format(ccd)
+
+            # New ACIS badpix status bit 17 (frame store shadow) not
+            # included in standard bpixmask in 4.13.
+            mkgarf.detsubsys = mkgarf.detsubsys+";BPMASK=0x03ffff"
+
             oo = mkgarf()
             oo = filter_mkgarf_verbose(oo)
             if oo:

--- a/share/doc/xml/mktgresp.xml
+++ b/share/doc/xml/mktgresp.xml
@@ -404,15 +404,20 @@ parameter is angstroms.
     </PARAMLIST>
 
 
-    <ADESC title="Changes in the scripts 4.13.1 (January 20201) release">
-        <PARA>
-        Updated detsubsys parameter to recognize the new ACIS frame store 
-        shadow bit (17).    
-        </PARA>
-        <PARA>
+    <ADESC title="Changes in the scripts 4.13.1 (March 20201) release">
+      <PARA title="Ignore the frame-store shadow region">
+	The frame-store shadow is now included when calculating the
+	grating ARFs for ACIS observations. This means that there will
+    a change to the effective area at wavelengths which intersect the
+    bottom edge of the CCD (if any).  Please see the
+	<HREF link="https://cxc.cfa.harvard.edu/ciao4.13/caveats/acis_shadow_badpix.html">ACIS
+	frame-store caveat</HREF> for more information.
+    </PARA>
+    <PARA title="HRC-I+LETG Line Spread Function">
     Updated to support HRC-I+LETG LSFPARM files if they are available
-    in the CALDB.        
-        </PARA>
+    in the CALDB.  They are expected to be released in March 2021 with 
+    the Chandra CALDB 4.9.5 release.
+    </PARA>
 
 
     </ADESC>
@@ -498,7 +503,7 @@ parameter is angstroms.
         for this tool</HREF>
         on the CIAO website for an up-to-date listing of known bugs.
       </PARA></BUGS>
-   <LASTMODIFIED>January 2021</LASTMODIFIED>
+   <LASTMODIFIED>February 2021</LASTMODIFIED>
 
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/mktgresp.xml
+++ b/share/doc/xml/mktgresp.xml
@@ -414,7 +414,12 @@ parameter is angstroms.
     </ADESC>
 
 
-
+    <ADESC title="Changes in the scripts 4.13.1 (January 20201) release">
+        <PARA>
+        Updated detsubsys parameter to recognize the new ACIS frame store 
+        shadow bit (17).    
+        </PARA>
+    </ADESC>
 
     <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">
       <PARA>
@@ -488,7 +493,7 @@ parameter is angstroms.
         for this tool</HREF>
         on the CIAO website for an up-to-date listing of known bugs.
       </PARA></BUGS>
-   <LASTMODIFIED>May 2019</LASTMODIFIED>
+   <LASTMODIFIED>January 2021</LASTMODIFIED>
 
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/mktgresp.xml
+++ b/share/doc/xml/mktgresp.xml
@@ -404,6 +404,19 @@ parameter is angstroms.
     </PARAMLIST>
 
 
+    <ADESC title="Changes in the scripts 4.13.1 (January 20201) release">
+        <PARA>
+        Updated detsubsys parameter to recognize the new ACIS frame store 
+        shadow bit (17).    
+        </PARA>
+        <PARA>
+    Updated to support HRC-I+LETG LSFPARM files if they are available
+    in the CALDB.        
+        </PARA>
+
+
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
       <PARA>
         Fix for HRC-I + LETG data sets.  There was a mismatch between
@@ -411,14 +424,6 @@ parameter is angstroms.
         to create the RMF.  As of CALDB 4.9.3, there are no grating RMF
         calibrations for HRC-I so the output is a diagonal RMF.
       </PARA>
-    </ADESC>
-
-
-    <ADESC title="Changes in the scripts 4.13.1 (January 20201) release">
-        <PARA>
-        Updated detsubsys parameter to recognize the new ACIS frame store 
-        shadow bit (17).    
-        </PARA>
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.10.3 (October 2018) release">


### PR DESCRIPTION
Following from #209 and Pat's helpdesk questions, `mktgresp` now adding `BPMASK=0x03ffff` to `detsubsys`.

