### PR TITLE
typo in srcflux.xml

### DIFF
--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -969,7 +969,7 @@ bounds(region(my.reg))
 	source and background regions.</SYNOPSIS>
 	<DESC>
 	  <PARA>
-	    There are 4 different methods for computing the
+	    There are 5 different methods for computing the
 	    fraction of the PSF in the source and background
 	    regions:
 	  </PARA>


### PR DESCRIPTION
The "marx" method is part of the list, so there are 5, not 4 methods.