### PR TITLE
Add conda-forge to check_ciao_version

### DIFF
--- a/bin/check_ciao_version
+++ b/bin/check_ciao_version
@@ -54,7 +54,7 @@ import sys
 from optparse import OptionParser
 
 toolname = "check_ciao_version"
-version = "29 September 2021"
+version = "15 November 2021"
 
 try:
     from ciao_contrib import logger_wrapper as lw

--- a/ciao_contrib/_tools/versioninfo.py
+++ b/ciao_contrib/_tools/versioninfo.py
@@ -360,6 +360,11 @@ def check_conda_versions(ciao):
     for chan in {v['channel'] for v in found.values()}:
         channels.extend(["-c", chan])
 
+    # Add in conda-forge, after the ones we installed CIAO with.
+    # Is this a great idea?
+    #
+    channels.extend(["-c", "conda-forge"])
+
     # We use --no-update-deps since the expected users of this
     # functionality are likely to want to know just if the CIAO packages
     # need updating, not any dependency.


### PR DESCRIPTION
It's not clear whether we need the conda-forge option. We probably
don't, but just in case we need it we add it.