### PR TITLE
change how the tarfile is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,31 +43,34 @@ a lot of data, and may rely on unreleased versions of CIAO).
 
 ## How to create a tarball for the CIAO CM team
 
+This has **changed** in CIAO 4.14, bith the internals of the script
+and the arguments.
+
 A) a development release
 
-    % ./mk_script_tarfile 4.12 dev
+    % ./mk_script_tarfile 4.14.dev
 
 will create the file
 
-    ciao-4.12-contrib-DEV.tar.gz
+    ciao-4.14-contrib-DEV.tar.gz
 
 with a version file that looks like
 
-    % cat ciao-4.12/contrib/VERSION.CIAO_scripts 
-    scripts 4.12.DEV Friday, December 12, 2014
+    % cat ciao-4.14/contrib/VERSION.CIAO_scripts
+    scripts 4.14.DEV Friday, December 10, 2021
 
 B) a release candidate
 
-    % ./mk_script_tarfile 4.12 2
+    % ./mk_script_tarfile 4.14.0
 
 will create the file
 
-    ciao-4.12-contrib-2.tar.gz
+    ciao-4.14-contrib-0.tar.gz
 
 with a version file that looks like
 
-    % cat ciao-4.12/contrib/VERSION.CIAO_scripts 
-    scripts 4.12.2 Friday, December 12, 2014
+    % cat ciao-4.14/contrib/VERSION.CIAO_scripts
+    scripts 4.14.0 Friday, December 10, 2021
 
 At present there is no system to automatically look up the version
 number.
@@ -104,7 +107,7 @@ An example run:
     Input directores:
       /proj/xena/ciaot_install/osx64.131202/ciao-4.7
       ciao-4.7/contrib
-   
+
     Note: converting AXAF_HRC-I_QE_FILE -> AXAF_HRC_I_QE_FILE
     Note: converting AXAF_HRC-I_QEU_FILE -> AXAF_HRC_I_QEU_FILE
     ...
@@ -117,7 +120,7 @@ An example run:
       xoffset,i,h,INDEF,INDEF,INDEF,"celldetect offset of x axis from optical axis"
     Note: minval/maxval is INDEF in
       yoffset,i,h,INDEF,INDEF,INDEF,"celldetect offset of y axis from optical axis"
-   
+
     Created: ciao-4.7/contrib/lib/python2.7/site-packages/ciao_contrib/runtool.py
 
 The first lines tell you where it is looking for the tools and

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ a lot of data, and may rely on unreleased versions of CIAO).
 
 ## How to create a tarball for the CIAO CM team
 
-This has **changed** in CIAO 4.14, bith the internals of the script
+This has **changed** in CIAO 4.14, with the internals of the script
 and the arguments.
 
 A) a development release

--- a/bin/detilt
+++ b/bin/detilt
@@ -1,22 +1,22 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
-# 
+#
 # Copyright (C) 2015  Smithsonian Astrophysical Observatory
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 
 """Usage:
   detilt infile outfile tilt

--- a/bin/dewiggle
+++ b/bin/dewiggle
@@ -1,24 +1,24 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
-# 
+#
 # Copyright (C) 2015,2016 Smithsonian Astrophysical Observatory
-# 
-# 
-# 
+#
+#
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 
 """Usage:
   dewiggle infile outfile

--- a/bin/download_obsid_caldb
+++ b/bin/download_obsid_caldb
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 #
 # Copyright (C) 2013-2021 Smithsonian Astrophysical Observatory
@@ -44,7 +44,7 @@ CDA_SERVER="https://cxc.cfa.harvard.edu/cdaftp/arcftp/ChandraCalDB"
 
 def wrap_urlopen(url):
     """Wrap simple urlopen with a Request object w/ custom User-Agent
-    
+
     The ciao-install version of python doesn't setup the ssl certificates
     correctly so we have to access the cxc site w/o verification.
     """
@@ -90,7 +90,7 @@ def retrieve_config_files(baseurl, newver, rootdir, outdir):
     #
     init_output_dir("{}/config".format(outdir))
 
-    for dd in ["acis", "hrc", "default"]:        
+    for dd in ["acis", "hrc", "default"]:
         init_output_dir("{}/data/chandra/{}".format(outdir, dd))
 
         for ff in ["caldb.indx", "key.config"]:
@@ -103,7 +103,7 @@ def retrieve_config_files(baseurl, newver, rootdir, outdir):
             with open(outfile, "wb") as out_indx:
                 out_indx.write(p)
 
-            ftype = "config" if ff.endswith("config") else "indx"     
+            ftype = "config" if ff.endswith("config") else "indx"
             outfile="{}/config/{}-{}.{}".format(outdir,dd,newver,ftype)
             with open(outfile, "wb") as out_indx2:
                 out_indx2.write(p)
@@ -184,7 +184,7 @@ def filter_config(newver, outdir):
         fp.write("setenv CALDB {}\n".format(outdir))
         fp.write("setenv CALDBCONFIG {}/config/CHANDRA-{}.config\n".format(outdir, newver))
         fp.write("setenv CALDBALIAS none\n")
-        
+
     outconfig = "{}/config/caldbinit-{}.sh".format(outdir, newver)
     with open(outconfig, "w") as fp:
         fp.write("export CALDB={}\n".format(outdir))
@@ -303,7 +303,7 @@ def retrieve_caldb_file(baseurl, rootdir, looking_for, outdir, clobber, missing)
 
             url="{}/{}/{}".format(baseurl, zz, hasnam)
             page = wrap_urlopen(url)
-            
+
             if 'Content-Length' in page.headers:
                 fsize = int(page.headers['Content-Length'])
             else:
@@ -316,7 +316,7 @@ def retrieve_caldb_file(baseurl, rootdir, looking_for, outdir, clobber, missing)
 
             outfp = open(outfile, "wb")
 
-            if fsize is None: 
+            if fsize is None:
                 # page len unknown, skip hashes
                 outfp.write(page.read())
             else:
@@ -432,7 +432,7 @@ def get_tools(infile):
     from pycrates import read_file
     in_crate = read_file(infile,mode='r')
     grating = in_crate.get_key_value("GRATING")
-    
+
 
     acis_process_events = { 'grade' : None,        # 'gradefile'
                             'grdimg' : None,       # 'grade_image_file'
@@ -491,7 +491,7 @@ def get_tools(infile):
         }
 
 
