### PR TITLE
create FOVs in fluximage/*_obs (fix #389)

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -56,7 +56,8 @@ Updated scripts
     The pixel size calculation used when the maxsize parameter is set
     has been changed to avoid problems when also setting the psfecf
     parameter. There have been improvements when combining a large
-    number of observations.
+    number of observations. The FOV file is now created for each
+    reprojected event file and a combined version.
 
   reproject_obs
 

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -47,6 +47,10 @@ Updated scripts
     The script now sets the CALDBALIAS which is needed due to a change
     in the caldb4 Python module in CIAO 4.14.
 
+  fluximage
+
+    The script now created a FOV file for the observation.
+
   flux_obs, merge_obs
 
     The pixel size calculation used when the maxsize parameter is set

--- a/bin/flux_obs
+++ b/bin/flux_obs
@@ -55,7 +55,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'flux_obs'
-__revision__ = '04 November 2021'
+__revision__ = '05 November 2021'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -398,8 +398,7 @@ def setup_output_names(outdir, outhead, obsinfos, enbands,
 
     v3("Setting up output names")
 
-    obsids = [obs.obsid for obs in obsinfos]
-    out = fi.fluximage_output(outdir, outhead, obsids, enbands,
+    out = fi.fluximage_output(outdir, outhead, obsinfos, enbands,
                               psf=psf,
                               threshold=threshold)
 

--- a/bin/fluximage
+++ b/bin/fluximage
@@ -489,6 +489,7 @@ def fluximage():
 
     # What files are we going to create?
     outputs = fi.get_output_filenames(outpath, enbands, chips,
+                                      obs=obs,
                                       blanksky=(bkginfo is not None),
                                       psf=want_psf,
                                       thresh=utils.thresh_is_set(thresh))

--- a/bin/fluximage
+++ b/bin/fluximage
@@ -72,7 +72,7 @@ def handle_ancillary_input(obs, anctype, ancfile):
         warnmsg = ''
 
     if ancfile == "":
-        keyname = "{}FILE".format(anctype.upper())
+        keyname = f"{anctype.upper()}FILE"
         filename = obs.get_ancillary_(anctype)
 
         # local, rather than absolute path that .evtfile would return
@@ -86,21 +86,21 @@ def handle_ancillary_input(obs, anctype, ancfile):
             hdrval = None
 
         if hdrval is None:
-            v1("WARNING - {} keyword not found in {}.{}".format(keyname, infile, warnmsg))
+            v1(f"WARNING - {keyname} keyword not found in {infile}.{warnmsg}")
             obs.set_ancillary(anctype, 'NONE')
 
         elif filename is None:
-            v1("WARNING - {}={} not found for {}.{}".format(keyname, hdrval, infile, warnmsg))
+            v1(f"WARNING - {keyname}={hdrval} not found for {infile}.{warnmsg}")
             obs.set_ancillary(anctype, 'NONE')
 
         elif filename.lower() == 'none':
-            v1("WARNING - {} set to NONE in {}.{}".format(keyname, infile, warnmsg))
+            v1(f"WARNING - {keyname} set to NONE in {infile}.{warnmsg}")
 
         else:
-            v1("{} file {} found.".format(anctype.capitalize(), filename))
+            v1(f"{anctype.capitalize()} file {filename} found.")
 
     elif ancfile.lower() == "none":
-        v1("WARNING - {}file parameter set to NONE.{}".format(anctype, warnmsg))
+        v1(f"WARNING - {anctype}file parameter set to NONE.{warnmsg}")
         obs.set_ancillary(anctype, 'NONE')
 
     else:
@@ -177,7 +177,7 @@ def get_par(argv):
 
     evtfiles = fileio.expand_evtfiles_stack(pars['infile'])
     if len(evtfiles) == 0:
-        raise IOError("Unable to find any event files matching {}.".format(pars['infile']))
+        raise IOError(f"Unable to find any event files matching {pars['infile']}.")
     elif len(evtfiles) > 1:
         raise IOError("Found multiple matches to infile={}\n  {}\n".format(pars['infile'], " ".join(evtfiles)))
 
@@ -185,7 +185,7 @@ def get_par(argv):
     infile = params['infile']
 
     if infile != pars['infile']:
-        v1("Using event file {}".format(infile))
+        v1(f"Using event file {infile}")
 
     """
     # We assume that the first [ character indicates a DM filter,
@@ -218,7 +218,7 @@ def get_par(argv):
     v3("Processing input file")
     obs = obsinfo.ObsInfo(infile)
     if obs.nrows == 0:
-        raise IOError("There are no events in {}".format(infile))
+        raise IOError(f"There are no events in {infile}")
 
     # Now we have the instrument, we can validate the bands
     params["enbands"] = bands.validate_bands(obs.instrument, params["enbands"])
@@ -238,7 +238,7 @@ def get_par(argv):
         else:
             params['bin'] = paramio.pgetd(pfile, 'binsize')
             if params['bin'] <= 0:
-                raise ValueError("binsize={} is not valid, it must be a number greater than zero.".format(params['bin']))
+                raise ValueError(f"binsize={params['bin']} is not valid, it must be a number greater than zero.")
 
         params['xrange'] = None
         params['yrange'] = None
@@ -263,7 +263,7 @@ def get_par(argv):
         raise ValueError("asolfile can not be NONE.")
     elif pars['asolfile'] == "":
         for afile in obs.get_asol():
-            v1("Aspect solution {} found.".format(afile))
+            v1(f"Aspect solution {afile} found.")
     else:
         obs.set_asol(stk.build(pars['asolfile']))
 
@@ -274,14 +274,14 @@ def get_par(argv):
         v3('Looking in header for BPIXFILE keyword')
         badpix = obs.get_ancillary_('bpix')
         if badpix is None:
-            v1("WARNING - BPIXFILE={} not found for {}. Using CALDB version instead.".format(obs.get_keyword('BPIXFILE'), infile))
+            v1(f"WARNING - BPIXFILE={obs.get_keyword('BPIXFILE')} not found for {infile}. Using CALDB version instead.")
             obs.set_ancillary('bpix', 'CALDB')
 
         elif badpix.lower() == 'none':
-            v1("WARNING - BPIXFILE set to NONE in {}. The exposure map will be too high for bad pixels and columns.".format(infile))
+            v1(f"WARNING - BPIXFILE set to NONE in {infile}. The exposure map will be too high for bad pixels and columns.")
 
         else:
-            v1("Bad-pixel file {} found.".format(badpix))
+            v1(f"Bad-pixel file {badpix} found.")
 
     elif badpix == "caldb":
         v1("CalDB bad-pixel file is being used.")
@@ -299,11 +299,11 @@ def get_par(argv):
         if not os.path.isfile(badpix):
             badpix += '.gz'
             if not os.path.isfile(badpix):
-                raise IOError("Unable to find bad pixel file={} (or .gz version)".format(pars['badpixfile']))
+                raise IOError(f"Unable to find bad pixel file={pars['badpixfile']} (or .gz version)")
 
             v3("Found .gz version of badpixfile.")
 
-        v1("Bad-pixel file {}".format(badpix))
+        v1(f"Bad-pixel file {badpix}")
         obs.set_ancillary('bpix', badpix)
 
     # Both BPIX and MASK files depend on the cycle of an interleaved observation
@@ -312,7 +312,7 @@ def get_par(argv):
         checkval = obs.obsid.obsid
         get_obsid_fn = fileio.get_obsid
     else:
-        v3("This appears to be an interleaved observation: cycle={}".format(obs.obsid.cycle))
+        v3(f"This appears to be an interleaved observation: cycle={obs.obsid.cycle}")
         checkval = obs.obsid
         get_obsid_fn = fileio.get_obsid_object
 
@@ -321,7 +321,7 @@ def get_par(argv):
     if badpix not in ["CALDB", "NONE"]:
         badpixobsid = get_obsid_fn(badpix)
         if badpixobsid != checkval:
-            raise ValueError("The ObsID of the badpix and event files do not match: {} vs {}".format(badpixobsid, checkval))
+            raise ValueError(f"The ObsID of the badpix and event files do not match: {badpixobsid} vs {checkval}")
 
     v3("Validating MASKFILE")
     pars["maskfile"] = paramio.pgetstr(pfile, "maskfile")
@@ -330,7 +330,7 @@ def get_par(argv):
     if mask != "NONE":
         maskobsid = get_obsid_fn(mask)
         if maskobsid != checkval:
-            raise ValueError("The ObsID of the mask and event files do not match: {} vs {}".format(maskobsid, checkval))
+            raise ValueError(f"The ObsID of the mask and event files do not match: {maskobsid} vs {checkval}")
 
     # As of CIAO 4.6 there is no need for the pbkfile parameter.
     if obs.instrument == "HRC":
@@ -367,7 +367,7 @@ def get_par(argv):
         #
         params['psfecf'] = paramio.pgetd(pfile, 'psfecf')
         if params['psfecf'] <= 0 or params['psfecf'] > 1:
-            raise ValueError("psfecf={} is not valid, it must be > 0 and <= 1".format(params['psfecf']))
+            raise ValueError(f"psfecf={params['psfecf']} is not valid, it must be > 0 and <= 1")
 
     # only used (at present) for background subtraction
     params['random'] = paramio.pgeti(pfile, 'random')
@@ -442,9 +442,9 @@ def fluximage():
     if chips is None:
         if xrng is None and yrng is None:
             # this should have been caught earlier
-            raise ValueError("Unexpected: infile={} is empty.".format(evtfile))
+            raise ValueError(f"Unexpected: infile={evtfile} is empty.")
 
-        emsg = "Observation {} does not cover".format(evtfile)
+        emsg = f"Observation {evtfile} does not cover"
         if xrng is not None:
             emsg += " x={}:{}".format(*xrng)
         if yrng is not None:
@@ -504,21 +504,20 @@ def fluximage():
                                                   tmpdir=tmpdir
             )
 
-        grid = "x={0},y={1}".format(xgrid, ygrid)
+        grid = f"x={xgrid},y={ygrid}"
         ox = xgrid.nbins
         oy = ygrid.nbins
         pixsize = utils.sky_to_arcsec(obs.instrument, xgrid.size)
 
-        v1("The output images will have {} by {} pixels, pixel size of {} arcsec,".format(int(ox), int(oy), pixsize))
-        v1("    and cover {}.".format(grid))
+        v1(f"The output images will have {int(ox)} by {int(oy)} pixels, pixel size of {pixsize} arcsec,")
 
     else:
         grid = xygrid
         (ox, oy) = params['sizes']
 
-        v1("The output images will have {} by {} pixels,".format(int(ox), int(oy)))
-        v1("    and cover {}.".format(grid))
+        v1(f"The output images will have {int(ox)} by {int(oy)} pixels,")
 
+    v1(f"    and cover {grid}.")
     v1("")
     taskrunner = TaskRunner()
 
@@ -543,7 +542,7 @@ def fluximage():
     fi.add_history(outputs, pars, toolname, __revision__,
                    cleanup=cleanup)
 
-    v3("{} has run to completion.".format(sys.argv[0]))
+    v3(f"{sys.argv[0]} has run to completion.")
     fi.print_output(outputs, cleanup=cleanup)
 
 

--- a/bin/merge_obs
+++ b/bin/merge_obs
@@ -49,7 +49,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'merge_obs'
-__revision__ = '04 November 2021'
+__revision__ = '05 November 2021'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -500,7 +500,7 @@ def setup_output_names(outdir, outhead, obsinfos, enbands,
     v3("Setting up output names")
 
     obsids = [obs.obsid for obs in obsinfos]
-    out = fi.fluximage_output(outdir, outhead, obsids, enbands,
+    out = fi.fluximage_output(outdir, outhead, obsinfos, enbands,
                               psf=psf,
                               threshold=threshold)
 

--- a/bin/reproject_obs
+++ b/bin/reproject_obs
@@ -42,15 +42,13 @@ import sys
 import shutil
 import tempfile
 
-import cxcdm
 import paramio
 from region import CXCRegion
-import stk
 
 import ciao_contrib.logger_wrapper as lw
 
 from ciao_contrib.param_wrapper import open_param_file
-from ciao_contrib.runtool import add_tool_history, make_tool
+from ciao_contrib.runtool import add_tool_history
 
 import ciao_contrib._tools.fileio as fileio
 import ciao_contrib._tools.merging as merging
@@ -60,7 +58,7 @@ import ciao_contrib._tools.utils as utils
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'reproject_obs'
-__revision__ = '03 November 2021'
+__revision__ = '04 November 2021'
 
 lgr = lw.initialize_logger(toolname)
 v1 = lgr.verbose1
@@ -196,65 +194,6 @@ def _link_or_copy_file(infile, outfile, linkfile=True):
         shutil.copyfile(ifile, ofile)
 
     return True
-
-
-def get_content(infile):
-    """Return the CONTENT keyword of the file.
-
-    Parameters
-    ----------
-    infile : str
-        The input file. It must contain a CONTENT keyword.
-
-    """
-
-    v4(f"Checking CONTENT keyword of {infile}")
-    bl = cxcdm.dmBlockOpen(infile, update=False)
-    try:
-        keys = cxcdm.dmKeyRead(bl, 'CONTENT')
-        content = keys[1].decode('ascii')
-        return content
-    finally:
-        cxcdm.dmBlockClose(bl)
-
-
-def make_reprojected_fov(obsid, evtfile, asolfiles, msk, outfile):
-    """Create the FOV file using the reprojected data.
-
-    The skyfov method depends on the type of the aspect solution,
-    as given by the CONTENT type:
-
-        ASPSOL (pre DS 10.8.3)  - use method=minmax
-        ASPSOLOBI               - use method=convexhull
-
-    """
-
-    afiles = stk.build(asolfiles)
-    contents = set([get_content(f) for f in afiles])
-    if len(contents) != 1:
-        emsg = f"Multiple types of aspect solution found: " + \
-            f"{', '.join(contents)}\n  {asolfiles}"
-        raise OSError(emsg)
-
-    content = contents.pop()
-    if content == 'ASPSOLOBI':
-        method = 'convexhull'
-    elif content == 'ASPSOL':
-        method = 'minmax'
-    else:
-        raise OSError(f"Invalid CONTENT={content} in aspect solution")
-
-    v3(f"skyfov: obsid={obsid}  CONTENT={content}  method={method}")
-
-    skyfov = make_tool('skyfov')
-    skyfov.punlearn()
-    skyfov(infile=evtfile,
-           outfile=outfile,
-           aspect=asolfiles,  # assume not so long we need a stack file
-           mskfile=msk,
-           kernel="FITS",
-           method=method,
-           clobber=True)
 
 
 def combined_fovs(fovs, outfile):
@@ -530,8 +469,8 @@ def link_ancillary_files(taskrunner,
         pretasks = [mtask] + asoltasks[label]
         fovname = f"{outroot}{obsid}.fov"
         evtfile = f"{outroot}{obsid}_reproj_evt.fits"  # assume this is correct
-        taskrunner.add_task(taskname, pretasks, make_reprojected_fov,
-                            obsid, evtfile, asolcache[label], mfile, fovname)
+        taskrunner.add_task(taskname, pretasks, run.make_fov,
+                            evtfile, asolcache[label], mfile, fovname)
         tasks.append(taskname)
         fovtasks.append(taskname)
         fovfiles.append(fovname)
@@ -690,31 +629,32 @@ def reproject_obsids():
     if params['verbose'] > 0 and params['verbose'] < 5:
         params['verbose'] -= 1
 
-    file_checks(params['obsinfos'],
-                params['outdir'],
-                params['outhead'],
+    obsinfos = params['obsinfos']
+    outdir = params['outdir']
+    outhead = params['outhead']
+
+    file_checks(obsinfos, outdir, outhead,
                 clobber=params['clobber'])
 
     taskrunner = TaskRunner()
     (ref_files, rtask, warnings) = get_ref(taskrunner, lambda s: s,
                                            params['instrument'],
-                                           params['obsinfos'],
+                                           obsinfos,
                                            params['refcoord'],
-                                           params['outdir'],
-                                           params['outhead'],
+                                           outdir,
+                                           outhead,
                                            linkfiles=params['linkfiles'],
                                            tmpdir=params['tmpdir'],
                                            verbose=params['verbose'],
                                            parallel=params['parallel'])
 
     if params['evtmerge']:
-        mevtfile = merging.merged_evt_name(params['outdir'],
-                                           params['outhead'])
+        mevtfile = merging.merged_evt_name(outdir, outhead)
         merge_evt_files(taskrunner,
                         [rtask],
                         ref_files,
                         mevtfile,
-                        params['obsinfos'],
+                        obsinfos,
                         tmpdir=params['tmpdir'],
                         clobber=params['clobber'],
                         verbose=params['verbose'])
@@ -729,6 +669,21 @@ def reproject_obsids():
 
     spacer = '     '
     v1("\nThe following files were created:\n")
+
+    if len(obsinfos) == 1:
+       v1("The reprojected FOV file:")
+    else:
+        v1("The reprojected FOV files:")
+
+    for obs in obsinfos:
+        v1(f"{spacer}{outdir}{outhead}{obs.obsid}.fov")
+
+    v1("")
+    if len(obsinfos) > 1:
+        v1("The combined FOV file:")
+        v1(f"{spacer}{outdir}{outhead}merged.fov")
+        v1("")
+
     if len(ref_files) == 1:
         v1("The reprojected event file:")
     else:

--- a/bin/reproject_obs
+++ b/bin/reproject_obs
@@ -36,14 +36,12 @@ can be broken down into
 
 """
 
-import functools
 import os
 import sys
 import shutil
 import tempfile
 
 import paramio
-from region import CXCRegion
 
 import ciao_contrib.logger_wrapper as lw
 
@@ -58,7 +56,7 @@ import ciao_contrib._tools.utils as utils
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'reproject_obs'
-__revision__ = '04 November 2021'
+__revision__ = '05 November 2021'
 
 lgr = lw.initialize_logger(toolname)
 v1 = lgr.verbose1
@@ -196,18 +194,6 @@ def _link_or_copy_file(infile, outfile, linkfile=True):
     return True
 
 
-def combined_fovs(fovs, outfile):
-    """Create the combined FOV.
-
-    This loses the CCD_ID column.
-    """
-
-    v3("Combining FOV files")
-    shapes = [CXCRegion(f) for f in fovs]
-    combined = functools.reduce(lambda x, y: x + y, shapes)
-    combined.write(outfile, fits=True, clobber=True)
-
-
 def dmhedit_line(key, value):
     """Return a string that can be used as line in a
     file sent to dmhedit to change key to value.
@@ -304,6 +290,14 @@ def link_ancillary_files(taskrunner,
         but not CYCLE.
         """
 
+        # I would lile to just set
+        #    label = str(obsid)
+        # but although that works for multi-obi cases, which
+        # is what we care about here, it does not for interleaved
+        # data, as label would end in "e1" or "e2". So for now
+        # we recreate some - but not all - of the __str__ method
+        # of ciao_contrib._tools.utils.Obsid.
+        #
         key = obsid.obsid
         if obsid.is_multi_obi:
             label = f"{obsid.obsid}_{obsid.obi:03d}"
@@ -479,7 +473,7 @@ def link_ancillary_files(taskrunner,
     #
     taskname = labelconv("combined-fov")
     outfov = f"{outroot}merged.fov"
-    taskrunner.add_task(taskname, fovtasks, combined_fovs,
+    taskrunner.add_task(taskname, fovtasks, run.combined_fovs,
                         fovfiles, outfov)
     tasks.append(taskname)
 
@@ -556,14 +550,12 @@ def get_ref(taskrunner, labelconv,
 
     infiles = []
     outfiles = []
-    obsids = []
     asolfiles = []
     for obs in obsinfos:
         infiles.append(obs.get_evtfile())
         outfile = merging.obsid_reproj_evt_name(outdir, outhead, obs.obsid)
         outfiles.append(outfile)
         asolfiles.append(obs.get_asol())
-        obsids.append(obs.obsid)
 
     etask = merging.reproject_event_files(taskrunner,
                                           labelconv,

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -309,12 +309,19 @@ def name_asphist(head, num, blockname=False):
 def name_fov(head, obs):
     """The name of the FOV file.
 
-    Unlike the other obsids we use the obsid label.
+    Unlike the other obsids we use the obsid label. This is okay for
+    fluximage but becomes problematic for merge_obs, when the head
+    label already includes the obsid label. For now we hack around
+    this, but this needs to be re-worked.
+
     """
 
-    label = f"{obs.obsid.obsid}"
-    if obs.obsid.is_multi_obi:
-        label += f"_{obs.obsid.obi:03d}"
+    # Remember, obs.obsid includes any OBI number if needed.
+    #
+    label = str(obs.obsid)
+    if head.endswith(f'{label}_'):
+        v3(f"WARNING: name_fov sent head={head} - need to fix")
+        return head[:-1] + '.fov'
 
     return f"{head}{label}.fov"
 

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -954,6 +954,9 @@ def validate_obsinfo(infiles, colcheck=True):
         if so, set the ObsId object for the relevant observations
         to include the OBI when converting to a string
 
+        NOTE that the multi-obs check has been left in, but some
+        of it is not needed as ObsInfo now enforces it.
+
     The return value is a list of
     ciao_contrib._tools.obsinfo.ObsInfo objects
 
@@ -1006,14 +1009,12 @@ def validate_obsinfo(infiles, colcheck=True):
             blank_line = True
             continue
 
-        # The following is trying to be too clever,
-        # in that the expected behavior is to raise the error.
-        try:
+        if obs.obsid in obsids:
             v1(f"Skipping {infile} as both it and {obsids[obs.obsid]} have OBS_ID={obs.obsid}.")
             blank_line = True
             continue
-        except KeyError:
-            obsids[obs.obsid] = infile
+
+        obsids[obs.obsid] = infile
 
         if len(obsinfos) == 1:
             filelabel = "file is"
@@ -1080,7 +1081,7 @@ def validate_obsinfo(infiles, colcheck=True):
         sort_order = { 'P' : 2, 'S' : 1, None: 0 }
 
         sort_tag = sort_order[obs.obsid.cycle]
-        time_tag= (obs.tstart,sort_tag) # tuples sort too
+        time_tag= (obs.tstart, sort_tag) # tuples sort too
         obsinfos.append((time_tag, obs))
 
     ninfiles = len(obsinfos)
@@ -2922,6 +2923,12 @@ def merge(process,
     # data sets are large, so leave as is for now.
     #
     v1(f"\nCombining {nobs} observations.")
+
+    # Combine the FOV files
+    #
+    outfov = outfiles['combinedfov']
+    run.combined_fovs(outfiles['fovs'], outfov)
+
     if threshold:
         obsid_images = outfiles['out_thresh_images']
         obsid_expmaps = outfiles['out_thresh_expmaps']
@@ -2979,6 +2986,7 @@ def merge(process,
     if psfmerge is not None:
         display("The combined PSF map", outfiles['out_psfmaps'])
 
+    display("The combined FOV", [outfov])
     display("The co-added exposure-corrected image", outfiles['out_fluxmaps'])
 
 

--- a/ciao_contrib/_tools/tests/test_ciao_contrib_tools_obsinfo.py
+++ b/ciao_contrib/_tools/tests/test_ciao_contrib_tools_obsinfo.py
@@ -1,0 +1,51 @@
+"""test ciao_contrib._tools.obsinfo"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ciao_contrib._tools import obsinfo
+
+
+def test_normalize_path_not_absolute():
+    with pytest.raises(ValueError) as ve:
+        obsinfo.normalize_path('foo/bar')
+
+    assert str(ve.value) == "Expected an absolute path for fname=foo/bar"
+
+
+def test_normalize_path_in_cwd():
+    cwd = os.getcwd()
+    infile = f'{cwd}/foo/bar.fits'
+
+    ans = obsinfo.normalize_path(infile)
+    assert ans == 'foo/bar.fits'
+
+
+def test_normalize_path_different_basedir():
+    """Could create a temp directory but assume /foo is not valid"""
+
+    infile = '/foo/foo/bar.fits'
+    ans = obsinfo.normalize_path(infile)
+    assert ans == infile
+
+
+def test_normalize_path_same_basedir():
+
+    # this is not really a sensible way to calculate the number of hops
+    infile = Path() / '..' / '..' / 'foo' / 'bar.fits'
+    infile = str(infile.resolve())
+
+    ans = obsinfo.normalize_path(infile)
+
+    expected = '../../foo/bar.fits'
+    assert ans == expected
+
+
+def test_obsinfo_not_a_file():
+    with pytest.raises(OSError) as oe:
+        obsinfo.ObsInfo('not-a-file')
+
+    # error message is not nice!
+    assert str(oe.value) == "Unable to open infile='not-a-file'\n  dmImageOpen() file does not exist. 'not-a-file'"

--- a/ciao_contrib/_tools/tests/test_ciao_contrib_tools_utils.py
+++ b/ciao_contrib/_tools/tests/test_ciao_contrib_tools_utils.py
@@ -159,38 +159,23 @@ def test_obsid_basic_obi_invalid_not_a_number(verbose1, caplog):
 
 
 def test_obsid_multi_obi_no_obi():
-    """Pick a known multi-obi case
+    """Pick a known multi-obi case"""
 
-    Perhaps we should error out in this case?
-    """
+    with pytest.raises(utils.MultiObiError) as me:
+        utils.ObsId('3057')
 
-    o = utils.ObsId('3057')
-    assert o.obsid == '3057'
-    assert o.cycle is None
-    assert o.obi is None
-    assert not o.is_multi_obi
-
-    assert str(o) == '3057'
+    assert str(me.value) == 'For multi-OBI datasets like 3057 the obi argument must be set'
 
 
 def test_obsid_multi_obi():
-    """Pick a known multi-obi case
-
-    Note that we do not set the is_multi_obi flag
-    automatically, which could be wrong.
-
-    """
+    """Pick a known multi-obi case"""
 
     o = utils.ObsId('3057', obi='002')
     assert o.obsid == '3057'
     assert o.cycle is None
     assert o.obi == 2
-    assert not o.is_multi_obi
-
-    assert str(o) == '3057'
-
-    o.is_multi_obi = True
     assert o.is_multi_obi
+
     assert str(o) == '3057_002'
 
 

--- a/ciao_contrib/_tools/tests/test_ciao_contrib_tools_utils.py
+++ b/ciao_contrib/_tools/tests/test_ciao_contrib_tools_utils.py
@@ -1,0 +1,413 @@
+"""Check ciao_contrib._tools.utils"""
+
+import pytest
+
+from ciao_contrib.logger_wrapper import get_verbosity, set_verbosity
+from ciao_contrib._tools import utils
+
+
+@pytest.fixture
+def verbose0():
+    orig = get_verbosity()
+    set_verbosity(0)
+    yield
+    set_verbosity(orig)
+
+
+@pytest.fixture
+def verbose1():
+    orig = get_verbosity()
+    set_verbosity(1)
+    yield
+    set_verbosity(orig)
+
+
+def test_list_multi_obi_obsids_is_copy():
+    x = utils.list_multi_obi_obsids()
+    x[0] = -43
+    y = utils.list_multi_obi_obsids()
+    assert y[0] == 82
+
+
+def test_list_multi_obi_obsids_size():
+    assert len(utils.list_multi_obi_obsids()) == 30
+
+
+def test_list_multi_obi_obsids_is_ordered():
+    x = utils.list_multi_obi_obsids()
+    y = sorted(x)
+    assert x == y
+
+
+@pytest.mark.parametrize('obsid',
+                         [82, 108, 279, 3764, 62249, 62264, 62796])
+def test_is_multi_obi(obsid):
+    """This is just a check we can copy values..."""
+    assert utils.is_multi_obi_obsid(obsid)
+
+
+@pytest.mark.parametrize('obsid', ['merged', 'Merged', 'MERGED'])
+def test_obsid_fails_if_merged(obsid):
+
+    with pytest.raises(ValueError) as ve:
+        utils.ObsId(obsid)
+
+    assert str(ve.value) == f"The OBS_ID value is '{obsid}'"
+
+
+def test_obsid_basic():
+    o = utils.ObsId('1024')
+    assert o.obsid == '1024'
+    assert o.cycle is None
+    assert o.obi is None
+    assert not o.is_multi_obi
+
+    assert str(o) == '1024'
+
+
+@pytest.mark.parametrize('cycle', ['P', 'S'])
+def test_obsid_basic_cycle(cycle):
+    o = utils.ObsId('1024', cycle)
+    assert o.obsid == '1024'
+    assert o.cycle == cycle
+    assert o.obi is None
+    assert not o.is_multi_obi
+
+    out = '1024e' + ('2' if cycle == 'S' else '1')
+    assert str(o) == out
+
+
+def test_obsid_basic_cycle_invalid(verbose1, caplog):
+
+    assert len(caplog.record_tuples) == 0
+
+    o = utils.ObsId('1024', cycle='p')
+
+    assert len(caplog.record_tuples) == 1
+    mod, lvl, msg = caplog.record_tuples[0]
+    assert mod == 'cxc.ciao.contrib.module._tools.utils'
+    assert lvl == 20
+    assert msg == 'WARNING: ObsId 1024 has unrecognized CYCLE=p, assuming not interleaved.'
+
+    assert o.obsid == '1024'
+    assert o.cycle is None
+    assert o.obi is None
+    assert not o.is_multi_obi
+
+    assert str(o) == '1024'
+
+
+@pytest.mark.parametrize('obi', ['000', '001'])
+def test_obsid_basic_obi(obi):
+    """By default the OBI is ignored"""
+    o = utils.ObsId('1024', obi=obi)
+    assert o.obsid == '1024'
+    assert o.cycle is None
+    assert o.obi == int(obi)
+    assert not o.is_multi_obi
+
+    assert str(o) == '1024'
+
+
+def test_obsid_basic_obi_not_multi():
+
+    o = utils.ObsId('1024', obi='002')
+    with pytest.raises(ValueError) as ve:
+        o.is_multi_obi = True
+
+    assert str(ve.value) == 'ObsId 1024 is not recognized as a multi-OBI dataset.'
+
+
+def test_obsid_basic_obi_invalid_negative(verbose1, caplog):
+
+    assert len(caplog.record_tuples) == 0
+
+    o = utils.ObsId('1024', obi='-2')
+
+    assert len(caplog.record_tuples) == 1
+    mod, lvl, msg = caplog.record_tuples[0]
+    assert mod == 'cxc.ciao.contrib.module._tools.utils'
+    assert lvl == 20
+    assert msg == 'WARNING: ObsId 1024 has obi=-2 which is < 0; ignoring.'
+
+    assert o.obsid == '1024'
+    assert o.cycle is None
+    assert o.obi is None
+    assert not o.is_multi_obi
+
+    assert str(o) == '1024'
+
+
+def test_obsid_basic_obi_invalid_not_a_number(verbose1, caplog):
+
+    assert len(caplog.record_tuples) == 0
+
+    o = utils.ObsId('1024', obi='x')
+
+    assert len(caplog.record_tuples) == 1
+    mod, lvl, msg = caplog.record_tuples[0]
+    assert mod == 'cxc.ciao.contrib.module._tools.utils'
+    assert lvl == 20
+    assert msg == 'WARNING: ObsId 1024 has invalid obi=x (expected integer); ignoring.'
+
+    assert o.obsid == '1024'
+    assert o.cycle is None
+    assert o.obi is None
+    assert not o.is_multi_obi
+
+    assert str(o) == '1024'
+
+
+def test_obsid_multi_obi_no_obi():
+    """Pick a known multi-obi case
+
+    Perhaps we should error out in this case?
+    """
+
+    o = utils.ObsId('3057')
+    assert o.obsid == '3057'
+    assert o.cycle is None
+    assert o.obi is None
+    assert not o.is_multi_obi
+
+    assert str(o) == '3057'
+
+
+def test_obsid_multi_obi():
+    """Pick a known multi-obi case
+
+    Note that we do not set the is_multi_obi flag
+    automatically, which could be wrong.
+
+    """
+
+    o = utils.ObsId('3057', obi='002')
+    assert o.obsid == '3057'
+    assert o.cycle is None
+    assert o.obi == 2
+    assert not o.is_multi_obi
+
+    assert str(o) == '3057'
+
+    o.is_multi_obi = True
+    assert o.is_multi_obi
+    assert str(o) == '3057_002'
+
+
+def test_print_version_v0(verbose0, caplog):
+
+    assert len(caplog.record_tuples) == 0
+    utils.print_version('bob', '0.1')
+    assert len(caplog.record_tuples) == 0
+
+
+def test_print_version_v1(verbose1, caplog):
+
+    assert len(caplog.record_tuples) == 0
+    utils.print_version('bob', '0.1')
+    assert len(caplog.record_tuples) == 2
+    for mod, lvl, _ in caplog.record_tuples:
+        assert mod == 'cxc.ciao.contrib.module._tools.utils'
+        assert lvl == 20
+
+    msg = caplog.record_tuples[0][2]
+    assert msg == 'Running bob'
+
+    msg = caplog.record_tuples[1][2]
+    assert msg == 'Version: 0.1\n'
+
+
+@pytest.mark.parametrize('outroot,outdir,outhead',
+                         [('foo', '', 'foo_'),
+                          ('foo/', 'foo/', ''),
+                          ('foo/bar', 'foo/', 'bar_'),
+                          ('', '', '')  # should this be an error?
+                          ])
+def test_split_outroot(outroot, outdir, outhead):
+    adir, ahead = utils.split_outroot(outroot)
+    assert adir == outdir
+    assert ahead == outhead
+
+
+@pytest.mark.parametrize('val,expected',
+                         [('indef', None),
+                          ('INDEF', None),
+                          ('2', 2),
+                          ('2.0', 2),
+                          ('-1', -1),
+                          ('-1.0', -1),
+                          ('2.1', 2.1),
+                          ('-2.1', -2.1),
+                         ])
+def test_to_number(val, expected):
+
+    ans = utils.to_number(val)
+    if expected is None:
+        assert ans is None
+        return
+
+    assert ans == expected
+    assert type(ans) == type(expected)
+
+
+def test_to_number_invalid():
+
+    with pytest.raises(ValueError) as ve:
+        utils.to_number('2x')
+
+    assert str(ve.value) == "Unable to convert '2x' to a number."
+
+
+@pytest.mark.parametrize('vals,expected',
+                         [([1, 3, 2], [1, 3, 2]),
+                          (["1", "3", "2"], ["1", "3", "2"]),
+                          ([1, 3, 3, 2, 1], [1, 3, 2]),
+                          ([1, 1, 1, 1], [1]),
+                          ([], [])
+                         ])
+def test_getUniqueSynset(vals, expected):
+    out = utils.getUniqueSynset(vals)
+    assert out == expected
+
+
+@pytest.mark.parametrize("val", [None, "", "none", "None", "0", "0%", ":"])
+def test_thresh_is_not_set(val):
+    assert not utils.thresh_is_set(val)
+
+
+@pytest.mark.parametrize("val", ["2", "2:", "2%"])
+def test_thresh_is_set(val):
+    assert utils.thresh_is_set(val)
+
+
+@pytest.mark.parametrize("invalid,msg",
+                         [("" ,"Expected a:b:c or a:b:#c, not "),
+                          ("2", "Expected a:b:c or a:b:#c, not 2"),
+                          ("2:3", "Expected a:b:c or a:b:#c, not 2:3"),
+                          ("2:3:0.2:2", "Expected a:b:c or a:b:#c, not 2:3:0.2:2"),
+
+                          # errors for lo/hi
+                          ("::", "Unable to convert '' to a number."),
+                          ("x::", "Unable to convert 'x' to a number."),
+                          ("2::", "Unable to convert '' to a number."),
+                          ("2:x:", "Unable to convert 'x' to a number."),
+
+                          ("2:3:#x", "Unable to convert 'x' to a number."),
+                          ("2:3:#0", "Number of bins must be > 0 in 2:3:#0"),
+                          ("2:3:#-1", "Number of bins must be > 0 in 2:3:#-1"),
+                          ("2:3:0", "The binsize must be > 0 in 2:3:0"),
+                          ("2:3:-0.2", "The binsize must be > 0 in 2:3:-0.2"),
+                          ])
+def test_parse_range_errors(invalid, msg):
+    """TODO: we should error out when lo >= hi"""
+
+    with pytest.raises(ValueError) as ve:
+        utils.parse_range(invalid)
+
+    assert str(ve.value) == msg
+
+
+def test_parse_range_nbins():
+
+    lo, hi, binsize, nbins = utils.parse_range('2:12:#10')
+    assert lo == 2.0
+    assert hi == 12.0
+    assert binsize == 1.0
+    assert nbins == 10
+
+
+def test_parse_range_stepsize():
+
+    lo, hi, binsize, nbins = utils.parse_range('2:12:1')
+    assert lo == 2.0
+    assert hi == 12.0
+    assert binsize == 1.0
+    assert nbins == 10
+
+
+@pytest.mark.parametrize("invalid,msg",
+                         [("", "xygrid should be a filename or 2 ranges separated by a comma, not ''!"),
+                          ("2:12:1", "xygrid should be a filename or 2 ranges separated by a comma, not '2:12:1'!"),
+                          ("foo,bar", "xygrid should be a filename or xlo:xhi:#nx or dx,ylo:yhi:#ny or dy, not 'foo,bar'!"),
+
+                          ])
+def test_parse_xygrid_string_errors(invalid, msg):
+    """This is slightly tricky as invalid must not match an image file name"""
+
+    with pytest.raises(ValueError) as ve:
+        utils.parse_xygrid(invalid)
+
+    assert str(ve.value) == msg
+
+
+def test_parse_xygrid_string_square():
+
+    outstr, binsize, xrng, yrng, nbins = utils.parse_xygrid('2:12:1, 3:12:1')
+    assert outstr == 'x=2:12:1,y= 3:12:1'
+    assert binsize == 1
+    assert xrng == (2, 12)
+    assert yrng == (3, 12)
+    assert nbins == (10, 9)
+
+
+def test_parse_xygrid_string_rectangle():
+
+    outstr, binsize, xrng, yrng, nbins = utils.parse_xygrid('2:12:#10,3:12:#18')
+    assert outstr == 'x=2:12:#10,y=3:12:#18'
+    assert binsize == 0.5
+    assert xrng == (2, 12)
+    assert yrng == (3, 12)
+    assert nbins == (10, 18)
+
+
+@pytest.mark.parametrize("invalid", ["12", "foobar", "12 , 13,14", ",23", " ,  23  "])
+def test_parse_refpos_string_errors(invalid):
+    with pytest.raises(ValueError) as ve:
+        utils.parse_refpos(invalid)
+
+    assert str(ve.value) == f'Unable to parse {invalid} as a ra and dec value.'
+
+
+@pytest.mark.parametrize("invalid", ["x,23", "12:23:45:2,23"])
+def test_parse_refpos_string_errors_ra(invalid):
+    with pytest.raises(ValueError) as ve:
+        utils.parse_refpos(invalid)
+
+    assert str(ve.value).startswith(f'Could not parse the RA value, ')
+
+
+@pytest.mark.parametrize("invalid", ["23,x", "12:23:45.2,12:23:45:23", "12,-100", "12, 100"])
+def test_parse_refpos_string_errors_dec(invalid):
+    with pytest.raises(ValueError) as ve:
+        utils.parse_refpos(invalid)
+
+    assert str(ve.value).startswith(f'Could not parse the Dec value, ')
+
+
+@pytest.mark.parametrize("arg", [""," ", "           "])
+def test_parse_refpos_empty_string(arg):
+    assert utils.parse_refpos(arg) is None
+
+
+def test_parse_refpos():
+    ra, dec, dummy = utils.parse_refpos(" 12 , -0.1 ")
+    assert dummy is None
+    assert ra == 12.0
+    assert dec == -0.1
+
+
+def test_sky_to_arcsec_invalid():
+    with pytest.raises(ValueError) as ve:
+        utils.sky_to_arcsec('XMM', 23)
+
+    assert str(ve.value) == "Invalid instrume=XMM argument, expected ACIS or HRC."
+
+
+def test_sky_to_arcsec_acis():
+    out = utils.sky_to_arcsec('ACIS', 1000)
+    assert out == 492.0
+
+
+def test_sky_to_arcsec_hrc():
+    out = utils.sky_to_arcsec('HRC', 10000)
+    assert out == 1318.0

--- a/ciao_contrib/_tools/utils.py
+++ b/ciao_contrib/_tools/utils.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016
+#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2021
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -97,7 +97,7 @@ def is_multi_obi_obsid(obsid):
     try:
         return int(obsid) in _multi_obi_obsids
     except ValueError:
-        raise ValueError("obsid argument does not appear to be an integer: {}".format(obsid))
+        raise ValueError(f"obsid argument does not appear to be an integer: {obsid}")
 
 
 # TODO: should the file name be provided to ObsId so that error
@@ -105,7 +105,7 @@ def is_multi_obi_obsid(obsid):
 #
 
 @functools.total_ordering
-class ObsId(object):
+class ObsId:
     """Represents an observation, as specified by
     an OBS_ID value and, optionally:
 
@@ -116,27 +116,25 @@ class ObsId(object):
       obi_num
         for multi-obi datasets.
 
-    Unlike the header of the ACIS file, the cycle
-    attribute will only be present if this file
-    appears to be part of an interleaved-mode
+    Unlike the header of the ACIS file, the cycle attribute will only
+    be present if this file appears to be part of an interleaved-mode
     observation (either CYCLE=S or TIMEDELB!=0).
 
-    The presence of the OBI_NUM keyword in a file depends
-    on how it was processed (if an archive evt2 file then
-    it may not have the keyword [*], but if processed via
-    chandra_repro then it should have it).
+    The presence of the OBI_NUM keyword in a file depends on how it
+    was processed (if an archive evt2 file then it may not have the
+    keyword [*], but if processed via chandra_repro then it should
+    have it).
 
-    [*] multi-obi datasets will not have it because they
-    are formed by merging together the different OBIs
-    which results in the keyword being removed.
+    [*] multi-obi datasets will not have it because they are formed by
+    merging together the different OBIs which results in the keyword
+    being removed.
 
-    Converting to a string uses the observation
-    id followed by "e1" if a primary observation
-    or "e2" if a secondary observation. The decision
-    to append "_{:03d}.format(obi)" to this string is
-    controlled by the is_multi_obi attribute. I am not 100% happy
-    with this interface - hard to reason about - but it
-    makes some things easier.
+    Converting to a string uses the observation id followed by "e1" if
+    a primary observation or "e2" if a secondary observation. The
+    decision to append "_{:03d}.format(obi)" to this string is
+    controlled by the is_multi_obi attribute. I am not 100% happy with
+    this interface - hard to reason about - but it makes some things
+    easier.
 
     Objects are judged to be equal based on
 
@@ -144,19 +142,20 @@ class ObsId(object):
       2) cycle (primary before secondary)
       3) OBI_NUM (lower values first; None/undefined is "first")
 
-    So the ordering is nothing to do with time (even though
-    for many cases it will end up so, it is not guaranteed). Also,
-    as the values are strings, the comparison is done using
-    string rather than numeric rules (apart from OBI_NUM).
+    So the ordering is nothing to do with time (even though for many
+    cases it will end up so, it is not guaranteed). Also, as the
+    values are strings, the comparison is done using string rather
+    than numeric rules (apart from OBI_NUM).
 
-    If an ObsId is marked as being multi-obi, then it is checked
-    to make sure we recognize it (as there's a small set of
-    such observations, and it is not expected to increase,
-    this is a feasible check). This behavior may change,
-    as more experience is gained with the multi-OBI case.
+    If an ObsId is marked as being multi-obi, then it is checked to
+    make sure we recognize it (as there's a small set of such
+    observations, and it is not expected to increase, this is a
+    feasible check). This behavior may change, as more experience is
+    gained with the multi-OBI case.
 
-    Use the make_obsid_from_headers() routine if you
-    have a dictionary of headers.
+    Use the make_obsid_from_headers() routine if you have a dictionary
+    of headers.
+
     """
 
     def __init__(self, obsid, cycle=None, obi=None):
@@ -178,12 +177,12 @@ class ObsId(object):
         single OBI of a multi-OBI dataset, it may not be important).
         """
 
-        v3("ObsId sent obsid={} cycle={} obi={}".format(obsid, cycle, obi))
+        v3(f"ObsId sent obsid={obsid} cycle={cycle} obi={obi}")
         if obsid.lower() == "merged":
-            raise ValueError("The OBS_ID value is '{}'".format(obsid))
+            raise ValueError(f"The OBS_ID value is '{obsid}'")
 
         if cycle not in [None, 'P', 'S']:
-            v1("WARNING: ObsId {} has unrecognized CYCLE={}, assuming not interleaved.".format(obsid, cycle))
+            v1(f"WARNING: ObsId {obsid} has unrecognized CYCLE={cycle}, assuming not interleaved.")
             cycle = None
 
         obival = None
@@ -191,11 +190,11 @@ class ObsId(object):
             try:
                 obival = int(obi)
                 if obival < 0:
-                    v1("WARNING: ObsId {} has obi={} which is < 0; ignoring.".format(obsid, obi))
+                    v1(f"WARNING: ObsId {obsid} has obi={obi} which is < 0; ignoring.")
                     obival = None
 
             except ValueError:
-                v1("WARNING: ObsId {} has invalid obi={} (expected integer); ignoring.".format(obsid, obi))
+                v1(f"WARNING: ObsId {obsid} has invalid obi={obi} (expected integer); ignoring.")
 
         # Note: store obi as an integer value; it's an integer in
         # the header, so retain that here. The choice to display as
@@ -225,23 +224,24 @@ class ObsId(object):
 
     @property
     def is_multi_obi(self):
-        """Is this marked as a multi-OBI observation (so that
-        the OBI value is included in the string
-        representation of the ObsId)? This can only be set
-        if the OBI value is not None, and if the ObsId is
-        recognized as a multi-OBI dataset (it errors out,
-        as a safety precaution; this might be relaxed).
+        """Is this marked as a multi-OBI observation (so that the OBI value is
+        included in the string representation of the ObsId)? This can
+        only be set if the OBI value is not None, and if the ObsId is
+        recognized as a multi-OBI dataset (it errors out, as a safety
+        precaution; this might be relaxed).
+
         """
         return self._is_multi_obi
 
     @is_multi_obi.setter
     def is_multi_obi(self, flag):
         if flag and self.obi is None:
-            raise ValueError("Unable to set multi-obi flag for ObsId {} as no OBI value.".format(self.obsid))
-        v3("Checking if ObsId {} (with OBI={}) is a multi-OBI dataset".format(self.obsid, self.obi))
-        v4("ObsId {} has type {}".format(self.obsid, type(self.obsid)))
+            raise ValueError(f"Unable to set multi-obi flag for ObsId {self.obsid} as no OBI value.")
+
+        v3(f"Checking if ObsId {self.obsid} (with OBI={self.obi}) is a multi-OBI dataset")
+        v4(f"ObsId {self.obsid} has type {type(self.obsid)}")
         if flag and not is_multi_obi_obsid(self.obsid):
-            raise ValueError("ObsId {} is not recognized as a multi-OBI dataset.".format(self.obsid))
+            raise ValueError(f"ObsId {self.obsid} is not recognized as a multi-OBI dataset.")
 
         self._is_multi_obi = flag
 
@@ -249,25 +249,24 @@ class ObsId(object):
     # it (since it's not needed in the vast-majority of ObsIds). To support
     # multi-OBI datasets, the is_multi_obi flag can be changed by the caller
     # (since it's not obvious we can tell from an ObsId/OBI value whether
-    # it's a multi-obi dataset)
+    # it's a multi-obi dataset). Technically we now can, but this comment
+    # is from an earlier version of the code.
     #
     def __str__(self):
         """The OBI is included if is_multi_obi is set on the object
         (and there is an OBI value to include)."""
-        out = "{}".format(self.obsid)
+        out = f"{self.obsid}"
         if self.cycle == 'P':
             out += 'e1'
         elif self.cycle == 'S':
             out += 'e2'
         if self.is_multi_obi and self.obi is not None:
-            out += "_{:03d}".format(self.obi)
+            out += f"_{self.obi:03d}"
         return out
 
     def __repr__(self):
         "This is only for debugging rather than being valid Python"
-        return "ObsId({},cycle={},obi={})".format(self.obsid,
-                                                  self.cycle,
-                                                  self.obi)
+        return f"ObsId({self.obsid},cycle={self.cycle},obi={self.obi})"
 
     # no checks to avoid attribute errors if used with an invalid rhs
     def __eq__(self, rhs):
@@ -307,7 +306,7 @@ def make_obsid_from_headers(headers, infile=None):
     """
 
     if infile is not None:
-        v3("Looking for ObsId from headers of {}.".format(infile))
+        v3(f"Looking for ObsId from headers of {infile}.")
     else:
         v3("Looking for ObsId from headers.")
 
@@ -318,17 +317,17 @@ def make_obsid_from_headers(headers, infile=None):
         if infile is None:
             emsg += "."
         else:
-            emsg += " in {}.".format(infile)
+            emsg += f" in {infile}."
         raise KeyError(emsg)
     except TypeError:
         raise TypeError("The input must accept string indexing.")
 
     if obsid.lower() == "merged":
-        emsg = "The OBS_ID value is '{}'".format(obsid)
+        emsg = f"The OBS_ID value is '{obsid}'"
         if infile is None:
             emsg += "."
         else:
-            emsg += " in {}.".format(infile)
+            emsg += f" in {infile}."
         raise ValueError(emsg)
 
     try:
@@ -337,38 +336,38 @@ def make_obsid_from_headers(headers, infile=None):
         try:
             timedelb = float(timedelb)
         except ValueError:
-            v3("ObsId: obsid={} cycle={} unable to convert timedelb={}".format(obsid, cycle, timedelb))
+            v3(f"ObsId: obsid={obsid} cycle={cycle} unable to convert timedelb={timedelb}")
             cycle = None
 
         if timedelb > 0:
-            v3("TIMEDEL={} is > 0 so assuming interleaved.".format(timedelb))
+            v3(f"TIMEDEL={timedelb} is > 0 so assuming interleaved.")
         else:
-            v3("TIMEDEL={} is <= 0 so assuming non-interleaved.".format(timedelb))
+            v3(f"TIMEDEL={timedelb} is <= 0 so assuming non-interleaved.")
             cycle = None
 
     except KeyError:
-        v3("ObsId: obsid={}; does not contain CYCLE or TIMEDELB.".format(obsid))
+        v3(f"ObsId: obsid={obsid}; does not contain CYCLE or TIMEDELB.")
         cycle = None
 
     if cycle not in [None, 'P', 'S']:
-        v1("WARNING: ObsId {} has unrecognized CYCLE={}, assuming not interleaved.".format(obsid))
+        v1(f"WARNING: ObsId {obsid} has unrecognized CYCLE={cycle}, assuming not interleaved.")
         cycle = None
 
     try:
         obi = headers['OBI_NUM']
     except KeyError:
-        v3("ObsId: obsid={}; does not contain OBI_NUM".format(obsid))
+        v3(f"ObsId: obsid={obsid}; does not contain OBI_NUM")
         obi = None
 
-    v3("ObsId: obsid={} cycle={} obi={}".format(obsid, cycle, obi))
+    v3(f"ObsId: obsid={obsid} cycle={cycle} obi={obi}")
     return ObsId(obsid, cycle=cycle, obi=obi)
 
 
 def print_version(toolname, version):
     """Print the name and version of the script"""
 
-    v1("Running {}".format(toolname))
-    v1("Version: {}\n".format(version))
+    v1(f"Running {toolname}")
+    v1(f"Version: {version}\n")
 
 
 def split_outroot(outroot):
@@ -395,7 +394,7 @@ def split_outroot(outroot):
     else:
         outhead = head + "_"
 
-    v3("Splitting outroot parameter: {} to dirname={} head={}".format(outroot, outdir, outhead))
+    v3(f"Splitting outroot parameter: {outroot} to dirname={outdir} head={outhead}")
     return (outdir, outhead)
 
 
@@ -413,8 +412,9 @@ def to_number(inval):
         try:
             out = float(inval)
         except ValueError:
-            raise ValueError("Unable to convert '{0}' to a number.".format(inval))
+            raise ValueError(f"Unable to convert '{inval}' to a number.") from None
 
+    # should we use out.is_integer()?
     if int(out) == out:
         return int(out)
     else:
@@ -464,7 +464,7 @@ def parse_range(rstr):
 
     toks = rstr.split(":")
     if len(toks) != 3:
-        raise ValueError("Expected a:b:c or a:b:#c, not {}".format(rstr))
+        raise ValueError(f"Expected a:b:c or a:b:#c, not {rstr}")
 
     toks = [tok.strip() for tok in toks]
     lo = to_number(toks[0])
@@ -472,14 +472,14 @@ def parse_range(rstr):
     if toks[2][0] == '#':
         nbins = to_number(toks[2][1:])
         if nbins <= 0:
-            raise ValueError("Number of bins must be > 0 in {}".format(rstr))
+            raise ValueError(f"Number of bins must be > 0 in {rstr}")
 
         binsize = (hi - lo) * 1.0 / nbins
 
     else:
         binsize = to_number(toks[2])
         if binsize <= 0:
-            raise ValueError("The binsize must be > 0 in {}".format(rstr))
+            raise ValueError(f"The binsize must be > 0 in {rstr}")
 
         nbins = (hi - lo) * 1.0 / binsize
 
@@ -502,11 +502,11 @@ def parse_xygrid(gstr):
     in the output image for each axis.
     """
 
-    v3("Verifying xygrid={}".format(gstr))
+    v3(f"Verifying xygrid={gstr}")
 
     with rt.new_pfiles_environment(ardlib=False, copyuser=False):
         devnull = open('/dev/null', 'w')
-        sbp.call(["get_sky_limits", "image={}".format(gstr)],
+        sbp.call(["get_sky_limits", f"image={gstr}"],
                  stdout=devnull, stderr=devnull)
         devnull.close()
         xygrid = paramio.pgetstr("get_sky_limits", "xygrid")
@@ -516,7 +516,7 @@ def parse_xygrid(gstr):
 
     xystk = xygrid.split(",")
     if len(xystk) != 2:
-        raise ValueError("xygrid should be a filename or 2 ranges separated by a comma, not '{}'!".format(xygrid))
+        raise ValueError(f"xygrid should be a filename or 2 ranges separated by a comma, not '{xygrid}'!")
 
     # Note: lose some info if there is an error
     try:
@@ -524,14 +524,14 @@ def parse_xygrid(gstr):
         yrng = parse_range(xystk[1])
 
     except ValueError:
-        raise ValueError("xygrid should be a filename or xlo:xhi:#nx or dx,ylo:yhi:#ny or dy, not '{}'!".format(xygrid))
+        raise ValueError(f"xygrid should be a filename or xlo:xhi:#nx or dx,ylo:yhi:#ny or dy, not '{xygrid}'!") from None
 
     xbinsize = xrng[2]
     ybinsize = yrng[2]
 
     # We pick the smaller binsize (expect them to be the same)
     if xbinsize != ybinsize:
-        v1("WARNING: X and Y axis bin sizes are different ({} vs {}); using the smaller.".format(xbinsize, ybinsize))
+        v1(f"WARNING: X and Y axis bin sizes are different ({xbinsize} vs {ybinsize}); using the smaller.")
         binsize = min(xbinsize, ybinsize)
     else:
         binsize = xbinsize
@@ -539,7 +539,7 @@ def parse_xygrid(gstr):
     if int(binsize) == binsize:
         binsize = int(binsize)
 
-    return ("x={},y={}".format(xystk[0], xystk[1]), binsize,
+    return (f"x={xystk[0]},y={xystk[1]}", binsize,
             (xrng[0], xrng[1]), (yrng[0], yrng[1]), (xrng[3], yrng[3]))
 
 
@@ -563,7 +563,7 @@ def parse_refpos(refpos):
         v3("Reference position is a file.")
         return (None, None, refpos)
 
-    v3("Extracting reference position from " + refpos)
+    v3(f"Extracting reference position from {refpos}")
 
     # Assume that no spaces are used to separate out
     # sexagesimal formats, so that we can treat the
@@ -571,7 +571,7 @@ def parse_refpos(refpos):
     #
     coord = stk.build(refpos)
     if len(coord) != 2:
-        raise ValueError("Unable to parse {} as a ra and dec value.".format(refpos))
+        raise ValueError(f"Unable to parse {refpos} as a ra and dec value.")
 
     ra = coords.format.ra2deg(coord[0])
     dec = coords.format.dec2deg(coord[1])
@@ -589,7 +589,7 @@ def sky_to_arcsec(instrume, pixsize):
     elif instrume == 'HRC':
         return pixsize * 0.1318
     else:
-        raise ValueError("Invalid instrume={} argument, expected ACIS or HRC.".format(instrume))
+        raise ValueError(f"Invalid instrume={instrume} argument, expected ACIS or HRC.")
 
 
 def process_tmpdir(tmpdir):
@@ -606,10 +606,10 @@ def process_tmpdir(tmpdir):
 
     dname = os.path.abspath(tmpdir)
     if not os.path.exists(dname):
-        raise IOError("The temporary directory {} does not exist!".format(dname))
+        raise IOError(f"The temporary directory {dname} does not exist!")
 
     if not os.path.isdir(dname):
-        raise IOError("The temporary directory {} is not actually a directory!".format(dname))
+        raise IOError(f"The temporary directory {dname} is not actually a directory!")
 
     os.environ["ASCDS_WORK_PATH"] = dname
     return dname

--- a/ciao_contrib/_tools/utils.py
+++ b/ciao_contrib/_tools/utils.py
@@ -100,6 +100,13 @@ def is_multi_obi_obsid(obsid):
         raise ValueError(f"obsid argument does not appear to be an integer: {obsid}")
 
 
+class MultiObiError(ValueError):
+    """Handle an ObsId with multi OBIs but OBI_NUM is not set"""
+
+    # when did it become okay to use an empty class statement?
+    pass
+
+
 # TODO: should the file name be provided to ObsId so that error
 #       messages can be more illuminating?
 #
@@ -214,7 +221,7 @@ class ObsId:
         #
         if is_multi_obi_obsid(obsid):
             if obival is None:
-                raise ValueError(f"For multi-OBI datasets like {obsid} the obi argument must be set")
+                raise MultiObiError(f"For multi-OBI datasets like {obsid} the obi argument must be set")
 
             self._is_multi_obi = True
 

--- a/ciao_contrib/_tools/utils.py
+++ b/ciao_contrib/_tools/utils.py
@@ -156,6 +156,9 @@ class ObsId:
     Use the make_obsid_from_headers() routine if you have a dictionary
     of headers.
 
+    Experimental change: for multi-obi observations we error out if
+    obi is not set.
+
     """
 
     def __init__(self, obsid, cycle=None, obi=None):
@@ -207,6 +210,14 @@ class ObsId:
 
         self._is_multi_obi = False
 
+        # experimental support for multi-obi cases
+        #
+        if is_multi_obi_obsid(obsid):
+            if obival is None:
+                raise ValueError(f"For multi-OBI datasets like {obsid} the obi argument must be set")
+
+            self._is_multi_obi = True
+
     @property
     def obsid(self):
         "The ObsId value."
@@ -233,6 +244,7 @@ class ObsId:
         """
         return self._is_multi_obi
 
+    # TODO: take this away????
     @is_multi_obi.setter
     def is_multi_obi(self, flag):
         if flag and self.obi is None:

--- a/share/doc/xml/flux_obs.xml
+++ b/share/doc/xml/flux_obs.xml
@@ -64,10 +64,13 @@
 	creating this directory if necessary.
 	The output files include:
       </PARA>
-      <!-- WHY use a list for one item here? -->
       <LIST>
-	<ITEM>reproj/broad&flname;, the exposure-corrected
-	broad-band image.</ITEM>
+	<ITEM>
+	  reproj/broad&flname;, the exposure-corrected broad-band image;
+	</ITEM>
+	<ITEM>
+	  reproj/merged.fov, the merged FOV file from all the observations.
+	</ITEM>
       </LIST>
 
       <PARA>
@@ -92,6 +95,7 @@
 	  <LINE>&upr; punlearn &rname; &fname;</LINE>
 	  <LINE>&upr; &rname; 5826/repro/acisf05826_repro_evt2.fits,5827/repro/acisf05827_repro_evt2.fits reproj/</LINE>
 	  <LINE>&upr; &fname; reproj/ m87</LINE>
+	  <LINE>&upr; ds9 m87_broad&flname; -region m87_merged.fov</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -159,6 +163,7 @@
       <QEXAMPLE>
 	<SYNTAX>
 	  <LINE>&upr; &fname; "merged/*reproj_evt.fits" merged/</LINE>
+	  <LINE>&upr; ds9 merged/broad&flname; -region merged/merged.fov</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -1451,6 +1456,7 @@
       <TABLE>
 	<CAPTION>Combined data</CAPTION>
 	<ROW><DATA>Type</DATA><DATA>Filename</DATA></ROW>
+	<ROW><DATA>Merged FOV file</DATA><DATA>outroot_merged.fov</DATA></ROW>
 	<ROW><DATA>Counts image</DATA><DATA>outroot_blabel.img</DATA></ROW>
 	<ROW><DATA>Combined exposure map</DATA><DATA>outroot_blabel.expmap</DATA></ROW>
 	<ROW><DATA>Clipped counts image</DATA><DATA>outroot_blabel_thresh.img</DATA></ROW>
@@ -1465,6 +1471,7 @@
       <TABLE>
 	<CAPTION>Per-observation data</CAPTION>
 	<ROW><DATA>Type</DATA><DATA>Filename</DATA></ROW>
+	<ROW><DATA>FOV file</DATA><DATA>outroot_obsid.fov</DATA></ROW>
 	<ROW><DATA>Counts image</DATA><DATA>outroot_obsid_blabel.img</DATA></ROW>
 	<ROW><DATA>Combined exposure map</DATA><DATA>outroot_obsid_blabel.expmap</DATA></ROW>
 	<ROW><DATA>Clipped counts image</DATA><DATA>outroot_obsid_blabel_thresh.img</DATA></ROW>
@@ -1528,6 +1535,15 @@
       <PARA title="Interleaved mode">
 	For interleaved-mode data, "e1" or "e2" is appended to the ObsId
 	value when creating file names.
+      </PARA>
+
+      <PARA title="Multi-OBI datasets">
+	There are 30 ObsIds which contain multiple OBI segments. If the
+	data has been split using
+	<HREF link="https://cxc.harvard.edu/ciao/ahelp/splitobs.html">splitobs</HREF>
+	then they can be combined using &mname;, but the ObsId labels
+	will contain the suffix _00n (where n is the OBI_NUM value
+	from the header).
       </PARA>
 
       <!--
@@ -1708,6 +1724,12 @@
 	</ITEM>
 
 	<ITEM>
+	  A FOV file for each observation is created using the reprojected
+	  event files. These regions are combined to create the merged
+	  FOV file.
+	</ITEM>
+
+	<ITEM>
 	  For each band, the counts images and exposure maps are summed,
 	  and used to create exposure-corrected images,
 	  one per band. Any observation PSF maps are combined together,
@@ -1727,7 +1749,12 @@
 	to this the combination could cause the script to fail).
       </PARA>
       <PARA>
-	There have been improvements to the handling of a large number
+	The script now generates the FOV file for each reprojected event file
+	and a combined region file (merged.fov) that includes all the individual
+	observation FOV files.
+      </PARA>
+      <PARA>
+	There have been improvements to how the script handles a large number
 	of observations.
       </PARA>
     </ADESC>

--- a/share/doc/xml/fluximage.xml
+++ b/share/doc/xml/fluximage.xml
@@ -65,7 +65,7 @@
 	  <LINE>&pr; cd 1843</LINE>
 	  <LINE>&pr; chandra_repro indir=. outdir=repro</LINE>
 	  <LINE>&pr; fluximage . fluxed/</LINE>
-	  <LINE>&pr; ds9 fluxed/broad_flux.img</LINE>
+	  <LINE>&pr; ds9 fluxed/broad_flux.img -region fluxed/1843.fov</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -92,7 +92,8 @@
 	    directory).
 	    Finally ds9 is used to view the exposure-corrected
 	    image, the name of which includes the energy range, effective
-	    energy used and the binning factor.
+	    energy used and the binning factor. The FOV file, which indicates
+	    the extent of the observation, is also shown in the ds9 window.
 	  </PARA>
 	  <PARA>
 	    Note that reprocessing your data - whether via chandra_repro or
@@ -247,7 +248,7 @@
 	  <LINE>&pr; cd 6202</LINE>
 	  <LINE>&pr; chandra_repro indir=. outdir=repro</LINE>
 	  <LINE>&pr; fluximage repro/ fluxed/</LINE>
-	  <LINE>&pr; ds9 fluxed/wide_flux.img</LINE>
+	  <LINE>&pr; ds9 fluxed/wide_flux.img -region fluxed/6202.fov</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -1308,11 +1309,13 @@
 	<ROW><DATA>E</DATA><DATA>Optional PSF map (no threshold)</DATA><DATA>outroot_blabel.psfmap</DATA></ROW>
 	<ROW><DATA>C</DATA><DATA>Clipped counts image</DATA><DATA>outroot_blabel_thresh.img</DATA></ROW>
 	<ROW><DATA>C</DATA><DATA>Clipped exposure map</DATA><DATA>outroot_blabel_thresh.expmap</DATA></ROW>
+	<ROW><DATA>A</DATA><DATA>FOV file</DATA><DATA>outroot_obsid.fov</DATA></ROW>
 	<ROW><DATA>A</DATA><DATA>Exposure-corrected image</DATA><DATA>outroot_blabel_flux.img</DATA></ROW>
       </TABLE>
 
       <PARA>
 	where blabel is either the band name (e.g. soft, broad, ...),
+	obsid is the observation number (and can include the OBI number for the small number of multi-OBI observations),
 	"lo-hi" where lo and hi are the limits of the
 	range (keV for ACIS, PI for HRC), or band1 to bandn (when using spectral
 	weight files).
@@ -1538,7 +1541,7 @@
 	science analysis threads</HREF>.  The following steps are taken to create the data products:
       </PARA>
       <LIST>
-	<ITEM>skyfov and get_fov_limits: to determine the output image area</ITEM>
+	<ITEM>skyfov and get_fov_limits: to determine the output image area, and to create the FOV file</ITEM>
 	<ITEM>dmcopy: to create an events image with the specified binning factor</ITEM>
 	<ITEM>hrc_bkgrnd_lookup, reproject_events, and dmimgcalc: to subtract the particle background (HRC-I only)</ITEM>
 	<ITEM>asphist: to build the aspect histogram(s)</ITEM>
@@ -1581,6 +1584,13 @@
 	is used to filter the particle background file; this
 	value is displayed on screen and written to the background
 	files as the STATFILT keyword.
+      </PARA>
+    </ADESC>
+
+    <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
+      <PARA>
+	The script now generates the FOV file for the observation, which
+	is called &lt;obsid&gt;.fov in the outroot location.
       </PARA>
     </ADESC>
 
@@ -1779,6 +1789,6 @@
 	listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>February 2021</LASTMODIFIED>
+    <LASTMODIFIED>December 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/merge_obs.xml
+++ b/share/doc/xml/merge_obs.xml
@@ -141,6 +141,7 @@
 	  <LINE>&upr; chandra_repro 5826,5827 outdir=""</LINE>
 	  <LINE>&upr; punlearn &mname;</LINE>
 	  <LINE>&upr; &mname; 5826/,5827/ m87</LINE>
+	  <LINE>&upr; ds9 m87_broad&flname; -region m87_merged.fov</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -191,6 +192,7 @@
       <QEXAMPLE>
 	<SYNTAX>
 	  <LINE>&upr; &mname; "*/repro/*evt2.fits" merged/</LINE>
+	  <LINE>&upr; ds9 merged/broad&flname; -region merged/merged.fov</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -1575,6 +1577,7 @@
 	<CAPTION>Combined data</CAPTION>
 	<ROW><DATA>Type</DATA><DATA>Filename</DATA></ROW>
 	<ROW><DATA>Merged event file</DATA><DATA>outroot_merged_evt.fits</DATA></ROW>
+	<ROW><DATA>Merged FOV file</DATA><DATA>outroot_merged.fov</DATA></ROW>
 	<ROW><DATA>Counts image</DATA><DATA>outroot_blabel.img</DATA></ROW>
 	<ROW><DATA>Combined exposure map</DATA><DATA>outroot_blabel.expmap</DATA></ROW>
 	<ROW><DATA>Clipped counts image</DATA><DATA>outroot_blabel_thresh.img</DATA></ROW>
@@ -1590,6 +1593,7 @@
 	<CAPTION>Per-observation data</CAPTION>
 	<ROW><DATA>Type</DATA><DATA>Filename</DATA></ROW>
 	<ROW><DATA>Reprojected event file</DATA><DATA>outroot_obsid_reproj_evt.fits</DATA></ROW>
+	<ROW><DATA>FOV file</DATA><DATA>outroot_obsid.fov</DATA></ROW>
 	<ROW><DATA>Counts image</DATA><DATA>outroot_obsid_blabel.img</DATA></ROW>
 	<ROW><DATA>Combined exposure map</DATA><DATA>outroot_obsid_blabel.expmap</DATA></ROW>
 	<ROW><DATA>Clipped counts image</DATA><DATA>outroot_obsid_blabel_thresh.img</DATA></ROW>
@@ -1653,6 +1657,15 @@
       <PARA title="Interleaved mode">
 	For interleaved-mode data, "e1" or "e2" is appended to the ObsId
 	value when creating file names.
+      </PARA>
+
+      <PARA title="Multi-OBI datasets">
+	There are 30 ObsIds which contain multiple OBI segments. If the
+	data has been split using
+	<HREF link="https://cxc.harvard.edu/ciao/ahelp/splitobs.html">splitobs</HREF>
+	then they can be combined using &mname;, but the ObsId labels
+	will contain the suffix _00n (where n is the OBI_NUM value
+	from the header).
       </PARA>
 
       <!--
@@ -1837,6 +1850,12 @@
 	<ITEM>
 	  The event files are reprojected to the new reference position,
 	  or copied if no reprojection is needed.
+	</ITEM>
+
+	<ITEM>
+	  A FOV file for each observation is created using the reprojected
+	  event files. These regions are combined to create the merged
+	  FOV file.
 	</ITEM>
 
 	<ITEM>
@@ -2076,7 +2095,12 @@
 	to this the combination could cause the script to fail).
       </PARA>
       <PARA>
-	There have been improvements to the handling of a large number
+	The script now generates the FOV file for each reprojected event file
+	and a combined region file (merged.fov) that includes all the individual
+	observation FOV files.
+      </PARA>
+      <PARA>
+	There have been improvements to how the script handles a large number
 	of observations.
       </PARA>
     </ADESC>

--- a/share/doc/xml/reproject_obs.xml
+++ b/share/doc/xml/reproject_obs.xml
@@ -671,7 +671,7 @@
 	</ROW>
 	<ROW>
 	  <DATA>FOVFILE</DATA>
-	  <DATA>obsid.fov</DATA><DATA>The field-of-view file for the reprojected obervation.</DATA>
+	  <DATA>obsid.fov</DATA><DATA>The field-of-view file for the reprojected observation.</DATA>
 	</ROW>
       </TABLE>
       <PARA>


### PR DESCRIPTION
We now create FOV files when running

- `fluximage`
- `reproject_obs`
- `flux_obs` [*]
- `merge_obs`

One interesting question is what the FOV file should be, since it isn't related to the selected band. For now we use the obsid number which looks a bit "interesting"

# Notes

The code could do with a clean up as there's several layers of behavior built on top of each other, and various similar-but-not-identical functionality spread throughout. One change that is made is that we are now more aggressive about handling of multi-OBI datasets - we know require the OBI_NUM value whereas previously we could support the old merged evt2 version in some cases. I think this should be okay (ie we don't really want to be using the combined version for anything). We now do mention `splitobs` in the screen output but don't necessarily fall over.

# Issues

[*] if you use the same directory/label for `reproject_obs` and `flux_obs` and have `clobber=no` (the default) then the script fails because it's trying to create a file that already exists:

```
% flux_obs rrr rrr/
Running flux_obs
Version: 05 November 2021

Found rrr/merged_evt.fits
Found rrr/3057_001_reproj_evt.fits
Found rrr/3057_002_reproj_evt.fits
Verifying 3 observations.
Skipping file: The OBS_ID value is 'Merged' in rrr/merged_evt.fits.
Found one interleaved/multi-OBI observation:
  - using label 3057_001
  - using label 3057_002
Skipped one observation.

Using CSC ACIS broad science energy band.
# flux_obs (05 November 2021): ERROR File rrr/3057_001.fov exists and clobber=no.
```

We can either fix this or tell users to use `clobber=yes` . That's for another day.

# Examples

## fluximage

```
% fluximage 3057_001 fff/
Running fluximage
Version: 04 November 2021

Found 3057_001/repro/acisf03057_repro_evt2.fits
Using event file 3057_001/repro/acisf03057_repro_evt2.fits
Using CSC ACIS broad science energy band.
Aspect solution 3057_001/repro/pcadf03057_001N001_asol1.fits found.
Bad-pixel file 3057_001/repro/acisf03057_repro_bpix1.fits found.
Mask file 3057_001/repro/acisf03057_001N005_msk1.fits found.

The output images will have 536 by 414 pixels, pixel size of 3.936 arcsec,
    and cover x=1728.5:6016.5:8,y=1960.5:5272.5:8.

Running tasks in parallel with 12 processors.
Creating 6 aspect histograms for obsid 3057_001
Creating 6 instrument maps for obsid 3057_001
Creating 6 exposure maps for obsid 3057_001
Combining 6 exposure maps for obsid 3057_001
Thresholding data for obsid 3057_001
Exposure-correcting image for obsid 3057_001

The following files were created:

 The clipped counts image is:
     fff/broad_thresh.img

 The observation FOV is:
     fff/3057_001.fov

 The clipped exposure map is:
     fff/broad_thresh.expmap

 The exposure-corrected image is:
     fff/broad_flux.img
```

## reproject_obs

```
% reproject_obs 3057_001,3057_002 rrr/
Running reproject_obs
Version: 05 November 2021

Found 3057_001/repro/acisf03057_repro_evt2.fits
Found 3057_002/repro/acisf03057_repro_evt2.fits
Verifying 2 observations.
Found one interleaved/multi-OBI observation:
  - using label 3057_001
  - using label 3057_002
Calculating new tangent point.
New tangent point: RA=1h 58m 35.188s Dec=-24d 59' 55.39"

Observations to be reprojected:

    Obsid    Obs Date   Exp    DETNAM     SIM_Z    FP   Sepn   PA
                       (ks)                (mm)    (K)   (')  (deg)
-------------------------------------------------------------------
1 3057_001  2002-11-10  11.2 ACIS-235678 -190.143 153.4   0.0    +0
2 3057_002  2002-12-20   8.3 ACIS-235678 -190.140 153.4   0.0    +0

Running tasks in parallel with 12 processors.
Reprojecting 2 event files to a common tangent point.
Merging reprojected events files to rrr/merged_evt.fits

The following files were created:

The reprojected FOV files:
     rrr/3057_001.fov
     rrr/3057_002.fov

The combined FOV file:
     rrr/merged.fov

The reprojected event files:
     rrr/3057_001_reproj_evt.fits
     rrr/3057_002_reproj_evt.fits

The merged event file:
     rrr/merged_evt.fits
```

## flux_obs

```
%  flux_obs rrr fofo/
Running flux_obs
Version: 05 November 2021

Found rrr/merged_evt.fits
Found rrr/3057_001_reproj_evt.fits
Found rrr/3057_002_reproj_evt.fits
Verifying 3 observations.
Skipping file: The OBS_ID value is 'Merged' in rrr/merged_evt.fits.
Found one interleaved/multi-OBI observation:
  - using label 3057_001
  - using label 3057_002
Skipped one observation.

Using CSC ACIS broad science energy band.
Calculating the output grid

The merged images will have 563 by 501 pixels, a pixel size of 3.936 arcsec,
    and cover x=1728.5:6232.5:8, y=1896.5:5904.5:8.

Creating the fluxed images for 2 observations in parallel.
Creating 6 aspect histograms for obsid 3057_001
Creating 6 aspect histograms for obsid 3057_002
Creating 6 instrument maps for obsid 3057_001
Creating 6 instrument maps for obsid 3057_002
Creating 6 exposure maps for obsid 3057_001
Creating 6 exposure maps for obsid 3057_002
Combining 6 exposure maps for obsid 3057_001
Thresholding data for obsid 3057_001
Exposure-correcting image for obsid 3057_001
Combining 6 exposure maps for obsid 3057_002
Thresholding data for obsid 3057_002
Exposure-correcting image for obsid 3057_002

Combining 2 observations.

The following files were created:

The co-added clipped counts image is:
     fofo/broad_thresh.img

The co-added clipped exposure map is:
     fofo/broad_thresh.expmap

The combined FOV is:
     fofo/merged.fov

The co-added exposure-corrected image is:
     fofo/broad_flux.img

```

## merge_obs

```
% merge_obs 3057_001,3057_002 mmm/
Running merge_obs
Version: 05 November 2021

Found 3057_001/repro/acisf03057_repro_evt2.fits
Found 3057_002/repro/acisf03057_repro_evt2.fits
Verifying 2 observations.
Found one interleaved/multi-OBI observation:
  - using label 3057_001
  - using label 3057_002
Using CSC ACIS broad science energy band.
Calculating new tangent point.
New tangent point: RA=1h 58m 35.188s Dec=-24d 59' 55.39"

Observations to be reprojected:

    Obsid    Obs Date   Exp    DETNAM     SIM_Z    FP   Sepn   PA
                       (ks)                (mm)    (K)   (')  (deg)
-------------------------------------------------------------------
1 3057_001  2002-11-10  11.2 ACIS-235678 -190.143 153.4   0.0    +0
2 3057_002  2002-12-20   8.3 ACIS-235678 -190.140 153.4   0.0    +0

Running tasks in parallel with 12 processors.
Reprojecting 2 event files to a common tangent point.
Merging reprojected events files to mmm/merged_evt.fits

Calculating the output grid

The merged images will have 563 by 501 pixels, a pixel size of 3.936 arcsec,
    and cover x=1728.5:6232.5:8, y=1896.5:5904.5:8.

Creating the fluxed images for 2 observations in parallel.
Creating 6 aspect histograms for obsid 3057_001
Creating 6 aspect histograms for obsid 3057_002
Creating 6 instrument maps for obsid 3057_001
Creating 6 instrument maps for obsid 3057_002
Creating 6 exposure maps for obsid 3057_001
Creating 6 exposure maps for obsid 3057_002
Combining 6 exposure maps for obsid 3057_001
Thresholding data for obsid 3057_001
Exposure-correcting image for obsid 3057_001
Combining 6 exposure maps for obsid 3057_002
Thresholding data for obsid 3057_002
Exposure-correcting image for obsid 3057_002

Combining 2 observations.

The following files were created:

The co-added clipped counts image is:
     mmm/broad_thresh.img

The co-added clipped exposure map is:
     mmm/broad_thresh.expmap

The combined FOV is:
     mmm/merged.fov

The co-added exposure-corrected image is:
     mmm/broad_flux.img

```