### PR TITLE
Tweak sherpa_contrib.utils.renorm

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,7 +1,7 @@
 ## 4.14.0 - December 2021
 
 When a script errors out the message will now be displayed in red
-unless the NO_COLOR environment variable is set - see
+unless the NO_COLOR environment variable is set - see the site at
 https://no-color.org/ - or the output is being written to a file
 rather than a TTY.
 
@@ -70,3 +70,8 @@ Updated Python modules
 
     The module has been updated to reflect new tools (dmradar) and
     parameter settings in CIAO 4.14.
+
+  sherpa_contrib.utils
+
+    The sherpa_contrib.utils.renorm routine has seen several minor
+    fixes.

--- a/share/doc/xml/renorm.xml
+++ b/share/doc/xml/renorm.xml
@@ -6,7 +6,7 @@
   <ENTRY key="renorm" context="contrib" pkg="sherpa"
 	 refkeywords="guess change renormalizae renormalise
 		      normalize normalise norm parameter
-		      level
+		      level amplitude amplscale rescale
 		      "
 	 seealsogroups="sh.par" displayseealsogroups="">
 
@@ -15,7 +15,7 @@
     </SYNOPSIS>
 
     <SYNTAX>
-      <LINE>renorm(id=None, cpt=None, bkg_id=None, names=None, limscale=1000)</LINE>
+      <LINE>renorm(id=None, cpt=None, bkg_id=None, names=None, limscale=10000)</LINE>
     </SYNTAX>
 
     <DESC>
@@ -77,7 +77,7 @@ from sherpa_contrib.utils import *
 	</ROW>
 	<ROW>
 	  <DATA>limscale</DATA>
-	  <DATA>1000.0</DATA>
+	  <DATA>10000.0</DATA>
 	  <DATA>
 	    The minimum and maximum limits of the normalization
 	    parameter are set to newval / limscale and newval * limscale
@@ -137,19 +137,27 @@ from sherpa_contrib.utils import *
 
       <QEXAMPLE>
         <SYNTAX>
-          <LINE>&pr; renorm(limscale=1e4)</LINE>
+          <LINE>&pr; renorm(limscale=1e3)</LINE>
 	</SYNTAX>
 	<DESC>
           <PARA>
 	    Change the minimum and maximum limits of the normalization
 	    parameter tp be equal to the new parameter value divided
-	    and multiplied by 1e4, respectively, rather than the
-	    default of 1e3.
+	    and multiplied by 1e3, respectively, rather than the
+	    default of 1e4.
 	  </PARA>
         </DESC>
       </QEXAMPLE>
 
     </QEXAMPLELIST>
+
+    <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
+      <PARA>
+	There have been minor changes: the limscale parameter now defaults to
+	1e4 and the routine now does nothing if the data sum in the noticed
+	region is zero or less.
+      </PARA>
+    </ADESC>
 
     <ADESC title="Changes in the scripts 4.8.2 (January 2016) release">
       <PARA>
@@ -165,6 +173,6 @@ from sherpa_contrib.utils import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2016</LASTMODIFIED>
+    <LASTMODIFIED>December 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/sherpa_contrib.xml
+++ b/share/doc/xml/sherpa_contrib.xml
@@ -73,6 +73,13 @@ import sherpa_contrib.all
 
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
+      <PARA>
+	The renorm routine in sherpa_contrib.utils has seen minor
+	improvements.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.13.0 (2020) release">
       <PARA title="XSPEC convolution models">
 	As the XSPEC convolution models are now supported by Sherpa
@@ -169,6 +176,6 @@ import sherpa_contrib.all
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>December 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/sherpa_utils.xml
+++ b/share/doc/xml/sherpa_utils.xml
@@ -77,6 +77,12 @@ from sherpa_contrib.all import *
 
     </DESC>
 
