### PR TITLE
download_chandra_obsid no-longer downloads vvref2 files by default

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -3,6 +3,12 @@
 
 Updated scripts
 
+  download_chandra_obsid
+
+    The --exclude option has been added, to allow file types to be
+    excluded, and the vvref file type has been added to identify the
+    vvref2.pdf.gz file in the secondary directory.
+
   download_obsid_caldb
   
     The script will now skip downloading CALDB files associated with

--- a/bin/download_chandra_obsid
+++ b/bin/download_chandra_obsid
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2020
-#            Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -71,7 +71,7 @@ import ciao_contrib.logger_wrapper as lw
 import ciao_contrib.cda.data as data
 
 TOOLNAME = "download_chandra_obsid"
-VERSION = "02 November 2020"
+VERSION = "04 March 2021"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)
@@ -104,8 +104,8 @@ setting of https://cxc.cfa.harvard.edu/cdaftp/
 
 
 COPYRIGHT_STR = """
-Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2020
-          Smithsonian Astrophysical Observatory
+Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2020, 2021
+Smithsonian Astrophysical Observatory
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/download_chandra_obsid
+++ b/bin/download_chandra_obsid
@@ -71,7 +71,7 @@ import ciao_contrib.logger_wrapper as lw
 import ciao_contrib.cda.data as data
 
 TOOLNAME = "download_chandra_obsid"
-VERSION = "04 March 2021"
+VERSION = "05 March 2021"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)
@@ -89,6 +89,10 @@ download the V&V, fov, and evt2 files for these observations. Stacks
 can also be used for these arguments (e.g. @obsids.txt where
 obsids.txt is a text file with one obsid per line). See 'ahelp stack'
 for more information on stacks.
+
+The --exclude flag can be used to exclude one or more filetypes;
+for example '--exclude vvref' will avoid downloading the larger
+V&V file for the ObsId.
 
 The data is written to the current directory, with each obsid being
 saved to its own directory (following the layout used by the Chandra
@@ -173,6 +177,9 @@ def download_chandra_obsid():
     parser.add_argument("filetypes", nargs='?',  # todo: enforce valid
                         help="Optional comma-separated list (or stack) of file types")
 
+    parser.add_argument("--exclude",
+                        help="Optional comma-separated list (or stack) of file types")
+
     parser.add_argument("--quiet", "-q", action="store_true",
                         help="Download the files without any screen output? [default: %(default)s]")
     parser.add_argument("--version", "-v", dest="list_version",
@@ -233,9 +240,18 @@ def download_chandra_obsid():
         tlist = [t.lower() for t in stk.build(tlist)]
         for t in tlist:
             if t not in data.known_file_types:
-                raise ValueError("{} is not a valid file type".format(t) +
+                raise ValueError(f"{t} is not a valid file type" +
                                  " - must be one of:\n" +
-                                 "{}".format(data.known_file_types_str))
+                                 "{data.known_file_types_str}")
+
+    elist = args.exclude
+    if elist is not None:
+        elist = [t.lower() for t in stk.build(elist)]
+        for t in elist:
+            if t not in data.known_file_types:
+                raise ValueError(f"{t} is not a valid file type" +
+                                 " - must be one of:\n" +
+                                 "{data.known_file_types_str}")
 
     if args.mirror_site:
         mirror = args.mirror_site
@@ -243,7 +259,8 @@ def download_chandra_obsid():
         mirror = None
 
     mirror = data.get_mirror_location(mirror)
-    data.download_chandra_obsids(olist, filetypes=tlist, mirror=mirror)
+    data.download_chandra_obsids(olist, filetypes=tlist, excludes=elist,
+                                 mirror=mirror)
 
 
 if __name__ == "__main__":

--- a/ciao_contrib/cda/data.py
+++ b/ciao_contrib/cda/data.py
@@ -368,10 +368,18 @@ class ObsId:
 
     def filter_files(self, types=None, formats=None):
         """Filter the list of files by the given types and/or formats.
