### PR TITLE
blanksky_sample: constrain time bounds of blanksky events

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -18,6 +18,11 @@ New scripts
 
 Updated scripts
 
+  blanksky_sample
+
+    The dead-time correction is now used to better sample the time
+    values created for the events in the blank-sky file.
+
   chandra_repro
 
     The reprocessed event file now has a CONTENT keyword set to "EVT2"

--- a/share/doc/xml/blanksky_sample.xml
+++ b/share/doc/xml/blanksky_sample.xml
@@ -339,7 +339,7 @@ ute
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the July 2021 Release">
+    <ADESC title="Changes in the scipts 4.14.0 (December 2021) release">
       <PARA>
 	Incorporated deadtime correction from reference observation to
 	better bound the time range the randomly sampled time values
@@ -358,6 +358,6 @@ ute
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>July 2021</LASTMODIFIED>
+    <LASTMODIFIED>December 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
incorporate deadtime correction to the constrain the time bounds for the randomly assigned values to events and reflect effective ONTIME/LIVETIME/EXPOSURE of reference observation and not just rely on TSTART/TSTOP.