+    <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
+      <PARA>
+	The renorm routine has seen minor improvements.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.11.4 (2019) release">
       <PARA title="Plotting can now use matplotlib">
 	The plot_instmap_weights() routine now uses the
@@ -110,6 +116,6 @@ from sherpa_contrib.all import *
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>June 2019</LASTMODIFIED>
+    <LASTMODIFIED>December 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/sherpa_contrib/tests/test_sherpa_contrib_utils.py
+++ b/sherpa_contrib/tests/test_sherpa_contrib_utils.py
@@ -1,0 +1,282 @@
+#
+#  Copyright (C) 2021
+#            Smithsonian Astrophysical Observatory
+#
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+
+"""
+Test sherpa_contrib.utils
+"""
+
+import logging
+
+import numpy as np
+
+import pytest
+
+from sherpa.astro import instrument
+from sherpa.astro import ui
+from sherpa.utils.err import ArgumentErr, ParameterErr
+
+from sherpa_contrib.utils import renorm
+
+
+@pytest.fixture
+def reset():
+    """Run the test with a clean environment"""
+    ui.clean()
+    yield
+    ui.clean()
+
+
+@pytest.fixture
+def setup_src():
+    """Create a basic source"""
+
+    chans = np.arange(1, 11, dtype=np.int16)
+    counts = np.asarray([1, 2, 3, 3, 2, 1, 0, 1, 2, 0], dtype=np.int16)
+    ui.load_arrays(1, chans, counts, ui.DataPHA)
+
+    # fake up a response
+    egrid = np.arange(1, 12) * 0.1
+    elo = egrid[:-1]
+    ehi = egrid[1:]
+    arf = instrument.create_arf(elo, ehi)
+    ui.set_arf(arf)
+
+
+def test_renorm_empty_names():
+    with pytest.raises(ArgumentErr) as ae:
+        renorm(names=[])
+
+    assert str(ae.value) == "Invalid names argument: '[]'"
+
+
+@pytest.mark.parametrize('model', ['powlaw1d', 'xspowerlaw'])
+def test_renorm_no_thawed_norm(model, reset, setup_src, caplog):
+    """WHat happens if the parameter is frozen?"""
+
+    mdl = ui.create_model_component(model, 'mdl')
+    ui.set_source(mdl)
+
+    # tweak the slope (it is the first argument for both)
+    mdl.pars[0].val = 1.2
+
+    mdl.pars[-1].frozen = True
+
+    assert caplog.record_tuples == []
+
+    with caplog.at_level(logging.INFO):
+        renorm()
+
+    # Check we got a warning
+    assert caplog.record_tuples == [('sherpa', logging.WARN,
+                                     'no thawed parameters found matching: ampl, norm')]
+
+    # slope and normalization unchanged
+    assert mdl.pars[0].val == pytest.approx(1.2)
+    assert mdl.pars[-1].val == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize('model', ['powlaw1d', 'xspowerlaw'])
+def test_renorm_no_matching_name(model, reset, setup_src, caplog):
+    """Let's give a silly name"""
+
+    mdl = ui.create_model_component(model, 'mdl')
+    ui.set_source(mdl)
+
+    # tweak the slope (it is the first argument for both)
+    mdl.pars[0].val = 1.2
+
+    mdl.pars[-1].frozen = True
+
+    assert caplog.record_tuples == []
+
+    with caplog.at_level(logging.INFO):
+        renorm(names=['FOObar', 'bazFoo', 'bob'])
+
+    # Check we got a warning
+    assert caplog.record_tuples == [('sherpa', logging.WARN,
+                                     'no thawed parameters found matching: foobar, bazfoo, bob')]
+
+    # slope and normalization unchanged
+    assert mdl.pars[0].val == pytest.approx(1.2)
+    assert mdl.pars[-1].val == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize('model', ['powlaw1d', 'xspowerlaw'])
+def test_renorm_outside_range_high(model, reset, setup_src):
+    """What happens if the normalization is too high.
+
+    Actually, I'm wondering when/how we can test the ParameterErr
+    check logic, as how do we trigger it?
+    """
+
+    # The idea is that the hard maximum is often 3.4e38
+    # so if we scale the counts to a large-enpugh value
+    # we can trigger the failure case.
+    #
+    y = ui.get_data().counts
+    ui.set_dep(1e38 * y)
+
+    mdl = ui.create_model_component(model, 'mdl')
+
+    ui.set_source(mdl)
+
+    # tweak the slope (it is the first argument for both)
+    mdl.pars[0].val = 1.2
+
+    assert mdl.pars[-1].val == pytest.approx(1)
+
+    with pytest.raises(ParameterErr) as pe:
+        renorm()
+
+    emsg = f'parameter mdl.{mdl.pars[-1].name} has a maximum of 3.40282e+38'
+    assert str(pe.value) == emsg
+
+
+@pytest.mark.parametrize('model', ['powlaw1d', 'xspowerlaw'])
+def test_renorm_no_data(model, reset, setup_src, caplog):
+    """What happens if their is no data?"""
+
+    y = ui.get_data().counts
+    ui.set_dep(np.zeros_like(y))
+
+    mdl = ui.create_model_component(model, 'mdl')
+
+    ui.set_source(mdl)
+
+    # tweak the slope (it is the first argument for both)
+    mdl.pars[0].val = 1.2
+
+    assert mdl.pars[-1].val == pytest.approx(1)
+
+    assert caplog.record_tuples == []
+
+    with caplog.at_level(logging.INFO):
+        renorm()
+
+    # Check we got a warning
+    assert caplog.record_tuples == [('sherpa', logging.ERROR,
+                                     'data sum evaluated to <= 0; no re-scaling attempted')]
+
+    # values don't change
+    assert mdl.pars[0].val == pytest.approx(1.2)
+    assert mdl.pars[-1].val == pytest.approx(1)
+    assert mdl.pars[-1].min == pytest.approx(0)
+    assert mdl.pars[-1].max >= 1e24
+
+
+@pytest.mark.parametrize('model', ['powlaw1d', 'xspowerlaw'])
+def test_renorm_single_cpt(model, reset, setup_src):
+    """Check we can rescale a simple component"""
+
+    mdl = ui.create_model_component(model, 'mdl')
+    ui.set_source(mdl)
+
+    # tweak the slope (it is the first argument for both)
+    mdl.pars[0].val = 1.2
+
+    assert mdl.pars[-1].val == pytest.approx(1)
+    assert mdl.pars[-1].min == pytest.approx(0)
+    # max is either 3.4e38 or 1e24
+    assert mdl.pars[-1].max >= 1e24
+
+    renorm()
+
+    # slope unchanged
+    assert mdl.pars[0].val == pytest.approx(1.2)
+
+    # normalization changed
+    val = 4.968740850227226
+    assert mdl.pars[-1].val == pytest.approx(val)
+    assert mdl.pars[-1].min == pytest.approx(val / 10000)
+    assert mdl.pars[-1].max == pytest.approx(val * 10000)
+
+
+@pytest.mark.parametrize('model', ['powlaw1d', 'xspowerlaw'])
+def test_renorm_absorbed_cpt(model, reset, setup_src):
+    """Check we can rescale an absorbed component"""
+
+    # we don't care that xswabs is not for science here
+    amdl = ui.create_model_component('xswabs', 'amdl')
+    amdl.nh = 0.1
+
+    mdl = ui.create_model_component(model, 'mdl')
+    ui.set_source(amdl * mdl)
+
+    # tweak the slope (it is the first argument for both)
+    mdl.pars[0].val = 1.2
+
+    assert mdl.pars[-1].val == pytest.approx(1)
+    assert mdl.pars[-1].min == pytest.approx(0)
+    # max is either 3.4e38 or 1e24
+    assert mdl.pars[-1].max >= 1e24
+
+    renorm()
+
+    # slope unchanged
+    assert mdl.pars[0].val == pytest.approx(1.2)
+
+    # normalization changed; thanks to the absorption it
+    # is larger than the test_renorm_single_cpt case.
+    #
+    val = 22.1179
+    assert mdl.pars[-1].val == pytest.approx(val)
+    assert mdl.pars[-1].min == pytest.approx(val / 10000)
+    assert mdl.pars[-1].max == pytest.approx(val * 10000)
+
+
+@pytest.mark.parametrize('model,omodel',
+                         [('powlaw1d', 'xspowerlaw'),
+                          ('xspowerlaw', 'powlaw1d')])
+def test_renorm_specify_cpt(model, omodel, reset, setup_src):
+    """Check we change the requested component"""
+
+    # we don't care that xswabs is not for science here
+    amdl = ui.create_model_component('xswabs', 'amdl')
+    amdl.nh = 0.1
+
+    mdl = ui.create_model_component(model, 'mdl')
+    omdl = ui.create_model_component(omodel, 'omdl')
+
+    ui.set_source(amdl * (omdl + mdl))
+
+    # tweak the slope (it is the first argument for both)
+    mdl.pars[0].val = 1.2
+    omdl.pars[0].val = 1.2
+
+    assert mdl.pars[-1].val == pytest.approx(1)
+    assert omdl.pars[-1].val == pytest.approx(1)
+
+    renorm(cpt=amdl * mdl)
+
+    # slope unchanged
+    assert mdl.pars[0].val == pytest.approx(1.2)
+    assert omdl.pars[0].val == pytest.approx(1.2)
+
+    # check only one normalization has changed
+    #
+    val = 22.1179
+    assert mdl.pars[-1].val == pytest.approx(val)
+    assert mdl.pars[-1].min == pytest.approx(val / 10000)
+    assert mdl.pars[-1].max == pytest.approx(val * 10000)
+
+    assert omdl.pars[-1].val == pytest.approx(1)
+    assert omdl.pars[-1].min == pytest.approx(0)
+    assert omdl.pars[-1].max >= 1e24

