### PR TITLE
download_obsid_caldb: set CALDBALIAS to dummy value

### DIFF
--- a/bin/download_obsid_caldb
+++ b/bin/download_obsid_caldb
@@ -28,7 +28,7 @@ import ciao_contrib.logger_wrapper as lw
 
 
 toolname = "download_obsid_caldb"
-__revision__ = "18 February 2021"
+__revision__ = "04 October 2021"
 
 lw.initialize_logger(toolname)
 
@@ -528,7 +528,8 @@ def setup_caldb_environment(outdir, newconfig):
 
     os.environ["CALDB"] = outdir
     os.environ["CALDBCONFIG"] = "{}/software/tools/caldb.config".format(outdir)  # newconfig
-
+    os.environ["CALDBALIAS"] = "None"
+    
     return oldcaldb
 
 

--- a/share/doc/xml/download_obsid_caldb.xml
+++ b/share/doc/xml/download_obsid_caldb.xml
@@ -355,6 +355,16 @@ they are skipped and only the background files are actually retrieved.
     
     </PARAMLIST>
 
+    <ADESC title="Changes in the script 4.14.0 (December 2021) release">
+      <PARA>
+        The script now internally sets the CALDBALIAS environment
+        variable to be compatible with changes in the pycaldb4
+        module.      
+      </PARA>
+    
+    </ADESC>
+
+
     <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">
       <PARA>
         The script will now skip downloading CALDB files associated with
@@ -427,7 +437,7 @@ they are skipped and only the background files are actually retrieved.
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>February 2021</LASTMODIFIED>
+    <LASTMODIFIED>October 2021</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>
 


### PR DESCRIPTION
Fix for #503 

Internally set the `CALDBALIAS` environment variable which is now required by the pycaldb4 module in CIAO 4.14.
