### PR TITLE
chandra_repro: update CONTENT and HDUCLAS2 keywords

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -7,6 +7,11 @@ rather than a TTY.
 
 Updated scripts
 
+  chandra_repro
+
+    The reprocessed event file now has a CONTENT keyword set to "EVT2"
+    and HDUCLAS2 keyword set to "ACCEPTED".
+
   check_ciao_version
 
     The script now reports the 'conda install' command that is needed

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -2073,6 +2073,13 @@ def l2_acis_events(params):
     v5("dmcopy returned")
     v5(out)
 
+    dmhedit(evt2_file, file="", operation="add", key="CONTENT",
+            value="EVT2", datatype="string", unit="",
+            comment="What data product")
+    dmhedit(evt2_file, file="", operation="add", key="HDUCLAS2",
+            value="ACCEPTED", datatype="string", unit="",
+            comment="")
+
     #!## run dmappend to copy the REGION block from evt1a to evt2
     if grating != 'NONE':
         dmappend.punlearn()
@@ -2196,6 +2203,13 @@ def l2_hrc_events(params):
     out=dmcopy()
     v5("dmcopy returned")
     v5(out)
+
+    dmhedit(evt2_file, file="", operation="add", key="CONTENT",
+            value="EVT2", datatype="string", unit="",
+            comment="What data product")
+    dmhedit(evt2_file, file="", operation="add", key="HDUCLAS2",
+            value="ACCEPTED", datatype="string", unit="",
+            comment="")
 
     #!## run dmappend to copy the REGION block from evt1a to evt2
     # always use the original evt1a not pi filtered

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -790,6 +790,15 @@ acisf084244478N003_2_bias0.fits.gz
       </PARAM>
     </PARAMLIST>
 
+<ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
+  <PARA>
+  Updated the Level 2 event file keywords : CONTENT="EVT2"  and HDUCLAS2="ACCEPTED".
+  </PARA>
+
+
+</ADESC>
+
+
 
 <ADESC title="Changes in the script 4.13.3 (September 2021) release">
   <PARA>

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -792,9 +792,8 @@ acisf084244478N003_2_bias0.fits.gz
 
 <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
   <PARA>
-  Updated the Level 2 event file keywords : CONTENT="EVT2"  and HDUCLAS2="ACCEPTED".
+    Updated the Level 2 event file keywords : CONTENT="EVT2"  and HDUCLAS2="ACCEPTED".
   </PARA>
-
 
 </ADESC>
 
@@ -1234,6 +1233,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>September 2021</LASTMODIFIED>
+    <LASTMODIFIED>December 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #489 

only affects keywords; evt2 is/has always had standard filters applied.
