### PR TITLE
Chandra repro bowtie not applicable

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,3 +1,17 @@
+## 4.13.3 - September 2021
+
+Updated scripts
+
+  chandra_repro
+  
+    The HRC-S/LETG bow-tie filter, designed to reduce background, 
+    is not appropriate for data acquired after the HRC instrument
+    gain was changed. The bow-tie filter is marked invalid in CALDB
+    4.9.6 for these data.  chandra_repro has been modified to correctly
+    recognize that the file is not appropriate and continue processing
+    without it.  
+
+
 ## 4.13.2 - June 2021
 
 Updated scripts

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -164,9 +164,9 @@ def filter_aspsolobi_from_aspsol(asol_list,mydir,params):
         
     if "ASPSOLOBI" in content_values:
         if len( content_values["ASPSOLOBI"] ) > 1:
-            error_out("Too many ASPSOLOBI aspect file found.  If this "+
+            error_out(params, "Too many ASPSOLOBI aspect file found.  If this "+
             "is a mutli-obi observations, be sure to split it first "+
-            "using the splitobs script")
+            "using the splitobs script", 'input error')
 
     if "ASPSOL" in content_values and "ASPSOLOBI" in content_values:
         v2("WARNING: The primary directory has both CONTENT=ASPSOL and "+
@@ -196,7 +196,7 @@ def filter_aspsolobi_from_aspsol(asol_list,mydir,params):
                                               mydir, params)
         return new_asol
     
-    error_out("Unknown CONTENT keywords found in the aspect solution files")
+    error_out(params, "Unknown CONTENT keywords found in the aspect solution files", 'input error')
     
 
 def update_aspsol_to_aspsolobi(asol_list,mydir, params):
@@ -229,7 +229,7 @@ def update_aspsol_to_aspsolobi(asol_list,mydir, params):
             params["recreate_tg_mask"] = True
 
     if len(asol_list) == 0:
-        error_out("ERROR: No aspect solution files found")
+        error_out(params, "ERROR: No aspect solution files found", 'input error')
 
     # remove \n
     instk = [a.strip() for a in asol_list] 
@@ -241,8 +241,8 @@ def update_aspsol_to_aspsolobi(asol_list,mydir, params):
         if obsid is None:
             obsid = tab.get_key_value("OBS_ID")
         elif obsid != tab.get_key_value("OBS_ID"):
-            error_out("ERROR: The OBS_ID values in the aspect solution "+
-                      "files are different")
+            error_out(params, "ERROR: The OBS_ID values in the aspect solution "+
+                      "files are different", 'input error')
 
     outfile = "pcadf{:05d}_repro_asol1.fits".format(int(obsid))
     outfile = os.path.join(mydir, outfile)
@@ -1761,7 +1761,7 @@ def run_tgdetect2_and_create_mask(params):
     elif params["detnam"] == "HRC-S":
         evtfilter = "[status=xxxxxx00xxxx0xxx0000x000x00000xx]"
     else:
-        error_out("Bad detnam")  # should have crashed long before this
+        error_out(params, "Bad detnam", 'input error')  # should have crashed long before this
         
     dmcopy.infile = "{}[@{}]{}".format(params["evt1_file"],
                                        params["flt1_file"],
@@ -2100,7 +2100,7 @@ def lookup_hrc_pi_filter(evtfile):
         return None
     
     if len(calfiles) > 1:
-        error_out("Too many TGPIMASK2 CALDB files found for this dataset")
+        raise RuntimeError("ERROR: Too many TGPIMASK2 CALDB files found for this dataset")
 
     retval = calfiles[0]
     retval = retval.split("[")   # remove block name

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -2096,7 +2096,7 @@ def lookup_hrc_pi_filter(evtfile):
     calfiles = cdb.search
     
     if not calfiles or len(calfiles) == 0:
-        v1("No TGPIMASK2 CALDB files found for this dataset")
+        v1("No TGPIMASK2 CALDB file found for this dataset")
         return None
     
     if len(calfiles) > 1:

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "04 March 2021"
+version = "14 September 2021"
 
 # import standard python modules as required
 #
@@ -2096,7 +2096,8 @@ def lookup_hrc_pi_filter(evtfile):
     calfiles = cdb.search
     
     if not calfiles or len(calfiles) == 0:
-        error_out("No TGPIMASK2 CALDB files found for this dataset")
+        v1("No TGPIMASK2 CALDB files found for this dataset")
+        return None
     
     if len(calfiles) > 1:
         error_out("Too many TGPIMASK2 CALDB files found for this dataset")
@@ -2129,19 +2130,20 @@ def l2_hrc_events(params):
 
     # HRC-S/LETG gets background filtering
     if detnam == 'HRC-S' and grating == "LETG" and pifilter == 1:
-        v1("Applying the HRC-S/LETG background filter...")
-        # filtname = os.path.expandvars("$CALDB/data/chandra/hrc/tgpimask2/letgD1999-07-22pireg_tgmap_N0001.fits")
-        bg_filtered_evt1a = os.path.join(outdir, root + '_repro_bgfilt_evt1a.fits')
-        params["cleanup_files"].append(bg_filtered_evt1a)
         filtname = lookup_hrc_pi_filter(evt1a)
-        dmcopy.punlearn()
-        dmcopy.infile=evt1a+"[EVENTS][(tg_mlam,pi)=region("+filtname+")]"
-        dmcopy.outfile=bg_filtered_evt1a
-        dmcopy.clobber=clobber
-        out=dmcopy()
-        v5("dmcopy returned")
-        v5(out)
-        evt1a = bg_filtered_evt1a
+        if filtname is not None:
+            v1("Applying the HRC-S/LETG background filter...")
+            # filtname = os.path.expandvars("$CALDB/data/chandra/hrc/tgpimask2/letgD1999-07-22pireg_tgmap_N0001.fits")
+            bg_filtered_evt1a = os.path.join(outdir, root + '_repro_bgfilt_evt1a.fits')
+            params["cleanup_files"].append(bg_filtered_evt1a)
+            dmcopy.punlearn()
+            dmcopy.infile=evt1a+"[EVENTS][(tg_mlam,pi)=region("+filtname+")]"
+            dmcopy.outfile=bg_filtered_evt1a
+            dmcopy.clobber=clobber
+            out=dmcopy()
+            v5("dmcopy returned")
+            v5(out)
+            evt1a = bg_filtered_evt1a
 
     if grating == 'NONE':
         filtered_evt1 = os.path.join(outdir, root + '_repro_filt_evt1.fits')

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -791,6 +791,19 @@ acisf084244478N003_2_bias0.fits.gz
     </PARAMLIST>
 
 
+<ADESC title="Changes in the script 4.13.3 (September 2021) release">
+  <PARA>
+    The HRC-S/LETG bow-tie filter, designed to reduce background, 
+    is not appropriate for data acquired after the HRC instrument
+    gain was changed. The bow-tie filter is marked invalid in CALDB
+    4.9.6 for these data.  chandra_repro has been modified to correctly
+    recognize that the file is not appropriate and continue processing
+    without it.  
+  </PARA>
+
+</ADESC>
+
+
 <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">
   <PARA>
     Now updates the reprocessed aspect solution file, pcadf*_repro_asol1.fits,
@@ -1212,6 +1225,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>September 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Changes requested by Dale to allow for hrc-s/bowtie filter to be optional.  Pending CALDB update will make it not-applicable for recent (circa 2021) data due to gain/high-voltage something or the other.

This change allows the CALDB query to return 0 results and then just skip the bowtie filtering rather than erroring out (and tripping up of the bad call to error_out, which is also now corrected in several places).
