### PR TITLE
Fix up access to obsidmerge header rules

### DIFF
--- a/bin/flux_obs
+++ b/bin/flux_obs
@@ -55,7 +55,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'flux_obs'
-__revision__ = '30 September 2021'
+__revision__ = '02 November 2021'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -524,6 +524,7 @@ def fluxobs():
                   psfmerge=params['psfmerge'],
                   threshold=is_thresh,
                   clobber=clobber,
+                  pathfrom=__file__,
                   tmpdir=tmpdir)
 
 

--- a/bin/merge_obs
+++ b/bin/merge_obs
@@ -49,7 +49,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'merge_obs'
-__revision__ = '30 September 2021'
+__revision__ = '02 November 2021'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -676,6 +676,7 @@ def merge_obs():
                   psfmerge=params['psfmerge'],
                   threshold=is_thresh,
                   clobber=clobber,
+                  pathfrom=__file__,
                   tmpdir=tmpdir)
 
     merging.display_merging_warnings(warnings,

--- a/ciao_contrib/_tools/run.py
+++ b/ciao_contrib/_tools/run.py
@@ -348,6 +348,10 @@ def get_lookup_table(toolname, pathfrom=None):
     strongly suggested that pathfrom is set to __file__ when
     called from the script, so that <dir> becomes the
     location of the script.
+
+    Ideally this would use importlib.resources or importlib.metadata
+    but we're not there yet.
+
     """
 
     if pathfrom is None:
@@ -355,9 +359,9 @@ def get_lookup_table(toolname, pathfrom=None):
     else:
         fname = pathfrom
     dirpath = os.path.dirname(os.path.realpath(fname))
-    fname = "{}_header_lookup.txt".format(toolname)
+    fname = f"{toolname}_header_lookup.txt"
 
-    v3("Looking for the lookup table for: " + toolname)
+    v3(f"Looking for the lookup table for: {toolname}")
 
     # The assumption is that the first of these is going to match
     # most use cases (conda and non-conda builds).
@@ -381,12 +385,12 @@ def get_lookup_table(toolname, pathfrom=None):
 
     for f in infiles:
         f = os.path.normpath(f)
-        v3("Looking for: " + f)
+        v3(f"Looking for: {f}")
         if os.path.exists(f):
             return f
 
     raise IOError("Unable to find the merging rules " +
-                  "for {} in\n{}".format(toolname, infiles))
+                  f"for {toolname} in\n{infiles}")
 
 
 def fix_bunit(infile, outfile, verbose=0):


### PR DESCRIPTION
Since we have a fall-through to the dmmerge header lookup rules
the code works, but less-than ideally, when we can no-longer find
the header file. In this case the obsidmerge header keyword list,
which got lost either because code was moved out of bin/ to a
library or because of changes due to packaging.

The fix is simple - send through the locataion of the scripts -
in this case flux_obs and merge_obs - so we can use this. It's not
idal - ideally we'd use importlib.resources/metadata but we are a
long way from that.