### PR TITLE
WIP convert_xspec_script to support table models

### DIFF
--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2020
+# Copyright (C) 2020, 2021
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -51,7 +51,7 @@ from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "09 December 2020"
+TOOLVER = "01 July 2021"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)
@@ -66,7 +66,7 @@ The conversion is not guaranteed to match XSPEC perfectly.
 """
 
 COPYRIGHT_STR = """
-Copyright (C) 2020
+Copyright (C) 2020, 2021
           Smithsonian Astrophysical Observatory
 
 This program is free software; you can redistribute it and/or modify
@@ -139,7 +139,11 @@ if __name__ == "__main__":
     arglist = lw.preprocess_arglist(sys.argv[1:])
     args = parser.parse_args(arglist)
 
-    # lw.set_verbosity(args.verbose)
+    # Overload the --debug/--tracebackdebug hidden setting to also
+    # change the verbosity.
+    #
+    if '--debug' in sys.argv[1:] or '--tracebackdebug' in sys.argv[1:]:
+        lw.set_verbosity(5)  # what should we set?
 
     if args.list_version:
         V1(TOOLVER)

--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -40,6 +40,8 @@ Convert the XSPEC save file to Sherpa and print out the results.
 This is **experimental** and is not guaranteed to create the
 exact same output in Sherpa as it does in XSPEC.
 
+Infile and outfile can be '-' which means stdin/stdout.
+
 """
 
 import argparse
@@ -51,7 +53,7 @@ from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "01 July 2021"
+TOOLVER = "02 July 2021"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)
@@ -96,17 +98,23 @@ def check_clobber(fname):
 @lw.handle_ciao_errors(TOOLNAME, TOOLVER)
 def convert(infile, outfile, clean=False, clobber=False):
 
-    if not clobber:
+    if outfile != '-' and not clobber:
         check_clobber(outfile)
 
-    try:
-        cts = open(infile, 'r')
-    except OSError as oe:
-        raise OSError(f"Unable to read from '{infile}'") from oe
+    if infile == '-':
+        cts = sys.stdin
+    else:
+        try:
+            cts = open(infile, 'r')
+        except OSError as oe:
+            raise OSError(f"Unable to read from '{infile}'") from oe
 
     out = xcm.convert(cts, clean=clean)
-    with open(outfile, 'w') as fh:
-        fh.write(out)
+    if outfile == '-':
+        sys.stdout.write(out)
+    else:
+        with open(outfile, 'w') as fh:
+            fh.write(out)
 
 
 if __name__ == "__main__":
@@ -114,8 +122,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=HELP_STR,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument("infile", help="XCM file to convert")
-    parser.add_argument("outfile", help="Sherpa file to create")
+    parser.add_argument("infile", help="XCM file to convert (- for stdin)")
+    parser.add_argument("outfile", help="Sherpa file to create (- for stdout)")
 
     parser.add_argument("--clean", dest="clean", action="store_true",
                         default=False,

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -23,6 +23,8 @@
       <LINE/>
       <LINE>Unlike most CIAO contributed scripts, there is no parameter file.</LINE>
       <LINE/>
+      <LINE>If infile or outfile are - then stdin or stdout are used, respectively.</LINE>
+      <LINE/>
       <LINE>The supported command-line flags can be found using -h/--help:</LINE>
       <LINE/>
       <LINE>--clean     if the script should start with a call to clean</LINE>
@@ -229,6 +231,30 @@ set_source(1, m1(m2 * m3))
 	</DESC>
       </QEXAMPLE>
 
+      <QEXAMPLE>
+	<SYNTAX>
+	  <LINE>&upr; echo "model phabs(apec)" | &tool; - -</LINE>
+	  <LINE>model phabs(apec)</LINE>
+	  <LINE>Unable to find parameter value for nH - skipping other parameters</LINE>
+	  <LINE>from sherpa.astro.ui import *</LINE>
+	  <LINE/>
+	  <LINE/>
+	  <LINE># model phabs(apec)</LINE>
+	  <LINE>m1 = create_model_component('xsphabs', 'm1')</LINE>
+	  <LINE>m2 = create_model_component('xsapec', 'm2')</LINE>
+	  <LINE/>
+	  <LINE># Set up the model expressions</LINE>
+	  <LINE>#</LINE>
+	  <LINE>set_source(1, m1 * (m2))</LINE>
+	</SYNTAX>
+	<DESC>
+	  <PARA>
+	    Convert the input from stdin - in this case the string "model phabs(apec)" -
+	    and write the output to stdin.
+	  </PARA>
+	</DESC>
+      </QEXAMPLE>
+
     </QEXAMPLELIST>
 
     <ADESC title="Known Problems">
@@ -281,7 +307,9 @@ set_source(1, m1(m2 * m3))
     <ADESC title="Changes in the scripts 4.13.3 (July 2021) release">
       <PARA>
 	Support for XSPEC table models has been added. Note that XSPEC etable
-	models are not correctly supported in CIAO 4.13.
+	models are not correctly supported in CIAO 4.13. Input and output
+	can no be taken from stdin and stdout respectively by using the
+	"-" name.
       </PARA>
     </ADESC>
 

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -278,6 +278,13 @@ set_source(1, m1(m2 * m3))
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.13.3 (July 2021) release">
+      <PARA>
+	Support for XSPEC table models has been added. Note that XSPEC etable
+	models are not correctly supported in CIAO 4.13.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
       <PARA>
 	The script is new in this release.
@@ -306,6 +313,6 @@ set_source(1, m1(m2 * m3))
     </BUGS>
 -->
 
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>July 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/sherpa_contrib/tests/test_xcm.py
+++ b/sherpa_contrib/tests/test_xcm.py
@@ -85,7 +85,7 @@ set_source(1, m1 * m2)
 
 
 @pytest.mark.parametrize('expr',
-                         [pytest.param('cflux(powerlaw)', marks=pytest.mark.xfail),
+                         ['cflux(powerlaw)',
                           'cflux * powerlaw'])
 def test_cflux_powerlaw(expr):
     """cflux of powerlaw"""
@@ -124,7 +124,7 @@ m3 = create_model_component('xspowerlaw', 'm3')
 
 # Set up the model expressions
 #
-set_source(1, m1( (m2 * m3))
+set_source(1, m1(m2 * m3))
 """
 
     f = StringIO(f'model cflux*(phabs * powerlaw )')