+
+        If types is None then we exclude the vvref file type; that is if
+        you want to download the vvref2.pdf file you need to supply
+        a list of types and include the ''vvref' option. This is not
+        a great design!
         """
 
         V3(f"Before filtering: {len(self.files)} files")
-        if types is not None:
+        if types is None:
+            # exclude the vvref file
+            self.files = [f for f in self.files if not f.is_type(['vvref'])]
+        else:
             self.files = [f for f in self.files if f.is_type(types)]
         if formats is not None:
             self.files = [f for f in self.files if f.is_format(formats)]
@@ -459,11 +467,13 @@ def download_chandra_obsids(obsids,
     obsids should be a list of obsid values - e.g. [1843, 1557]
 
     If filetypes is None then all data for each obsid will be
-    downloaded, otherwise it is an array of strings determining which
-    files to download. See the known_file_types array in this module
-    for the list of supported types. An example would be ['evt2',
-    'bpix', 'asol'] to download just the level 2 event file, bad-pixel
-    file, and aspect solution files.
+    downloaded *EXCEPT* for the vvref file type, otherwise it is an
+    array of strings determining which files to download. See the
+    known_file_types array in this module for the list of supported
+    types. An example would be ['evt2', 'bpix', 'asol'] to download
+    just the level 2 event file, bad-pixel file, and aspect solution
+    files. This means that the only way to download the vvref file is
+    to expicitly ask for it.
 
     The mirror argument, if set to None (the default), means that the
     CDA HTTPS archive is used (the BASE_URL settign). Set it to the name

--- a/ciao_contrib/cda/data.py
+++ b/ciao_contrib/cda/data.py
@@ -496,7 +496,7 @@ def download_chandra_obsids(obsids,
         in both.
     mirror : str or None, optional
         If None then use the CDA HTTPS archive is used (the BASE_URL
-        settign), otherwise set it to the name of a mirror archive to
+        setting), otherwise set it to the name of a mirror archive to
         use that location instead. The value should refer to the
         directory that contains the "byobsid" directory.  The default
         value is equivalent to setting mirror to

--- a/ciao_contrib/cda/data.py
+++ b/ciao_contrib/cda/data.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2019, 2020
-#            Smithsonian Astrophysical Observatory
+#  Copyright (C) 2010, 2011, 2013, 2014, 2015, 2016, 2017, 2019, 2020, 2021
+#  Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@ Example with screen output:
   import ciao_contrib.logger_wrapper as lw
   lw.initialize_logger("download", verbose=1)
   out = download_chandra_obsids([1843, 1844],
-             ["evt1", "asol", "bpix", "mtl"])
+             ["vv", "evt1", "asol", "bpix", "mtl"])
 
 """
 
@@ -109,6 +109,7 @@ known_file_types = [
     "osol", "aqual",
     "sum", "pha2", "dtf", "plt",
     "adat",  # adat71 are PCAD Level 1 ACA image data files,
+    "vvref",
     "readme"
 ]
 known_file_types_str = known_file_types[:]
@@ -126,8 +127,10 @@ def extract_file_type(filename):
         return "oif"
     if filename.lower() == "00readme":
         return "readme"
-    if 'vv' in filename:
+    if 'vv2' in filename:
         return "vv"
+    if 'vvref2' in filename:
+        return "vvref"
 
     for ftype in known_file_types:
         suffix = '_{}'.format(ftype)

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd" [
  <!ENTITY tool "download_chandra_obsid">
 
- <!ENTITY ftypes "adat aoff aqual arf asol bias bpix cntr_img dtf eph0 eph1 evt1 evt1a evt2 flt fov full_img msk mtl oif osol pbk pha2 plt readme rmf soff src2 src_img stat sum vv">
+ <!ENTITY ftypes "adat aoff aqual arf asol bias bpix cntr_img dtf eph0 eph1 evt1 evt1a evt2 flt fov full_img msk mtl oif osol pbk pha2 plt readme rmf soff src2 src_img stat sum vv vvref">
 
  <!ENTITY pr "unix&#37;">
 
@@ -261,6 +261,15 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 	-->
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">
+      <PARA>
+	The vv option now only downloads the *_vv2.pdf file, and the
+	vvref option has been added to provide access to the *_vvref2.pdf
+	file. Note that most users only need the former (vv option) as
+	the vvref2 PDF file is significantly larger and is rarely needed.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
       <PARA>
 	The script should be more robust to changes made to the
@@ -343,6 +352,6 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>March 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -15,7 +15,7 @@
 		      data archive cda mirror public chaser webchaser
 		      dco download_chandra_obsids
                       &cdaenv;
-		      &ftypes; 00readme"
+		      &ftypes; 00readme include exclude"
          seealsogroups="contrib.cda"
 	 >
 
@@ -32,6 +32,7 @@
       <LINE>The supported file types are:</LINE>
       <LINE>&ftypes;</LINE>
       <LINE/>
+      <LINE>The --exclude flag allows you to skip a file type.</LINE>
       <LINE>The -m or --mirror flags allow you to use a mirror of the Chandra Data Archive.</LINE>
       <LINE>The -h or --help flags displays information on the command-line options.</LINE>
       <LINE>The -q or --quiet flags is used to turn off screen output.</LINE>
@@ -124,7 +125,7 @@ vv       pdf        78 Kb  ####################          &lt; 1 s  843.1 kb/s
 	  </PARA>
 
 <VERBATIM>
-Downloading files for ObsId 1842, total size is 63 Mb.
+Downloading files for ObsId 1842, total size is 81 Mb.
 
 Type     Format   Size  0........H.........1  Download Time Average Rate
 ------------------------------------------------------------------------
