### PR TITLE
When adding images, try to support a large-number of files (#481)

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -51,7 +51,8 @@ Updated scripts
 
     The pixel size calculation used when the maxsize parameter is set
     has been changed to avoid problems when also setting the psfecf
-    parameter.
+    parameter. There have been improvements when combining a large
+    number of observations.
 
 Updated Python modules
 

--- a/share/doc/xml/flux_obs.xml
+++ b/share/doc/xml/flux_obs.xml
@@ -1726,6 +1726,10 @@
 	allow the use of both the maxsize and the psfecf parameters (prior
 	to this the combination could cause the script to fail).
       </PARA>
+      <PARA>
+	There have been improvements to the handling of a large number
+	of observations.
+      </PARA>
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">

--- a/share/doc/xml/merge_obs.xml
+++ b/share/doc/xml/merge_obs.xml
@@ -2075,6 +2075,10 @@
 	allow the use of both the maxsize and the psfecf parameters (prior
 	to this the combination could cause the script to fail).
       </PARA>
+      <PARA>
+	There have been improvements to the handling of a large number
+	of observations.
+      </PARA>
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.13.1 (March 2021) release">


### PR DESCRIPTION
In dmimgcalc_add only, ensure we don't ever try to combine too
many files in a single call, to try to avoid hitting path-length
limits. The current approach is hoaky (it can only support nchunk^2
files at a maximum, where nchunk defaults to 100), but trying to
combine this many files is likely to cause problems elsewhere.

There isn't actually an easy way to determine the maximum number
of files because

- it is likely the operation argument that causes the overflow,
  since the input files are given as a stack
- it is likely the overall command length that is the issue, not
  just a single parameter

Hence the idea to pick 100 as a "nice" chunk size: we hopefully
won't have to do too many chunks for all-but the most large
combinations.

We can only do this for dmimgcalc_add since we have a nice
semigroup here (+). For a generic image combination we can't
know we can do this.

This may not fix #481 but it's not obvious what else we can do.