@@ -132,7 +132,6 @@ set_source(1, m1( (m2 * m3))
     check(expected, answer)
 
 
-@pytest.mark.xfail
 def test_cflux_absorbed_powerlaw2():
     """cflux of absorbed powerlaw
 
@@ -187,7 +186,6 @@ set_source(1, m1(m2 * m3))
     check(expected, answer)
 
 
-@pytest.mark.xfail
 def test_absorbed_cflux_powerlaw1():
     """absorbed cflux powerlaw"""
 

--- a/sherpa_contrib/tests/test_xcm.py
+++ b/sherpa_contrib/tests/test_xcm.py
@@ -1,0 +1,349 @@
+#
+#  Copyright (C) 2021
+#            Smithsonian Astrophysical Observatory
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+
+"""
+Test routines for the convert_xspec_script code
+"""
+
+from io import StringIO
+import os
+
+import pytest
+
+from sherpa_contrib.xspec import xcm
+
+
+def check(expected, answer):
+    print(answer)  # makes it easier to see on a failure
+    texps = expected.split('\n')
+    tanss = answer.split('\n')
+    for texp, tans in zip(texps, tanss):
+        assert tans == texp
+
+    assert len(tanss) == len(texps)
+
+
+def test_powerlaw():
+    """model powerlaw"""
+
+    expected = """from sherpa.astro.ui import *
+
+
+# model powerlaw
+m1 = create_model_component('xspowerlaw', 'm1')
+
+# Set up the model expressions
+#
+set_source(1, m1)
+"""
+
+    f = StringIO('model powerlaw')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+@pytest.mark.parametrize('expr',
+                         ['phabs * powerlaw',
+                          'phabs(powerlaw)',
+                          'phabs* powerlaw'])
+def test_absorbed_powerlaw(expr):
+    """model powerlaw"""
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model {expr}
+m1 = create_model_component('xsphabs', 'm1')
+m2 = create_model_component('xspowerlaw', 'm2')
+
+# Set up the model expressions
+#
+set_source(1, m1 * m2)
+"""
+
+    f = StringIO(f'model {expr}')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+@pytest.mark.parametrize('expr',
+                         [pytest.param('cflux(powerlaw)', marks=pytest.mark.xfail),
+                          'cflux * powerlaw'])
+def test_cflux_powerlaw(expr):
+    """cflux of powerlaw"""
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model {expr}
+m1 = create_model_component('xscflux', 'm1')
+m2 = create_model_component('xspowerlaw', 'm2')
+
+# Set up the model expressions
+#
+set_source(1, m1(m2))
+"""
+
+    f = StringIO(f'model {expr}')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+def test_cflux_absorbed_powerlaw1():
+    """cflux of absorbed powerlaw
+
+    Note the output isn't guaranteed to be the same for all the
+    tests so we need separate ones.
+    """
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model cflux*(phabs * powerlaw )
+m1 = create_model_component('xscflux', 'm1')
+m2 = create_model_component('xsphabs', 'm2')
+m3 = create_model_component('xspowerlaw', 'm3')
+
+# Set up the model expressions
+#
+set_source(1, m1( (m2 * m3))
+"""
+
+    f = StringIO(f'model cflux*(phabs * powerlaw )')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+@pytest.mark.xfail
+def test_cflux_absorbed_powerlaw2():
+    """cflux of absorbed powerlaw
+
+    Note the output isn't guaranteed to be the same for all the
+    tests so we need separate ones.
+    """
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model cflux(phabs(powerlaw))
+m1 = create_model_component('xscflux', 'm1')
+m2 = create_model_component('xsphabs', 'm2')
+m3 = create_model_component('xspowerlaw', 'm3')
+
+# Set up the model expressions
+#
+set_source(1, m1(m2 * m3))
+"""
+
+    f = StringIO(f'model cflux(phabs(powerlaw))')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+def test_cflux_absorbed_powerlaw3():
+    """cflux of absorbed powerlaw
+
+    I am not convinced that we have the correct interpretation
+    of this as I don't find the model command documentation to
+    really explain the difference between
+
+        clux(phabs*powerlaw)
+        cflux*phabs*powerlaw
+    """
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model cflux*phabs*powerlaw
+m1 = create_model_component('xscflux', 'm1')
+m2 = create_model_component('xsphabs', 'm2')
+m3 = create_model_component('xspowerlaw', 'm3')
+
+# Set up the model expressions
+#
+set_source(1, m1(m2 * m3))
+"""
+
+    f = StringIO(f'model cflux*phabs*powerlaw')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+@pytest.mark.xfail
+def test_absorbed_cflux_powerlaw1():
+    """absorbed cflux powerlaw"""
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model phabs * cflux(powerlaw )
+m1 = create_model_component('xsphabs', 'm1')
+m2 = create_model_component('xscflux', 'm2')
+m3 = create_model_component('xspowerlaw', 'm3')
+
+# Set up the model expressions
+#
+set_source(1, m1 * m2(m3))
+"""
+
+    f = StringIO(f'model phabs * cflux(powerlaw )')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+@pytest.mark.xfail
+def test_absorbed_cflux_powerlaw2():
+    """absorbed cflux powerlaw"""
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model phabs(cflux(powerlaw))
+m1 = create_model_component('xsphabs', 'm1')
+m2 = create_model_component('xscflux', 'm2')
+m3 = create_model_component('xspowerlaw', 'm3')
+
+# Set up the model expressions
+#
+set_source(1, m1 * m2(m3))
+"""
+
+    f = StringIO(f'model phabs(cflux(powerlaw)))')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+@pytest.mark.xfail
+def test_absorbed_cflux_powerlaw():
+    """absorbed cflux powerlaw"""
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model phabs(cflux*powerlaw)
+m1 = create_model_component('xsphabs', 'm1')
+m2 = create_model_component('xscflux', 'm2')
+m3 = create_model_component('xspowerlaw', 'm3')
+
+# Set up the model expressions
+#
+set_source(1, m1 * m2(m3))
+"""
+
+    f = StringIO(f'model phabs(cflux*powerlaw))')
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+@pytest.mark.xfail
+def test_atable_expression():
+    """This requires the Sherpa test data to be available
+    at the SHERPATESTDIR environment variable.
+    """
+
+    path = os.getenv('SHERPATESTDIR')
+    if path is None:
+        pytest.skip("Need SHERPATESTDIR environment variable")
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model mtable{xspec-tablemodel-RCS.mod}(zpowerlw)
+load_table_model('m1', 'xspec-tablemodel-RCS.mod')
+m1 = get_model_component('m1')
+m2 = create_model_component('xszpowerlw', 'm2')
+
+# Set up the model expressions
+#
+set_source(1, m1 * m2)
+"""
+
+    f = StringIO('model mtable{xspec-tablemodel-RCS.mod}(zpowerlw)')
+
+    # How to run this test and get back to the correct directory whatever
+    # happens?
+    thisdir = os.getcwd()
+    os.chdir(path)
+
+    try:
+        answer = xcm.convert(f)
+    finally:
+        os.chdir(thisdir)
+
+    check(expected, answer)
+
+
+def test_param_powerlaw():
+    """Check the parameter handling"""
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model  powerlaw
+m1 = create_model_component('xspowerlaw', 'm1')
+set_par(m1.PhoIndex, 1.7)
+set_par(m1.norm, 0.023, max=1e+20)
+
+# Set up the model expressions
+#
+set_source(1, m1)
+"""
+
+    f = StringIO("""model  powerlaw
+            1.7       0.01         -3         -2          9         10
+          0.023       0.01          0          0      1e+20      1e+24
+""")
+    answer = xcm.convert(f)
+    check(expected, answer)
+
+
+def test_param_powerlaw_links():
+    """Check the parameter handling"""
+
+    expected = f"""from sherpa.astro.ui import *
+
+
+# model  constant(powerlaw + powerlaw)
+m1 = create_model_component('xsconstant', 'm1')
+m2 = create_model_component('xspowerlaw', 'm2')
+m3 = create_model_component('xspowerlaw', 'm3')
+set_par(m1.factor, 2)
+set_par(m2.PhoIndex, 1.7)
+set_par(m2.norm, 3, max=1e+20)
+link(m3.PhoIndex, m2.PhoIndex)
+set_par(m3.norm, 4, max=1e+20)
+
+# Set up the model expressions
+#
+set_source(1, m1 * (m2 + m3))
+"""
+
+    f = StringIO("""
+model  constant(powerlaw + powerlaw)
+              2       0.01          0          0      1e+10      1e+10
+            1.7       0.01         -3         -2          9         10
+              3       0.01          0          0      1e+20      1e+24
+= p2
+              4       0.01          0          0      1e+20      1e+24
+
+""")
+    answer = xcm.convert(f)
+    check(expected, answer)

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -27,8 +27,6 @@ analysis in Sherpa.
 
 """
 
-import logging
-
 from collections import defaultdict
 
 import numpy as np
@@ -41,12 +39,13 @@ from sherpa.utils.err import ArgumentErr, DataErr
 import sherpa.astro.instrument
 import sherpa.models.parameter
 
+from ciao_contrib.logger_wrapper import get_module_logger
+
 
 __all__ = ("convert", )
 
-lgr = logging.getLogger(__name__)
-dbg = lgr.debug
-del lgr
+
+dbg = get_module_logger(__name__).debug
 
 
 # Helper classes and functions that can be used by the converted

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1082,7 +1082,30 @@ def convert_model(expr, postfix, groups, names):
     mnum = 1
 
     process = ModelExpression(expr, groups, postfix, names)
+
+    # Scan through each character and when we have identified a term
+    # "seperator" then process the preceeding token. We assume the
+    # text is valid XSPEC - i.e. there's little to no support for
+    # invalid commands.
+    #
+    # Note that we switch mode when { is found as we have to
+    # then find the matching } and not any of the other normal
+    # tokens.
+    #
+    in_curly_bracket = False
     for end, char in enumerate(expr):
+
+        if char == '{':
+            if in_curly_bracket:
+                raise ValueError("Unable to parse '{expr}'")
+
+            in_curly_bracket = True
+            continue
+
+        if in_curly_bracket:
+            if char == '}':
+                in_curly_bracket = False
+            continue
 
         # Not completely sure of the supported language.
         #

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2020  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2020, 2021  Smithsonian Astrophysical Observatory
 #
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -405,11 +405,9 @@ def parse_tie(pars, add_import, add, par, pline):
     #
     line = line.translate({32: None})
 
-    # Build up the link expression. The state token indicates
-    # whether we are processing a function like abs or sin.
+    # Build up the link expression.
     #
     expr = ''
-    state = 'normal'
     token = ''
     exponentiation = False
     while line != '':

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -871,9 +871,10 @@ def convert_model(expr, postfix, groups, names):
 
         for i, grp in enumerate(groups, 1):
             # break out the prefix if set
+            outlist = out[i - 1]
             if prefix is not None:
-                out[i - 1].append((prefix, None))
-            out[i - 1].append(('(', None))
+                outlist.append((prefix, None))
+            outlist.append(('(', None))
 
     def close_sep(storage, postfix=None):
         storage['separator'] -= 1
@@ -1019,6 +1020,12 @@ def convert_model(expr, postfix, groups, names):
     if len(storage['nmodels']) != 1:
         dbg(f"storage[nmodels] = {storage['nmodels']}")
         print("WARNING: unexpected issues counting models")
+
+    dbg(f"Found {len(out)} expressions")
+    for i, expr in enumerate(out):
+        dbg(f"Expression: {i + 1}")
+        for token in expr:
+            dbg(f"  {token}")
 
     return out
 


### PR DESCRIPTION
You can now convert a script that uses table models (as long as they're not ETABLE models, at least not until CIAO 4.14).

Unfortunately the model expressions aren't always right (as soon as things get complicated), which is why it is still a WIP