@@ -137,7 +138,7 @@ fov      fits     6 Kb  ####################          &lt; 1 s  108.1 kb/s
 msk      fits     5 Kb  ####################          &lt; 1 s  62.0 kb/s
 pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 
-    Total download size for ObsId 1842 = 63 Mb
+    Total download size for ObsId 1842 = 81 Mb
     Total download time for ObsId 1842 = 1 m 45 s
 </VERBATIM>
 	</DESC>
@@ -153,6 +154,19 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 	    asol, fov, and readme files from ObsId 1842.
 	  </PARA>
 	</DESC>
+      </QEXAMPLE>
+
+      <QEXAMPLE>
+	<SYNTAX>
+	  <LINE>&pr; download_chandra_obsid 1842 --exclude vvref</LINE>
+	</SYNTAX>
+	<DESC>
+	  <PARA>
+	    Download all but the vvref2.pdf file for obsid 1842. This file
+	    contains the detailed V&amp;V data for the observation and
+	    can be large.
+          </PARA>
+        </DESC>
       </QEXAMPLE>
 
       <QEXAMPLE>
@@ -271,17 +285,19 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
       </LIST>
       <PARA>
 	where the first file is intended for users, and the second is
-	only needed in rare situations. Since the vvref file is
-	significantly larger than the vv file (it can be a significant
-	fraction of the total data for an observation) we now no-longer
-	download the vvref2 file. The vv filetype option now only
-	selects the vv2 file, and the vvref option has been added to
-	select the vvref2 file.
+	only needed in rare situations. The vvref filetype has been added
+	to select this file, and the vv filetype now only refers to
+	the vv2 file.
+      </PARA>
+      <PARA title="Excluding file types">
+	The --exclude flag has been added to allow you to ignore
+	certain file types, so to avoid downloading the vvref2 file
+	you can say
       </PARA>
       <PARA>
-	For users who require the vvref2 file the easiest way is
-	to call download_chandra_obsid a second time and give a second
-	argument of "vvref".
+	<SYNTAX>
+	  <LINE>download_chandra_obsid 1843 --exclude vvref</LINE>
+        </SYNTAX>
       </PARA>
     </ADESC>
 

--- a/share/doc/xml/download_chandra_obsid.xml
+++ b/share/doc/xml/download_chandra_obsid.xml
@@ -124,7 +124,7 @@ vv       pdf        78 Kb  ####################          &lt; 1 s  843.1 kb/s
 	  </PARA>
 
 <VERBATIM>
-Downloading files for ObsId 1842, total size is 81 Mb.
+Downloading files for ObsId 1842, total size is 63 Mb.
 
 Type     Format   Size  0........H.........1  Download Time Average Rate
 ------------------------------------------------------------------------
@@ -137,7 +137,7 @@ fov      fits     6 Kb  ####################          &lt; 1 s  108.1 kb/s
 msk      fits     5 Kb  ####################          &lt; 1 s  62.0 kb/s
 pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
 
-    Total download size for ObsId 1842 = 81 Mb
+    Total download size for ObsId 1842 = 63 Mb
     Total download time for ObsId 1842 = 1 m 45 s
 </VERBATIM>
 	</DESC>
@@ -262,11 +262,26 @@ pbk      fits     4 Kb  ####################          &lt; 1 s  81.4 kb/s
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">
+      <PARA title="Validation and Verification files">
+	The Chandra archive contains two V&amp;V files for an observation:
+      </PARA>
+      <LIST>
+	<ITEM>axaff&lt;obsid&gt;N&lt;n&gt;_VV001_vv2.pdf</ITEM>
+	<ITEM>secondary/axaff&lt;obsid&gt;N&lt;n&gt;_VV001_vvref2.pdf.gz</ITEM>
+      </LIST>
       <PARA>
-	The vv option now only downloads the *_vv2.pdf file, and the
-	vvref option has been added to provide access to the *_vvref2.pdf
-	file. Note that most users only need the former (vv option) as
-	the vvref2 PDF file is significantly larger and is rarely needed.
+	where the first file is intended for users, and the second is
+	only needed in rare situations. Since the vvref file is
+	significantly larger than the vv file (it can be a significant
+	fraction of the total data for an observation) we now no-longer
+	download the vvref2 file. The vv filetype option now only
+	selects the vv2 file, and the vvref option has been added to
+	select the vvref2 file.
+      </PARA>
+      <PARA>
+	For users who require the vvref2 file the easiest way is
+	to call download_chandra_obsid a second time and give a second
+	argument of "vvref".
       </PARA>
     </ADESC>
 


### PR DESCRIPTION
download_chandra_obsid no only downloads the vvref2.pdf.gz file if explicitly asked for. The vvref option has been added to select these files, and the vv option now only selects the vv2.pdf file.

Fixes #463 but is a **tad** ugly.