### PR TITLE
Filter out frame-store rows for the instrument map

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -9,6 +9,14 @@ Updated scripts
     the transmission gratings (TG) if neither of the gratings
     were inserted during the observation.
 
+  fluximage, flux_obs, merge_obs
+
+    The frame-store shadow is now included when calculating the
+    instrument map for ACIS observations. This means that a small
+    number of rows of the instrument and exposure maps are now
+    excluded, to match the data processing. Please see the ACIS
+    frane-store caveat for more information:
+    https://cxc.cfa.harvard.edu/ciao4.13/caveats/acis_shadow_badpix.html
 
 ## 4.13.0 - December 2020
 

--- a/bin/flux_obs
+++ b/bin/flux_obs
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2018, 2020
-#           Smithsonian Astrophysical Observatory
+# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2018, 2020, 2021
+# Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -55,7 +55,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'flux_obs'
-__revision__ = '01 April 2020'
+__revision__ = '23 February 2021'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)

--- a/bin/fluximage
+++ b/bin/fluximage
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2018, 2020
-#           Smithsonian Astrophysical Observatory
+# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2018, 2020, 2021
+# Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -28,6 +28,7 @@ fluximage - create exposure corrected images for an ObsId
 
 import os
 import sys
+
 import paramio
 import stk
 import pycrates
@@ -47,7 +48,7 @@ from ciao_contrib._tools.taskrunner import TaskRunner
 import ciao_contrib._tools.fluximage as fi
 
 toolname = 'fluximage'
-__revision__  = '01 April 2020'
+__revision__  = '23 February 2021'
 
 lgr = lw.initialize_logger(toolname)
 v1 = lgr.verbose1

--- a/bin/merge_obs
+++ b/bin/merge_obs
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2018, 2020
-#           Smithsonian Astrophysical Observatory
+# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2018, 2020, 2021
+# Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -49,7 +49,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'merge_obs'
-__revision__ = '05 November 2020'
+__revision__ = '23 February 2021'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2018, 2019
-#           Smithsonian Astrophysical Observatory
+# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2018, 2019, 2021
+# Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -50,8 +50,9 @@ section is going to get run first. For now I think it is worth it.
 import os
 import tempfile
 import shutil
-import numpy as np
 import subprocess as sbp
+
+import numpy as np
 
 import paramio
 import pycrates as pcr
@@ -1206,18 +1207,24 @@ def instrument_map_acis(obs, outpath, chips, energies, units):
     badpix = obs.get_ancillary('bpix')
 
     for j in chips:
-        detsubsys = "ACIS-{}".format(j)
+        detsubsys = f"ACIS-{j}"
         if units == "time":
             detsubsys += ";IDEAL"
+
+        # Add the frame-store bit (needed since, as of CIAO 4.12, it
+        # isn't excluded automatically even though the data has been
+        # filtered at the L2 level).
+        #
+        detsubsys += ";BPMASK=0x03ffff"
 
         obsfile = obs.get_evtfile_no_dmfilter()
 
         if badpix == "CALDB":
             ardlib = None
         elif badpix == "NONE":
-            ardlib = "AXAF_ACIS{0}_BADPIX_FILE=NONE".format(j)
+            ardlib = f"AXAF_ACIS{j}_BADPIX_FILE=NONE"
         else:
-            ardlib = "AXAF_ACIS{0}_BADPIX_FILE={1}[BADPIX{0}]".format(j, badpix)
+            ardlib = f"AXAF_ACIS{j}_BADPIX_FILE={badpix}[BADPIX{j}]"
 
         for energy in energies:
             # Arguments are: outfile, maskfile, obsfile, detsubsys, monoenergy, weightfile, ardlib

--- a/share/doc/xml/flux_obs.xml
+++ b/share/doc/xml/flux_obs.xml
@@ -23,6 +23,7 @@
 		      expcorr correct
 		      obs obsid obsids observation observations
                       background subtract particle time subtract scale
+                      BPMASK detsubsys framestore frame store shadow
 		      csc soft medium hard broad wide weight weights weighted spectral spectrum"
 	 seealsogroups="mergescripts"
 	 displayseealsogroups="resptools">
@@ -1717,6 +1718,17 @@
 
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">
+      <PARA title="Ignore the frame-store shadow region">
+	The frame-store shadow is now included when calculating the
+	instrument map for ACIS observations. This means that a small number
+	of rows of the instrument and exposure maps are now excluded,
+	to match the data processing. Please see the
+	<HREF link="https://cxc.cfa.harvard.edu/ciao4.13/caveats/acis_shadow_badpix.html">ACIS
+	frame-store caveat</HREF> for more information.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
       <PARA>
 	The script has been updated to support aspect solutions produced
@@ -1906,6 +1918,6 @@
 	listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>April 2020</LASTMODIFIED>
+    <LASTMODIFIED>February 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/fluximage.xml
+++ b/share/doc/xml/fluximage.xml
@@ -12,6 +12,7 @@
 		      band bands combine merge mergeall merge-all merge_all
 		      csc soft medium hard broad wide weight weights
 		      spectral spectrum background bkg particle time subtract scale
+                      BPMASK detsubsys framestore frame store shadow
 		      BEVTFILE BKGMETH BKGSCALE STATFILT"
 	 seealsogroups="mergescripts"
 	 displayseealsogroups="resptools">
@@ -1276,7 +1277,7 @@
 	contamination layer can affect the analysis when using
 	a mono-chromatic energy for calculating exposure maps,
 	such as setting the bands parameter to one of the CSC
-	bands (in particular the soft band).	
+	bands (in particular the soft band).
       </PARA>
     </ADESC>
 
@@ -1583,6 +1584,17 @@
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">
+      <PARA title="Ignore the frame-store shadow region">
+	The frame-store shadow is now included when calculating the
+	instrument map for ACIS observations. This means that a small number
+	of rows of the instrument and exposure maps are now excluded,
+	to match the data processing. Please see the
+	<HREF link="https://cxc.cfa.harvard.edu/ciao4.13/caveats/acis_shadow_badpix.html">ACIS
+	frame-store caveat</HREF> for more information.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
       <PARA>
 	The script has been updated to support aspect solutions produced
@@ -1767,6 +1779,6 @@
 	listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>April 2020</LASTMODIFIED>
+    <LASTMODIFIED>February 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/merge_obs.xml
+++ b/share/doc/xml/merge_obs.xml
@@ -25,6 +25,7 @@
 		      obs obsid obsids observation observations
 		      reproject align
                       background subtract particle time subtract scale
+                      BPMASK detsubsys framestore frame store shadow
 		      csc soft medium hard broad wide weight weights weighted spectral spectrum"
 	 seealsogroups="mergescripts"
 	 displayseealsogroups="resptools">
@@ -2066,6 +2067,17 @@
 
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">
+      <PARA title="Ignore the frame-store shadow region">
+	The frame-store shadow is now included when calculating the
+	instrument map for ACIS observations. This means that a small number
+	of rows of the instrument and exposure maps are now excluded,
+	to match the data processing. Please see the
+	<HREF link="https://cxc.cfa.harvard.edu/ciao4.13/caveats/acis_shadow_badpix.html">ACIS
+	frame-store caveat</HREF> for more information.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
       <PARA>
 	The warning message about not using the merged event file for
@@ -2308,6 +2320,6 @@
 	listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>February 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Add BPMASK=0x03ffff filter to the detsubsys argument when running
mkinstmap to ignore the frame-store rows for ACIS data (this is for
the "flux image" routines only).

This is part of #209