--- a/sherpa_contrib/utils.py
+++ b/sherpa_contrib/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2009, 2010, 2011, 2012, 2014, 2015, 2016, 2019
+#  Copyright (C) 2009, 2010, 2011, 2012, 2014, 2015, 2016, 2019, 2021
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -73,7 +73,7 @@ __all__ = ["renorm", "get_instmap_weights", "save_instmap_weights",
 
 # Should this use its own logger, derived from the Sherpa one?
 logger = logging.getLogger("sherpa")
-warn = logger.warn
+warn = logger.warning
 error = logger.error
 info = logger.info
 del logger
@@ -114,7 +114,7 @@ class InstMapWeights:
 
     def __str__(self):
         def fmt(key, val):
-            return "{0:10} = {1}".format(key, str(val))
+            return f"{key:10} = {val}"
 
         names = ["id", "modelexpr", "xlo", "xhi", "xmid", "weight",
                  "fluxtype"]
@@ -132,8 +132,8 @@ class InstMapWeights:
         if fluxtype in self._valid_fluxtypes:
             self.fluxtype = fluxtype
         else:
-            emsg = "fluxtype set to {} but must be one of: {}".format(
-                fluxtype, " ".join(self._valid_fluxtypes))
+            emsg = f"fluxtype set to {fluxtype} but must be " + \
+                "one of: {}".format(" ".join(self._valid_fluxtypes))
             raise ValueError(emsg)
 
         # Set up the xlo/xhi/xmid arrays
@@ -156,10 +156,10 @@ class InstMapWeights:
         src = mdl(self._xlo, self._xhi)[:-1]
         if np.any(src < 0.0):
             emsg = "There are negative values in your source " + \
-                "model (id={0})!".format(self.id)
+                f"model (id={self.id})!"
             raise RuntimeError(emsg)
         if np.all(src <= 0.0):
-            emsg = "The source model for id={0} ".format(self.id) + \
+            emsg = f"The source model for id={self.id} " + \
                 "evaluates to 0!"
             raise RuntimeError(emsg)
 
@@ -248,8 +248,7 @@ class InstMapWeights:
         #          clobber=clobber)
 
         if not clobber and os.path.exists(filename):
-            raise IOError("{} exists and ".format(filename) +
-                          "clobber=False")
+            raise IOError(f"{filename} exists and clobber=False")
 
         elo = self.xlo[0]
         ehi = self.xhi[-1]
@@ -264,12 +263,12 @@ class InstMapWeights:
             fh.write('#TEXT/SIMPLE\n')
             fh.write('# X WEIGHT\n')
             fh.write('#\n')
-            fh.write("# DATE = {} / ".format(stime))
+            fh.write(f"# DATE = {stime} / ")
             fh.write("Date and time of file creation\n")
-            fh.write("# MODELEXPR = {}\n".format(self.modelexpr))
-            fh.write("# ENERG_LO = {} / ".format(elo))
+            fh.write(f"# MODELEXPR = {self.modelexpr}\n")
+            fh.write(f"# ENERG_LO = {elo} / ")
             fh.write("[keV] Minimum energy\n")
-            fh.write("# ENERG_HI = {} / ".format(ehi))
+            fh.write(f"# ENERG_HI = {ehi} / ")
             fh.write("[keV] Maximum energy\n")
             fh.write('#\n')
             for (x, weight) in zip(self.xmid, self.weight):
@@ -277,9 +276,9 @@ class InstMapWeights:
                 # and the energy values to also be "nice" then
                 # rely on the default formatting rules used by
                 # Python.
-                fh.write("{} {}\n".format(x, weight))
+                fh.write(f"{x} {weight}\n")
 
-        info("Created: {}".format(filename))
+        info(f"Created: {filename}")
 
     def plot(self, overplot=False, clearwindow=True, **kwargs):
         """Plot the weights values.
@@ -339,8 +338,7 @@ class InstMapWeights:
         hplot.y = self.weight.astype(np.float32)
         hplot.xlabel = 'Energy (keV)'
         hplot.ylabel = 'Weights'
-        hplot.title = 'Weights for {}: '.format(self.id) + \
-                      ' {}'.format(self.modelexpr)
+        hplot.title = f'Weights for {self.id}:  {self.modelexpr}'
 
         # There is no validation of the preference values.
         #
@@ -411,7 +409,7 @@ class InstMapWeights:
 
         elif nargs != 1:
             emsg = "_estimate_expmap() takes 2 or 4 arguments " + \
-                "({} given)".format(nargs + 1)
+                f"({nargs + 1} given)"
             raise TypeError(emsg)
 
         else:
@@ -426,7 +424,7 @@ class InstMapWeights:
                 specresp = cr.get_column("SPECRESP").values.copy()
             except ValueError as e:
                 fname = cr.get_filename()
-                raise ValueError("Crate {} - {}".format(fname, e))
+                raise ValueError(f"Crate {fname} - {e}") from None
 
         # Interpolate using the mid-point of the ARF
         # onto the mid-point of the grid if necessary.
@@ -478,7 +476,7 @@ class InstMapWeights:
         nargs = len(args)
         if nargs != 1 and nargs != 3:
             emsg = "estimate_expmap() takes 2 or 4 " + \
-                "arguments ({0} given)".format(nargs + 1)
+                f"arguments ({nargs + 1} given)"
             raise TypeError(emsg)
         return self._estimate_expmap(*args)
 
@@ -507,7 +505,7 @@ class InstMapWeights1DInt(InstMapWeights):
 
         else:
             emsg = "Internal error: need to handle .xlo/xhi " + \
-                "lengths of {0} and {1}!".format(nlo, nhi)
+                f"lengths of {nlo} and {nhi}!"
             raise RuntimeError(emsg)
 
 
@@ -681,13 +679,11 @@ def save_instmap_weights(*args, **kwargs):
     fname = "save_instmap_weights"
     nargs = len(args)
     if nargs == 0:
-        emsg = "{}() takes at least 1 argument ".format(fname) + \
-            "(0 given)"
+        emsg = f"{fname}() takes at least 1 argument (0 given)"
         raise TypeError(emsg)
 
     if nargs > 3:
-        emsg = "{}() takes at most 3 arguments ".format(fname) + \
-            "({} given)".format(nargs)
+        emsg = f"{fname}() takes at most 3 arguments ({nargs} given)"
         raise TypeError(emsg)
 
     # The default values
@@ -726,8 +722,8 @@ def save_instmap_weights(*args, **kwargs):
 
     for (n, v) in kwargs.items():
         if n not in argnames:
-            emsg = "{}() got an unexpected ".format(fname) + \
-                "keyword argument '{}'".format(n)
+            emsg = f"{fname}() got an unexpected " + \
+                f"keyword argument '{n}'"
             raise TypeError(emsg)
         user[n] = v
 
@@ -949,7 +945,7 @@ def estimate_weighted_expmap(id=None, arf=None, elo=None, ehi=None,
 # https://github.com/sherpa/sherpa/issues/104
 #
 def renorm(id=None, cpt=None, bkg_id=None, names=None,
-           limscale=1000.0):
+           limscale=10000.0):
     """Change the normalization of a model to match the data.
 
     The idea is to change the normalization to be a better match to
@@ -960,6 +956,10 @@ def renorm(id=None, cpt=None, bkg_id=None, names=None,
     calculation without first doing a fit. It is also only going to
     give reasonable results for models where the predicted data of a
     model is linearly related to the normalization.
+
+    .. versionchanged:: 4.14.0
+       The limscale parameter was changed from 1000 to 10000 since
+       the normalization can be very-sensitive to absorption parameters.
 
     Parameters
     ----------
@@ -1039,9 +1039,9 @@ def renorm(id=None, cpt=None, bkg_id=None, names=None,
 
     Change the minimum and maximum values of the normalization
     parameter to be the calculated value divided by and multiplied by
-    1e4 respectively (these changes are made to the soft limits).
+    1e3 respectively (these changes are made to the soft limits).
 
-    >>> renorm(limscale=1e4)
+    >>> renorm(limscale=1e3)
 
     """
 
@@ -1063,7 +1063,10 @@ def renorm(id=None, cpt=None, bkg_id=None, names=None,
         # In this case the get_[bkg_]model call is not needed above,
         # but leave in as it at least ensures there's a model defined
         # for the data set.
-        m = cpt
+        #
+        # We need to include the response
+        rsp = ui.get_response(id=id)
+        m = rsp(cpt)
 
     pars = [p for p in m.pars if p.name.lower() in matches and
             not p.frozen]
@@ -1075,6 +1078,11 @@ def renorm(id=None, cpt=None, bkg_id=None, names=None,
         return
 
     yd = d.get_dep(filter=True).sum()
+    if yd <= 0:
+        # assume that something odd is going odd here so do nothing
+        error("data sum evaluated to <= 0; no re-scaling attempted")
+        return
+
     ym = d.eval_model_to_fit(m).sum()
 
     # argh; these are numpy floats, and they do not throw a
@@ -1123,7 +1131,7 @@ def renorm(id=None, cpt=None, bkg_id=None, names=None,
                 # this should be impossible
                 reason = "for an unknown reason"
 
-            info("Parameter {} is restricted ".format(p.fullname) +
+            info(f"Parameter {p.fullname} is restricted " +
                  reason)
 
 # End


### PR DESCRIPTION
The code is slightly-better behaved when there's no data to guess against (issue #80).

A number of basic tests have been added of this routine.