-    retval = [pixlib, ardlib, acis_process_events, mkwarf, mkarf, 
+    retval = [pixlib, ardlib, acis_process_events, mkwarf, mkarf,
               mkpsfmap, mkacisrmf, hrc_process_events, misc]
 
     if grating.lower() in ['hetg', 'letg']:
@@ -529,7 +529,7 @@ def setup_caldb_environment(outdir, newconfig):
     os.environ["CALDB"] = outdir
     os.environ["CALDBCONFIG"] = "{}/software/tools/caldb.config".format(outdir)  # newconfig
     os.environ["CALDBALIAS"] = "None"
-    
+
     return oldcaldb
 
 
@@ -617,12 +617,12 @@ def print_new_setup(oldcaldb, outdir):
         verb0("source {}/software/tools/caldbinit.sh".format(outdir))
         verb0("")
 
-        
-        
-        
-        
-    
-    
+
+
+
+
+
+
 
 
 def locate_infile(infile):

--- a/bin/gti_align
+++ b/bin/gti_align
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 #
 # Copyright (C) 2015-2016, 2018, 2019

--- a/bin/multi_chip_gti
+++ b/bin/multi_chip_gti
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 #
 # Copyright (C) 2013-2014,2016 Smithsonian Astrophysical Observatory
@@ -42,18 +42,18 @@ from ciao_contrib.runtool import make_tool
 def input_order( infile, todo ):
     """
     Get the order of the CCDs in the subspace from the input.
-    
+
     This is important since ONTIME/LIVETIME/EXPOSURE are taken
-    from the *first* GTI, ie the first CCD in the subspace.  
+    from the *first* GTI, ie the first CCD in the subspace.
     """
-    
+
     from pycrates import read_file
     tab = read_file(infile)
-    
+
     ret_order = []
     ii = 0
 
-    # Ugh.  Wish there was a better way to get the number of 
+    # Ugh.  Wish there was a better way to get the number of
     # subspace components.
     while True:
         try:
@@ -61,7 +61,7 @@ def input_order( infile, todo ):
             subspace = tab.get_subspace_data( ii, "ccd_id")
         except Exception as e:
             break
-    
+
         for lo,hi in zip( subspace.range_min, subspace.range_max+1):
             for ccd in range( lo, hi ):
                 if ccd in ret_order:
@@ -74,7 +74,7 @@ def input_order( infile, todo ):
     t2 = dict(todo)
     # Only include ccds that are in the infile subspace already
     todo = [(x,t2[x]) for x in ret_order if x in t2 ]
-    
+
     return todo
 
 
@@ -84,8 +84,8 @@ def make_tempfile( tmpdir, suffix):
     """
     from tempfile import NamedTemporaryFile
 
-    class DelMe(str):    
-        # Trick to make sure temp files are always deleted.  
+    class DelMe(str):
+        # Trick to make sure temp files are always deleted.
         # As long as filename is passed around file will remain.
         # when filename goes away, garbage collection will delete it
         #
@@ -101,7 +101,7 @@ def make_tempfile( tmpdir, suffix):
 
     #
     # FWIW: There is a race condition here.  From the time the
-    # tempfile is closed (or goes out of scope) until the tool 
+    # tempfile is closed (or goes out of scope) until the tool
     # actually opens/creates it, the same tempfile name could be
     # generated again (say by another process).
     #
@@ -111,7 +111,7 @@ def make_tempfile( tmpdir, suffix):
     return outfile
 
 
-def prep_infile( cf, tmpdir ):    
+def prep_infile( cf, tmpdir ):
     """
     Create a copy of the input gti file that now has a CCD_ID subspace
     """
@@ -134,7 +134,7 @@ def prep_infile( cf, tmpdir ):
     # Remove CCD_ID column, subspace remains
     outfile = make_tempfile( tmpdir, "dmcopy_{}.gti".format(ccd))
     dmcopy( "{}[cols -ccd_id]".format( tmp2 ), outfile, clobber=True)
-    
+
     return outfile
 
 
@@ -147,7 +147,7 @@ def merge_files( infiles, outfile ):
     dmmerge = make_tool( "dmmerge")
     dmmerge( infiles, outfile, clobber=True, lookupTab="")
     return outfile
-    
+
 
 def not_none( ccd_fname ):
     """
@@ -174,23 +174,23 @@ def main():
     ccds = ["i0", "i1", "i2", "i3", "s0", "s1", "s2", "s3", "s4", "s5"]
 
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
+    pars = get_params(toolname, "rw", sys.argv,
                 verbose={"set":lw.set_verbosity, "cmd":verb1} )
 
     outfile_clobber_checks(pars["clobber"], pars["outfile"] )
 
     # Load *_gti parameters
     fnames = [ pars["{}_gti".format(x)] for x in ccds ]
-    
+
     # Determine which parameters are not "none" or blank
-    todo = [x for x in enumerate(fnames) if not_none(x)] 
+    todo = [x for x in enumerate(fnames) if not_none(x)]
 
     # Re-order ccds based on input file (if any)
     if not_none( (None, pars["infile"] )):
         todo = input_order( pars["infile"], todo )
 
     # Add ccd suspace to files
-    infiles = [prep_infile(t,pars["tmpdir"]) for t in todo ] 
+    infiles = [prep_infile(t,pars["tmpdir"]) for t in todo ]
 
     # Merge files
     merge_files( infiles, pars["outfile"] )
@@ -210,4 +210,3 @@ if __name__ == "__main__":
         print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
-  

--- a/bin/psfsize_srcs
+++ b/bin/psfsize_srcs
@@ -1,22 +1,22 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
- 
+
 # Copyright (C) 2013,2016 Smithsonian Astrophysical Observatory
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 from __future__ import print_function
 
 
@@ -53,7 +53,7 @@ def lookup_psffile_in_caldb( calfile ):
     """
     Lookup REEF caldb file -- calfile itself not currently used
     """
-    
+
     c = cldb.Caldb( "chandra", None, "REEF")
     myfile = c.search
     if len(myfile) != 1:
@@ -64,16 +64,16 @@ def lookup_psffile_in_caldb( calfile ):
 
 def get_psf_size( psffile, theta, phi, energy, fraction, pixsize=1 ):
     """
-    Get PSF size for given fration/theta/phi    
+    Get PSF size for given fration/theta/phi
     """
-    
+
     def initalize_psf( calfile ):
         """ Open PSF file """
         if not calfile or calfile[0:5] == 'CALDB':
             calfile = lookup_psffile_in_caldb( calfile )
         psf = psfInit( calfile )
         return psf
-    
+
     if len(theta) != len(phi) :
         raise LookupError("Must have same number of theta & phi values")
 
@@ -95,7 +95,7 @@ def get_keys_from_crate( myfile ):
 
 def parse_ebands( energy ):
     """
-    Parse energy band string    
+    Parse energy band string
     """
     csc = { 'broad' : 2.3, 'soft' : 0.92, 'ultrasoft' : 0.4, 'medium' : 1.56, 'hard' : 3.8, 'wide' : 1.5 }
     if energy in csc:
@@ -106,14 +106,14 @@ def parse_ebands( energy ):
         return retval
     except ValueError:
         pass # okay,will try other combos
-    
+
     if ':' not in energy:
         raise ValueError("Unknown energy {}".format(energy))
-    
+
     ee=energy.split(":")
     if 3 != len(ee):
         raise ValueError("Bad energy range format {}".format(energy))
-    
+
     try:
         retval = float(ee[2])
         return retval
@@ -123,19 +123,19 @@ def parse_ebands( energy ):
 
 def write_output(outfile, radii, ra_vals, dec_vals, coords, mykeys):
     """
-    Write output file 
-    """    
+    Write output file
+    """
     shape = ['circle'] * len(radii)
     component = range(1,len(radii)+1)
 
-    cnam = [x.upper() for x in [ 'shape', 'x', 'y', 'r', 'component', 
-        'ra', 'dec', 'theta', 'phi', 'detx', 'dety', "chip_id", "chipx", 
+    cnam = [x.upper() for x in [ 'shape', 'x', 'y', 'r', 'component',
+        'ra', 'dec', 'theta', 'phi', 'detx', 'dety', "chip_id", "chipx",
         "chipy", "near_chip_edge"]]
     cval = [ shape, coords["x"], coords["y"],
-        radii, component, ra_vals, dec_vals, 
-        coords["theta"], coords["phi"], coords["detx"], coords["dety"], 
+        radii, component, ra_vals, dec_vals,
+        coords["theta"], coords["phi"], coords["detx"], coords["dety"],
         coords["chip_id"], coords["chipx"], coords["chipy"], coords["offchip"] ]
-    units = ['', 'pixel', 'pixel', 'pixel', '', 'deg', 'deg', 'arcmin', 
+    units = ['', 'pixel', 'pixel', 'pixel', '', 'deg', 'deg', 'arcmin',
         'deg', "pixel", "pixel", "", "pixel", "pixel", ""]
     desc = [ 'region geometry',
         'X center',
@@ -171,10 +171,10 @@ def write_output(outfile, radii, ra_vals, dec_vals, coords, mykeys):
     lt.get_parameter("SCALE").set_value(coords["pixsize"])
     lt.get_parameter("OFFSET").set_value( 0.0 )
     lt.name = "CEL_R"
-    rc = tab.get_column("r")    
+    rc = tab.get_column("r")
     # Crates bug won't allow transform to be set? Error on write()
     #rc._set_transform(lt)
-        
+
     for k in mykeys:
         ck = pc.CrateKey()
         ck.name = k
@@ -186,13 +186,13 @@ def write_output(outfile, radii, ra_vals, dec_vals, coords, mykeys):
 
 def check_chip_edge( coords, mykeys, edge ):
     """
-    
+
     """
-    
+
     if mykeys["INSTRUME"].lower() == "hrc":
         coords["offchip"] = [False]*len(coords["chipx"])
         return
-    
+
     coords["offchip"] = [False]*len(coords["chipx"])
 
     xmin = 1 +edge
@@ -201,14 +201,14 @@ def check_chip_edge( coords, mykeys, edge ):
 
     if "FIRSTROW" not in mykeys or "NROWS" not in mykeys:
         verb0("Missing 'FIRSTROW' or 'NROWS' keyword, cannot determine if this is a subarray dataset")
-    
+
     # Handle subarray, (doesn't do windows)
     ylo = mykeys["FIRSTROW"] if "FIRSTROW" in mykeys else 1
     nrow = mykeys["NROWS"] if "NROWS" in mykeys else 1024
 
     ymin =  ylo + edge
     ymax = (nrow-1) - edge
-    
+
     def offchip( pos):
         x = pos[0]
         y = pos[1]
@@ -217,8 +217,8 @@ def check_chip_edge( coords, mykeys, edge ):
         return True
 
     coords["offchip"] = list(map( offchip, zip(coords["chipx"], coords["chipy"] )))
-    
-    
+
+
 
 
 #
@@ -228,9 +228,9 @@ def check_chip_edge( coords, mykeys, edge ):
 def main():
     from ciao_contrib.runtool import add_tool_history
     from ciao_contrib._tools.fileio import outfile_clobber_checks
-    
+
     # get parameters
-    pars = get_params(toolname, "rw", sys.argv, 
+    pars = get_params(toolname, "rw", sys.argv,
         verbose={"set":lw.set_verbosity, "cmd":verb1} )
 
     outfile_clobber_checks(pars["clobber"], pars["outfile"] )
@@ -242,20 +242,20 @@ def main():
     energy = parse_ebands( pars["energy"] )
 
     # Convert ra/dec to theta/phi and x/y
-    myfile = read_file( pars["infile"] ) 
+    myfile = read_file( pars["infile"] )
     mykeys = get_keys_from_crate( myfile )
     coords = cel_to_chandra( mykeys, ra_vals, dec_vals )
 
     check_chip_edge( coords, mykeys, AcisEdge )
 
     # Get PSF size
-    radii = get_psf_size( pars["psffile"], coords["theta"], coords["phi"], 
+    radii = get_psf_size( pars["psffile"], coords["theta"], coords["phi"],
         energy, float(pars["ecf"]), coords["pixsize"] )
 
     # Write output
     write_output(pars["outfile"], radii, ra_vals, dec_vals, coords, mykeys)
     add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
-    
+
 
 if __name__ == "__main__":
     try:
@@ -264,4 +264,3 @@ if __name__ == "__main__":
         print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
-    

--- a/bin/splitobs
+++ b/bin/splitobs
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 #
 # Copyright (C) 2013-2014,2016 Smithsonian Astrophysical Observatory
@@ -28,7 +28,7 @@ import os
 import sys
 
 import glob
-import shutil    
+import shutil
 
 
 
@@ -47,11 +47,11 @@ from pycrates import read_file
 
 TODO = """
 
-Intentionally skipping 
-   primary/orbit* 
-   secondary/aspect/ 
+Intentionally skipping
+   primary/orbit*
+   secondary/aspect/
    secondary/ephem/
-   supporting/ 
+   supporting/
 dirs.
 
 """
@@ -94,45 +94,45 @@ class ChandraObs( object ):
     def copy( self, inglob, outdir ):
         """
         Copy a glob of file names
-        """        
+        """
 
         to_cp = list(glob.glob(inglob))
 
         if to_cp is None or 0 == len(to_cp):
             return
-        
+
         for ff in to_cp:
             bn = os.path.basename(ff)
             outnm = outdir+"/"+bn
             if os.path.exists( outnm ):
                 verb0("Overwriting file '{}'".format(outnm))
             shutil.copy2( ff, outnm )
-    
+
     @staticmethod
     def get_exposure( outdir ):
         """
-        Report the exposure time of evt1 file in output dir        
+        Report the exposure time of evt1 file in output dir
         """
-        
+
         evt1 = glob.glob(outdir+"/secondary/*evt1.fits*")
         if 0 == len(evt1):
             raise IOError("There should be one event file by now")
         if len(evt1) > 1 :
             raise IOError("There should only be one event file now")
-        
+
         exposure = read_file( evt1[0] ).get_key_value("EXPOSURE")
-        
+
         estr = "{:.1f} ks".format( float(exposure)/1000.0)
         return estr
-        
+
 
 
 class InterleavedMode( ChandraObs ):
     """
     Interleaved mode obseravation.
-    
+
     The files in interleaved are easier since they are never combined
-    in L2.  Everything _e1_ is e1, everything e2 is e2, and 
+    in L2.  Everything _e1_ is e1, everything e2 is e2, and
     everthing that isn't either (eg pcad and level 0 files) are
     common to both.
     """
@@ -143,7 +143,7 @@ class InterleavedMode( ChandraObs ):
     def relocate( self, outroot):
         self.make_dirs( outroot, "e1")
         self.make_dirs( outroot, "e2")
-        
+
         for ee in ["e1", "e2"]:
             # Copy primary and secondary products
             self.copy( self.indir+"/primary/*_"+ee+"_*", outroot+"_"+ee+"/primary")
@@ -155,9 +155,9 @@ class InterleavedMode( ChandraObs ):
 
             exposure = self.get_exposure( "{}_{}".format( outroot, ee ))
             verb1( "Created: {}_{}, exposure={}".format( outroot, ee, exposure))
-        
 
-    
+
+
 class MultiObi(ChandraObs):
     """
     Multi OBI observation
@@ -203,67 +203,67 @@ class MultiObi(ChandraObs):
 
         for k in self.obinum:
             self.make_dirs( outroot, self.obinum[k])
-        
+
         for oo in self.obinum:
             for d in ["primary", "secondary"]:
                 # Multi-obi L1 file names have 5 digit obsid underscore 3 digit obinum
-                self.copy( "{}/{}/*f?????_{}N0*".format( self.indir, d, self.obinum[oo]), 
+                self.copy( "{}/{}/*f?????_{}N0*".format( self.indir, d, self.obinum[oo]),
                            "{}_{}/{}".format(outroot, self.obinum[oo], d ) )
 
             # L2 files are common (albeit useless) between OBIs
             self.copy("{}/primary/*2.fits*".format( self.indir),
                       "{}_{}/primary".format(outroot, self.obinum[oo] ))
 
-            # Now the extra work to separate the ASOL, PBK, and BIAS files, 
+            # Now the extra work to separate the ASOL, PBK, and BIAS files,
             # each of these is time based.  We use header info to locate
             # files by name in their standard dirs.
-            
+
             if self.asols[oo]:
                 for asol in self.asols[oo].split(","):
                     self.copy("{}/primary/{}*".format( self.indir, asol),
                               "{}_{}/primary".format(outroot, self.obinum[oo] ))
-            
+
             if self.pbks[oo]:
                 self.copy("{}/secondary/{}*".format( self.indir, self.pbks[oo]),
                           "{}_{}/secondary".format(outroot, self.obinum[oo] ))
-            
+
             if self.biases[oo]:
                 for bias in self.biases[oo].split(","):
                     self.copy("{}/secondary/{}*".format( self.indir, bias),
                               "{}_{}/secondary".format(outroot, self.obinum[oo] ))
-            
+
             if self.gratings[oo] in ['HETG', 'LETG']:
                 self.teardown_evt2(oo,outroot+"_{}".format(self.obinum[oo]))
-            
+
 
             exposure = self.get_exposure( "{}_{}".format( outroot,self.obinum[oo]  ))
             verb1( "Created: {}_{}, exposure={}".format( outroot,self.obinum[oo], exposure ))
-            
-    
+
+
 
     def teardown_evt2( self, obi, outroot ):
         """
         So much code for only 4 obsids ...
 
-        The l2 event file has multiple REGION extensions that are 
+        The l2 event file has multiple REGION extensions that are
         appropriate for each individual obi.  To be useful we need
         to extract the correct block, renamed to be simply REGION
         and create an obi-level, level2 event file.
-        
+
         """
         from ciao_contrib.runtool import dmcopy
         from ciao_contrib.runtool import dmappend
-        
+
         evt2_in = glob.glob( outroot+"/primary/*evt2.fits*")[0]
         evt2_out = outroot+"/primary/"+os.path.basename(evt2_in).strip(".gz").replace("N", "_{}N".format(self.obinum[obi]))
 
-        
+
         dmcopy( evt2_in, evt2_out, clobber=True, option="")
 
         # We know there are only at most 3 region blocks based on data
         # in the archive.  Mostly only have 2, only obsid 433 has 3.
 
-        for rr in ["region", "region2", "region3"]:  
+        for rr in ["region", "region2", "region3"]:
             try:
                 tab = read_file( evt2_in+"[{}]".format(rr))
             except:
@@ -273,7 +273,7 @@ class MultiObi(ChandraObs):
                 # Rename block to be 'region' to make uniform
                 dmappend( evt2_in+"[{}][REGION]".format(rr), evt2_out )
                 break
-        
+
         os.unlink( evt2_in )
 
 
@@ -298,7 +298,7 @@ def check_val( infiles, keywrd ):
 #  Multi Obi observations have the same OBS_ID, but different OBI_NUMs.
 #  Technically there could have been mutli-obi, interleaved mode
 #  observations, but there are none and multi-obi observations have
-#  been discontinued -- so there never will be.  
+#  been discontinued -- so there never will be.
 #
 #  We use these rules to determine which this observation is.
 #
@@ -314,7 +314,7 @@ def is_interleaved(infiles):
     if len(infiles) != 2:
         return False
 
-    
+
 
     try:
         check_val(infiles, "OBS_ID")
@@ -332,7 +332,7 @@ def is_interleaved(infiles):
     else:
         if tocheck[0] == tocheck[1]:
             raise RuntimeError("CYCLE keyword values are the same.  One should be 'P' and the other 'S'")
-        
+
         raise RuntimeError("Unknown set of CYCLE keywords: {}".format(tocheck))
 
 
@@ -347,12 +347,12 @@ def is_multiobi(infiles):
         return False
 
     tocheck = [x.get_key_value("OBI_NUM") for x in infiles ]
-    
+
     if len(tocheck) != len(set(tocheck)):
         raise RuntimeError("OBI_NUM values in the evt1 files are not unique, they should be.")
-    
+
     return True
-    
+
 
 
 def split_tg_regions():
@@ -365,24 +365,24 @@ def split_tg_regions():
 
 def check_indir( indir, clobber ):
     """
-    
+
     """
-    
+
     if not os.path.exists(indir+"/secondary"):
         raise IOError("ERROR: The input directory does not contain the secondary subdirectory")
-    
+
     if not os.path.exists(indir+"/primary"):
         raise IOErrror("ERROR: The input directory does not contain the primary subdirectory")
-    
+
     evt1 = locate_evt1_files( indir+"/secondary")
 
 
-    tabs = [read_file(x) for x in evt1]   # Open files only once 
+    tabs = [read_file(x) for x in evt1]   # Open files only once
 
     interleaved = is_interleaved( tabs )
     multiobi = is_multiobi( tabs )
 
-    
+
     if interleaved and multiobi:
         raise RuntimeError("No observation is both interleaved and multi-obi.  Make sure directories are uncluttered.")
     elif interleaved:
@@ -396,17 +396,17 @@ def check_indir( indir, clobber ):
 
 def locate_evt1_files( indir ):
     """
-    
+
     """
     retval = glob.glob( indir+"/*evt1.fits*")
     if retval is None or 0 == len(retval):
         raise IOError("Cannot locate level1 event files in directory '{}'".format(indir))
-    
+
     if 1 == len(retval):
         raise RuntimeError("Only one level 1 event file found; no need to run this script")
-    
+
     return(retval)
-    
+
 
 
 #
@@ -418,9 +418,9 @@ def main():
     from ciao_contrib.param_soaker import get_params
 
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
+    pars = get_params(toolname, "rw", sys.argv,
                 verbose={"set":lw.set_verbosity, "cmd":verb1} )
-    
+
     obs = check_indir(pars["indir"], (pars["clobber"]=="yes") )
     obs.relocate(pars["outroot"])
 
@@ -433,6 +433,3 @@ if __name__ == "__main__":
         print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
-  
-
-

--- a/bin/src_psffrac
+++ b/bin/src_psffrac
@@ -1,22 +1,22 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
- 
+
 # Copyright (C) 2013,2016 Smithsonian Astrophysical Observatory
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 
 from __future__ import print_function
 
@@ -47,7 +47,7 @@ def lookup_psffile_in_caldb( calfile ):
     """
     Lookup REEF caldb file -- calfile itself not currently used
     """
-    
+
     c = cldb.Caldb( "chandra", None, "REEF")
     myfile = c.search
     if len(myfile) != 1:
@@ -58,19 +58,19 @@ def lookup_psffile_in_caldb( calfile ):
 
 def get_psf_fractions( psffile, theta, phi, energy, radii, pixsize ):
     """
-    Get PSF size for given fration/theta/phi    
+    Get PSF size for given fration/theta/phi
     """
-    
+
     def initalize_psf( calfile ):
         """ Open PSF file """
         if not calfile or calfile.startswith('CALDB'):
             calfile = lookup_psffile_in_caldb( calfile )
         psf = psfInit( calfile )
         return psf
-    
+
     psf = initalize_psf( psffile )
     if len(theta) != len(phi) :
-        raise LookupError("Must have same number of theta & phi values")    
+        raise LookupError("Must have same number of theta & phi values")
 
     return [ psfFrac( psf, energy, tp[0],tp[1], pixsize*tp[2]) for tp in zip(theta,phi,radii)]
 
@@ -88,7 +88,7 @@ def sky_to_cel( myfile, x_vals, y_vals ):
         ra.append( sky[0][0] )
         dec.append( sky[0][1] )
     return ra,dec
-    
+
 
 
 def get_keys_from_crate( myfile ):
@@ -103,7 +103,7 @@ def get_keys_from_crate( myfile ):
 
 def parse_ebands( energy ):
     """
-    Parse energy band string    
+    Parse energy band string
     """
     csc = { 'broad' : 2.3, 'soft' : 0.92, 'ultrasoft' : 0.4, 'medium' : 1.56, 'hard' : 3.8, 'wide' : 1.5 }
     if energy in csc:
@@ -114,14 +114,14 @@ def parse_ebands( energy ):
         return retval
     except ValueError:
         pass # okay,will try other combos
-    
+
     if ':' not in energy:
         raise ValueError("Unknown energy {}".format(energy))
-    
+
     ee=energy.split(":")
     if 3 != len(ee):
         raise ValueError("Bad energy range format {}".format(energy))
-    
+
     try:
         retval = float(ee[2])
         return retval
@@ -131,21 +131,21 @@ def parse_ebands( energy ):
 
 def write_output(outfile, sky_x,sky_y,radii, ra_vals, dec_vals, coords, frac, mykeys):
     """
-    Write output file 
-    """    
+    Write output file
+    """
     shape = ['circle'] * len(radii)
     component = list(range(1,len(radii)+1))
     bgfrac = [0.0] * len(radii)
 
 
-    cnam = [x.upper() for x in [ 'shape', 'x', 'y', 'r', 'component', 
-        'ra', 'dec', 'theta', 'phi', 'detx', 'dety','chip_id', 'chipx', 
+    cnam = [x.upper() for x in [ 'shape', 'x', 'y', 'r', 'component',
+        'ra', 'dec', 'theta', 'phi', 'detx', 'dety','chip_id', 'chipx',
         'chipy', 'psffrac', 'bg_psffrac']]
-    cval = [ shape, sky_x, sky_y, radii, component, ra_vals, dec_vals, 
+    cval = [ shape, sky_x, sky_y, radii, component, ra_vals, dec_vals,
         coords["theta"], coords["phi"], coords["detx"], coords["dety"],
         coords["chip_id"], coords["chipx"], coords["chipy"],
         frac, bgfrac ]
-    units = ['', 'pixel', 'pixel', 'pixel', '', 'deg', 'deg', 'arcmin', 
+    units = ['', 'pixel', 'pixel', 'pixel', '', 'deg', 'deg', 'arcmin',
         'deg', 'pixel', 'pixel','', 'pixel', 'pixel','', '']
     desc = [ 'region geometry',
         'X center',
@@ -176,7 +176,7 @@ def write_output(outfile, sky_x,sky_y,radii, ra_vals, dec_vals, coords, frac, my
         cr.unit = units[ii]
         cr.values = cval[ii]
         tab.add_column( cr )
-    
+
     for k in mykeys:
         ck = pc.CrateKey()
         ck.name = k
@@ -184,7 +184,7 @@ def write_output(outfile, sky_x,sky_y,radii, ra_vals, dec_vals, coords, frac, my
         tab.add_key( ck )
 
     tab.write( outfile=outfile, clobber=True )
-    
+
 
 
 def parse_regions( region_stk, infile):
@@ -194,7 +194,7 @@ def parse_regions( region_stk, infile):
     from tempfile import NamedTemporaryFile
 
     import stk as stk
-    
+
     regions = stk.build( region_stk )
     all_files = []
     for region in regions:
@@ -206,21 +206,21 @@ def parse_regions( region_stk, infile):
         except:
             reg = "region({})".format(region)
             rr = regParse( reg )
-    
+
         tmproot = NamedTemporaryFile( dir=os.environ["ASCDS_WORK_PATH"])
         tfile = tmproot.name
         tmproot.close()
-    
+
         # convert to FITS and in physical coordinates
-    
+
         dmmakereg.region = reg
         dmmakereg.outfile = tfile
         dmmakereg.wcsfile = infile
         dmmakereg.kernel = 'fits'
         dmmakereg.clobber = True
-    
+
         verb2( dmmakereg() )
-    
+
         all_files.append( tfile )
 
     tmproot = NamedTemporaryFile( dir=os.environ["ASCDS_WORK_PATH"])
@@ -230,31 +230,31 @@ def parse_regions( region_stk, infile):
     verb2( dmmerge( infile=all_files, outfile=tfile, clobber=True) )
 
     for ff in all_files:
-        os.remove( ff) 
-    
+        os.remove( ff)
+
     tab = read_file( tfile )
-    
-    _shapes = tab.get_column("shape").values.tolist()    
+
+    _shapes = tab.get_column("shape").values.tolist()
 
     try:
         shapes = [ x.decode("ascii") for x in _shapes ]  ## For now anyways
     except:
         shapes = _shapes
-            
+
     # shape must be a circle
     check = [ x.lower() == 'circle' for x in shapes]
     if not all(check):
         raise ValueError("Only circle shapes are allowed")
-    
+
     xx = tab.get_column("x").values.tolist()
     yy = tab.get_column("y").values.tolist()
 
     # r's are arrays, get 1st element from each row
     rr = tab.get_column("r").values.tolist()
     rr = [ r[0] for r in rr ]
-    
+
     os.remove( tfile )
-    
+
     return xx,yy,rr
 
 
@@ -265,9 +265,9 @@ def parse_regions( region_stk, infile):
 def main():
     from ciao_contrib._tools.fileio import outfile_clobber_checks
     from ciao_contrib.runtool import add_tool_history
-    
+
     # get parameters
-    pars = get_params(toolname, "rw", sys.argv, 
+    pars = get_params(toolname, "rw", sys.argv,
         verbose={"set":lw.set_verbosity, "cmd":verb1} )
 
 
@@ -287,15 +287,15 @@ def main():
     ra_vals, dec_vals = sky_to_cel( myfile, sky_x,sky_y)
 
     coords = cel_to_chandra( mykeys, ra_vals, dec_vals )
-    
+
     # Get PSF size
-    frac = get_psf_fractions( pars["psffile"], coords["theta"], coords["phi"], 
+    frac = get_psf_fractions( pars["psffile"], coords["theta"], coords["phi"],
         energy, radii, coords["pixsize"])
 
     # Write output
     write_output(pars["outfile"], sky_x,sky_y,radii, ra_vals, dec_vals, coords, frac, mykeys)
     add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
-    
+
 
 if __name__ == "__main__":
     try:

--- a/bin/summarize_status_bits
+++ b/bin/summarize_status_bits
@@ -1,23 +1,23 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
-# 
+#
 # Copyright (C) 2013, 2016  Smithsonian Astrophysical Observatory
-# 
-# 
+#
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 
 
 
@@ -36,7 +36,7 @@ from collections import namedtuple
 Desc = namedtuple( 'Desc', ['key', 'bit', 'comment'] )
 
 
-acis_bitdef = [ # Taken from GEA memo 
+acis_bitdef = [ # Taken from GEA memo
       [
         Desc( "BIT31", "31", "Unused"),
         Desc( "BIT30", "30", "Unused"),
@@ -46,7 +46,7 @@ acis_bitdef = [ # Taken from GEA memo
         Desc( "BIT26", "26", "Unused"),
         Desc( "BIT25", "25", "Unused"),
         Desc( "BIT24", "24", "Unused")
-      ],[    
+      ],[
         Desc( "BADVF", "23", "Identified as a cosmic ray charge bloom (VFAINT mode)"),
         Desc( "RDSTKBKG", "22","Identified as a background event in vertical readout streak"),
         Desc("RDSTK", "21","Identified as a source event in vertical readout streak"),
@@ -64,14 +64,14 @@ acis_bitdef = [ # Taken from GEA memo
         Desc("BADOCLK", "10","Bad overclock value"),
         Desc("NOOCLK", " 9","Missing overclock value for this exposure"),
         Desc("BIASPAR", " 8","Bias parity error detected during observation")
-      ],[        
+      ],[
         Desc("UNKBIAS", " 7","Unknown bias value (4096)"),
         Desc("BADBIAS", " 6","Bad bias value (4095)"),
         Desc("BADPIXE", " 5","Surrounding event island falls on bad pixel"),
         Desc("BADPIX", " 4","Center of event island falls on bad pixel"),
         Desc("BADSUM", " 3","Total PHA value greater than 32767"),
         Desc("BADPHAS", " 2","PHAS value greater than 4095"),
-        Desc("BADLM", " 1","Center pixel PHA not local maximum"),              
+        Desc("BADLM", " 1","Center pixel PHA not local maximum"),
         Desc("BADPOS", " 0","Invalid chip coordinate")
       ]]
 
@@ -85,7 +85,7 @@ hrc_bitdef = [  # taken from Juda memo (reverse bit order)
         Desc("NILMODE", "26","Event was telemetered in Next In Line mode. Times are unreliable"),
         Desc("BADCRSV2", "25","V position outside of coarse position logic, position unknown"),
         Desc("BADCRSU2", "24","U position outside of coarse position logic, position unknown"),
-      ],[    
+      ],[
         Desc("BADCRSV", "23","V position outside the specified coarse position limits"),
         Desc("BADCRSU", "22","U position outside the specified coarse position limits"),
         Desc("TRIGV", "21","Number of V-axis taps with signal exceeding trigger above commanded level"),
@@ -103,7 +103,7 @@ hrc_bitdef = [  # taken from Juda memo (reverse bit order)
         Desc("SIGZERO", "10","Sum of all 6 tap is 0, event position is unknown"),
         Desc("SIGSUM", " 9","Sum of signal on U and V axis are discrepant, position may be inaccurate "),
         Desc("SIGAXIS", " 8","Total signal on V or U axis is 0")
-      ],[        
+      ],[
         Desc("BADPI", " 7","PI value out of range"),
         Desc("EVTOOT", " 6","Event out of time sequence"),
         Desc("AMPFLATV", " 5","AMP flatness test failed on V axis"),
@@ -119,24 +119,24 @@ hrc_bitdef = [  # taken from Juda memo (reverse bit order)
 def get_status_column( infile ):
     """
     Load event file and get status column values
-    
+
     """
     import cxcdm as dm
-    
+
     try:
-        tab = dm.dmTableOpen( infile+"[cols status]" )    
+        tab = dm.dmTableOpen( infile+"[cols status]" )
         if not tab:
             raise Exception("")
     except:
         raise IOError("Could not open infile '{}'".format(infile))
-    
+
     try:
         col = dm.dmTableOpenColumn( tab, "status" )
         if not col:
             raise Exception("")
     except:
         raise IOError("Could not open STATUS column in file '{}'".format(infile))
-    
+
     k,v = dm.dmKeyRead( tab, "INSTRUME" )
     v = v.decode("ascii")
     if "ACIS" == v:
@@ -148,18 +148,18 @@ def get_status_column( infile ):
 
     if not dm.dmBlockGetName( tab).startswith("EVENT"):
         raise IOError("File does not appear to be an event file")
-    
-    
-    status = dm.dmGetData(col, 1, dm.dmTableGetNoRows(tab) )        
 
-    dm.dmTableClose(tab)    
+
+    status = dm.dmGetData(col, 1, dm.dmTableGetNoRows(tab) )
+
+    dm.dmTableClose(tab)
     return status, bitdef
 
-    
+
 
 def check_bits( status):
     """
-    Check the bit values.    
+    Check the bit values.
 
     Note: same event can have many bits set.
     """
@@ -167,25 +167,25 @@ def check_bits( status):
 
     for byte in range( 4):
         check = [0,0,0,0]
-        for bit in range( 8 ):            
-            check[byte] = 2**(7-bit)            
-        
+        for bit in range( 8 ):
+            check[byte] = 2**(7-bit)
+
             # We use numpy to do a bitwise and () of the unit8 values.
             # then sum the values and divide by the value we are looking for.
-            # So if we are looking at bit 3, that is 2^3 = 8.  
+            # So if we are looking at bit 3, that is 2^3 = 8.
             # Numpy bitwise and will return 8 for those events whose bit is set, 0 otherwise.
             # sum them and then divide by 8 and we get the number of events with
             # that bit set.
-            counts[byte][bit] = np.bitwise_and( status, check ).sum() / check[byte] 
+            counts[byte][bit] = np.bitwise_and( status, check ).sum() / check[byte]
         #print "{:2d}% done".format( int(100*(byte+1)/4.0 ))
-    
+
     return counts
 
 
 def print_results( counts, total, bitdef ):
     """
-    
-    """    
+
+    """
 
     ff = "{:10s} {:>3} {:>7} {:>6}  {}"
 
@@ -193,7 +193,7 @@ def print_results( counts, total, bitdef ):
         print ("")
         print (ff.format( "BitName","Bit","NumEvt","%Evt", "BitDesc"))
         print (ff.format( "-------","---","------","----", "-------"))
-    
+
     banner = 0
 
     tp = [ ]
@@ -231,8 +231,3 @@ def summarize_bits():
 if __name__ == "__main__":
     summarize_bits()
     sys.exit(0)
-
-
-
-
-

--- a/bin/symmetrize
+++ b/bin/symmetrize
@@ -1,24 +1,24 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
-# 
+#
 # Copyright (C) 2015  Smithsonian Astrophysical Observatory
-# 
-# 
-# 
+#
+#
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-# 
+#
 
 """Usage:
   symmetrize infile outfile
@@ -69,7 +69,7 @@ def update_tgd( params ):
 
     v2("Reading symmetry data from '{}'\n".format(sfile))
     scorr_wav, scorr_data = read_symmetrization_correction_file(sfile)
-    
+
     if not clobber and os.path.isfile(outfile):
         raise IOError("outfile={} exists and clobber=no".format(outfile))
 

--- a/mk_script_tarfile
+++ b/mk_script_tarfile
@@ -1,127 +1,173 @@
 #!/usr/bin/env python
 
-"""
-Usage:
-  ./mk_script_tarfile <number or dev>
+"""Usage:
+  ./mk_script_tarfile <versino string>
 
 Aim:
 
 Create the tar file for the contributed scripts package, using
-either the identifier "dev" or the number (the main CIAO version
-is picked up automatically from the ciao-x.y/ directory).
-
-For CIAO 4.9 one version is created, which has both Python 2.7 and
-3.5 directory names in it. This may turn out to be a bad idea,
-in which case two versions will be created. This is still the case
-for CIAO 4.10.
-
-Whilst we could automate the choice of number, it seems safer
-to make the user specify it manually.
+the dotted vresino string, which shuold be 4.14.0 or 4.14.dev
+(adjust versino appropriately).
 
 The VERSION file (ciao-<>/contrib/VERSION.CIAO_scripts) is not
 tracked by git.
+
+The approach taken by this script has changed - it was manual, then
+based on setuptools - but now with setuptools moving to a buildm
+rather than install, system we are going back to running things
+manually.
 
 Files or directories called tests are not included in the tar
 file. This may be changed in the future (it may be useful to
 be able to run tests from an installed version), but the tests
 are currently very ad-hoc so it's not worth it.
 
-The copy argument has been removed.
-
 """
 
-import sys
-import os
+from collections import defaultdict
 import glob
-import time
+import os
+from pathlib import Path
+import shutil
 import subprocess as sbp
+import sys
+import time
 
-def get_ciao_version():
-    """Set up the CIAO version values based on the ciao-x.y/
-    directory in the current working directory.
-    """
 
-    dnames = [dname for dname in glob.glob("ciao-*.*")
-              if os.path.isdir(dname)]
-    if len(dnames) == 0:
-        sys.stderr.write("ERROR: no directory matching ciao-*.* found\n")
-        sys.exit(1)
-
-    elif len(dnames) != 1:
-        sys.stderr.write("ERROR: found {} ".format(len(dnames)) +
-                         "directories matching ciao-*.*!\n")
-        sys.exit(1)
-
-    toks = dnames[0][5:].split('.')
-    if len(toks) != 2:
-        raise IOError("Unexpected directory name {}".format(dnames[0]))
-
-    majver = toks[0]
-    minver = toks[1]
-    return { "minver": minver,
-             "majver": majver,
-             "version_dotted": "%s.%s" % (majver, minver),
-             "root": dnames[0] }
-
-def build_dist( rel_num, ver, prefix ):
+def build_dist(version, dirname, outdir, python="python3.8"):
     """Build contrib scripts package into a separate temp dir"""
 
-    install_dir = "{}/ciao-{}/contrib".format(prefix,rel_num)
+    outdir = Path(outdir)
+    outdir /= dirname
+    if outdir.exists():
+        raise OSError(f"Exists: {outdir}")
 
-    build_cmd = ["python", "setup.py",
-        "--version={}.{}".format(rel_num,ver),
-        "build", "--executable", "/usr/bin/env python",
-        "install", "--prefix", install_dir]
-    sbp.check_call( build_cmd)
+    outdir /= "contrib"
+    if outdir.exists():
+        raise OSError(f"Exists: {outdir}")
+
+    # This uses the default mode for the parent directories.
+    #
+    outdir.mkdir(parents=True)
+
+    # Copy directories over to this directory
+    #
+    for basedir in ["bin", "share/doc/xml", "data", "config", "param"]:
+        newdir = outdir / basedir
+        newdir.mkdir(parents=True)
+        nfiles = 0
+        for infile in glob.glob(f"{basedir}/*"):
+            if infile.endswith('~'):
+                continue
+
+            bname = os.path.basename(infile)
+            if bname.startswith('#'):
+                continue
+
+            shutil.copy2(infile, str(outdir / infile))
+            nfiles += 1
+
+        print(f'Copy to {basedir}: {nfiles} files')
+
+    # Create the lib structure. Unlike the other directories here we have
+    # to recurse into directories.
+    #
+    libdir = outdir / "lib" / python / "site-packages"
+    libdir.mkdir(parents=True)
+
+    for infile in ["lightcurves.py"]:
+        shutil.copy2(infile, str(libdir / infile))
+
+    for basedir in ['ciao_contrib', 'coords', 'crates_contrib', 'dax',
+                    'sherpa_contrib']:
+        for dirpath, dirnames, filenames in os.walk(basedir):
+            newdir = libdir / dirpath
+            newdir.mkdir()
+
+            # copy over the files
+            nfiles = 0
+            for infile in filenames:
+                if infile.endswith('~') or infile.startswith('#'):
+                    continue
+
+                shutil.copy2(f'{dirpath}/{infile}', str(newdir / infile))
+                nfiles += 1
+
+            print(f'Copy to lib/{python}/site-packages/{dirpath}: {nfiles} files')
+
+    # Create the egg info file: is it needed?
+    #
+    if python == 'python':
+        raise RuntimeError("What should the egg version be now?")
+
+    pyver = python[6:]
+    eggfile = libdir / f"ciao_contrib-{version}-py{pyver}.egg-info"
+    with open(eggfile, 'wt') as fh:
+        fh.write(f'''Metadata-Version: 1.0
+Name: ciao-contrib
+Version: {version}
+Summary: CIAO Contributed scripts
+Home-page: https://github.com/cxcsds/ciao-contrib/
+Author: CXCSDS and Friends
+Author-email: cxchelp@cfa.harvard.edu
+License: GNU GPL v3
+Description: UNKNOWN
+Platform: UNKNOWN
+''')
+
+    # Need to ensure all the bin files have a valid shebang - fortunately we
+    # don't need to replace anything so this is more a check.
+    #
+    scripts = defaultdict(int)
+    for infile in glob.glob(f"{outdir}/bin/*"):
+
+        firstline = open(infile, 'rt').readline().rstrip()
+        if not firstline.startswith('#!'):
+            raise OSError(f"shebang line for {infile}: {firstline}")
+
+        toks = firstline[2:].lstrip().split()
+
+        if (len(toks) == 1) and (toks[0] in ['/bin/sh', '/bin/bash']):
+            scripts[toks[0]] += 1
+            continue
+
+        if len(toks) != 2:
+            raise OSError(f"shebang line for {infile}: {firstline}")
+
+        if toks[0] != '/usr/bin/env':
+            raise OSError(f"shebang line for {infile}: {firstline}")
+
+        scripts[toks[1]] += 1
+
+    print("Script breakdown:")
+    for k, v in scripts.items():
+        print(f"  {k:10s}: {v}")
+
+    print("")
+
+    # libs
+
+    # Copy files over
+    #
+    for infile in ["Changes.CIAO_scripts", "README_CIAO_scripts"]:
+        shutil.copy2(infile, str(outdir / infile))
+
+    # Create version file
+    #
+    with open(outdir / 'VERSION.CIAO_scripts', 'wt') as fh:
+        datestr = f"scripts {version} "
+        datestr += time.strftime("%A, %B %e, %Y")
+        fh.write(datestr)
+        fh.write('\n')
+        print(f"Updated VERSION file: {datestr}")
 
 
-
-def make_tarfile(ver, cwd):
+def make_tarfile(tarfilegz, dname):
     """Create versioned tar file"""
 
-    cver = get_ciao_version()
+    print(f"Building {tarfilegz}")
 
-    if ver == "dev":
-        ver = ver.upper()
-    else:
-        ver = str(ver)
-
-    verstr = "%s.%s.%s" % (cver["majver"], cver["minver"], ver)
-
-
-    tarfile = "%s-contrib-%s.tar" % (cver["root"], ver)
-    tarfile = os.path.join( cwd, tarfile )
-    tarfilegz = tarfile + ".gz"
-    print("Tar file: {}".format(tarfile))
-
-    if ver != "DEV" and \
-            (os.path.exists(tarfile) or os.path.exists(tarfilegz)):
-
-        sys.stderr.write("ERROR: output file already exists\n")
-        sys.stderr.write("         {}\n".format(tarfile))
-        sys.stderr.write("         {}\n".format(tarfilegz))
-        sys.stderr.write("       Does the version number need updating?")
-        sys.stderr.write("\n\n")
-        sys.exit(1)
-
-    # Remove backup (*~) files
-    # (let find do this)
-    #
-    sbp.check_call(["find", ".", "-name", "*~", "-exec", "rm", "{}", ";"])
-
-    verfile = os.path.join(cver["root"], "contrib", "VERSION.CIAO_scripts")
-    print("Updating {} with current date and release number".format(verfile))
-    datestr = "scripts %s " % verstr
-    datestr += time.strftime("%A, %B %e, %Y")
-    with open(verfile, 'w') as fh:
-        fh.write(datestr)
-        fh.write("\n")
-
-    print("Building {}".format(tarfile))
-
-    # This does not keep soft links, which means that the python2.7/3.5
-    # split doubles the files (it's not a lot of space, but still).
-    # Do we have links anywhere else?
+    # This does not keep soft links.
     #
     # sbp.check_call(["tar", "chf", tarfile, "./" + cver["root"]])
     #
@@ -129,46 +175,83 @@ def make_tarfile(ver, cwd):
     for ename in [".gitignore", "tests", "__pycache__"]:
         args.append("--exclude={}".format(ename))
 
-    args.extend(["-cf", tarfile, "./" + cver["root"]])
-
+    args.extend(["-czf", tarfilegz, f"./{dname}"])
     sbp.check_call(args)
-    sbp.check_call(["gzip", "-f", tarfile])
+    print(f"\nCreated: {tarfilegz}")
 
-    print("\nCreated: {}".format(tarfilegz))
 
+def is_int(x):
+    try:
+        v = int(x)
+    except ValueError:
+        sys.stderr.write("ERROR: version string should be 4.14.0 or 4.14.dev\n")
+        sys.exit(1)
+
+    if v < 1:
+        sys.stderr.write("ERROR: major and minor terms must be >= 1\n")
+        sys.exit(1)
+
+
+def is_micro(x):
+    if x.upper() == 'DEV':
+        return 'DEV'
+
+    try:
+        v = int(x)
+    except ValueError:
+        sys.stderr.write("ERROR: version string should be 4.14.0 or 4.14.dev\n")
+        sys.exit(1)
+
+    if v < 0:
+        sys.stderr.write("ERROR: micro terms must be >= 0\n")
+        sys.exit(1)
+
+    return x
 
 
 if __name__ == "__main__":
 
     nargs = len(sys.argv)
-    if nargs != 3:
-        sys.stderr.write("Usage: %s <release> <number or dev>\n" % sys.argv[0])
-        sys.stderr.write("Example: %s 4.13 1\n" % sys.argv[0])
+    if nargs != 2:
+        sys.stderr.write(f"Usage: {sys.argv[0]} <release>\n\n")
+        sys.stderr.write(f"Examples:\n")
+        sys.stderr.write(f"  {sys.argv[0]} 4.14.0\n")
+        sys.stderr.write(f"  {sys.argv[0]} 4.14.dev\n")
+        sys.stderr.write('\n')
         sys.exit(1)
 
-    rel_num = sys.argv[1]
-    try:
-        release_number = float(rel_num)
-    except ValueError:
-        sys.stderr.write("ERROR: CIAO release must be a real number not %s\n" % rel_num)
+    userversion = sys.argv[1]
+    toks = userversion.split('.')
+    if len(toks) != 3:
+        sys.stderr.write("ERROR: version string should be 4.14.0 or 4.14.dev\n")
         sys.exit(1)
 
+    is_int(toks[0])
+    is_int(toks[1])
 
-    ver = sys.argv[2]
-    if ver != "dev":
-        try:
-            ver = int(ver)
-            if ver < 0:
-                sys.stderr.write("Error: version number must be >= 0, not %d\n" % ver)
-                sys.exit(1)
+    major = toks[0]
+    minor = toks[1]
+    micro = is_micro(toks[2])
 
-        except ValueError:
-            sys.stderr.write("ERROR: version must be an integer or the string dev, not %s\n" % ver)
+    dirname = f"ciao-{major}.{minor}"
+    version = f"{major}.{minor}.{micro}"
+
+    cwd = os.getcwd()
+    tarfile = f"{dirname}-contrib-{micro}.tar"
+    tarfile = os.path.join(cwd, tarfile)
+    tarfilegz = f'{tarfile}.gz'
+
+    if micro != 'DEV':
+        if os.path.exists(tarfile) or os.path.exists(tarfilegz):
+            sys.stderr.write("ERROR: output file already exists\n")
+            sys.stderr.write(f"         {tarfile}\n")
+            sys.stderr.write(f"         {tarfilegz}\n")
+            sys.stderr.write("       Does the version number need updating?")
+            sys.stderr.write("\n\n")
             sys.exit(1)
 
     from tempfile import TemporaryDirectory
-    with TemporaryDirectory( prefix="ciao-"+rel_num ) as tmpdir:
-        build_dist(rel_num, ver, tmpdir)
-        cwd = os.getcwd()
+    with TemporaryDirectory(prefix=dirname) as tmpdir:
+        build_dist(version, dirname, tmpdir)
         os.chdir(tmpdir)
-        make_tarfile(ver, cwd)
+        make_tarfile(tarfilegz, dirname)

--- a/mk_script_tarfile
+++ b/mk_script_tarfile
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 """Usage:
-  ./mk_script_tarfile <versino string>
+  ./mk_script_tarfile <version string>
 
 Aim:
 
 Create the tar file for the contributed scripts package, using
-the dotted vresino string, which shuold be 4.14.0 or 4.14.dev
-(adjust versino appropriately).
+the dotted version string, which should be 4.14.0 or 4.14.dev
+(adjust version appropriately).
 
 The VERSION file (ciao-<>/contrib/VERSION.CIAO_scripts) is not
 tracked by git.


### PR DESCRIPTION
The mk_script_tarfile 

a) now accepts a single argument - `4.14.0` or `4.14.dev` rather than separating out the two labels
b) internally we now create the tarfile manually rather than use setuptools

The latter is the bigger change, and is because of changes to the python packaging ecosystem - e.g. setuptools will remove the install command and there have been a lot changes related to PEP 517. For now I don't think we need the extra logic of setuptools as

1. we don't need to re-create the hashbang lines of the scripts
2. changes to how the tooling worked meant that it became unclear what the best approach was - we can look for CIAO 4.15 along with CXCCM in a better way to do this.

Creating the tarfile manually is - if I remember - how we used to do it. It's not ideal (the existing code is a bit hard-coded so will need to be updated if we add directories for instance), but will hopefully do for now.