### PR TITLE
Srcflux merge bugfix, take 2

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -87,6 +87,14 @@ Updated scripts
     The script now generates FOV files for each reprojected event file
     and a combined file (that includes all the individual shapes).
 
+  srcflux
+      Bug fix when merging results and a source is located at the very
+      edge of a CCD. This bug is trigger when a source is inside the
+      field of view but the source location computed at the mean
+      pointing (RA_PNT, DEC_PNT), is located on an inactive CCD.  The
+      bug would cause the script to fail with a syntax error.  It has
+      now been corrected.
+  
 Updated Python modules
 
   ciao_contrib.runtool

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -5,6 +5,30 @@ unless the NO_COLOR environment variable is set - see the site at
 https://no-color.org/ - or the output is being written to a file
 rather than a TTY.
 
+Using CIAO tools from DS9 (dax)
+
+  There have been a number of improvements to take advantage of
+  changes in CIAO 4.14, including:
+
+  - support for the new button bar feature in DS9 8.3
+
+  - the default absorption model in spectral fits is now phabs
+    rather than wabs and a second absorbing component can be
+    added
+
+  - a new menu - Adaptive Bin (Radial) - to call the new dmradar tool
+
+  - add the method argument to the 'Adaptive Bin' menu to support
+    new functionality in dmnautilus
+
+  - For dax tasks that output tables or regions, users can now
+    automatically open those output files using ds9's prism interface.
+    To enable this options, users need to run
+
+      $ pset dax prism=yes
+
+    before starting ds9.
+
 New scripts
 
   find_mono_energy
@@ -45,26 +69,6 @@ Updated scripts
     models as were supported in CIAO 4.13: please contact the CXC
     helpdesk if you are having problems with this script.
 
-  dax
-
-    There have been a number of improvements to take advantage of
-    changes in CIAO 4.14, including:
-
-    - support for the new button bar feature in DS9 8.3
-    - the default absorption model in spectral fits is now phabs
-      rather than wabs and a second absorbing component can be
-      added
-    - a new menu - Adaptive Bin (Radial) - to call the new dmradar tool
-    - add the method argument to the 'Adaptive Bin' menu to support
-      new functionality in dmnautilus
-    - For dax tasks that output tables or regions, users can now 
-      automatically open those output files using ds9's prism interface.  
-      To enable this options, users need to run 
-      
-        $ pset dax prism=yes
-        
-      before starting ds9.
-
   download_obsid_caldb
 
     The script now sets the CALDBALIAS which is needed due to a change
@@ -88,13 +92,12 @@ Updated scripts
     and a combined file (that includes all the individual shapes).
 
   srcflux
-      Bug fix when merging results and a source is located at the very
-      edge of a CCD. This bug is trigger when a source is inside the
-      field of view but the source location computed at the mean
-      pointing (RA_PNT, DEC_PNT), is located on an inactive CCD.  The
-      bug would cause the script to fail with a syntax error.  It has
-      now been corrected.
-  
+
+    Fixed a rare error when merging results. If a source was at the
+    edge of the field of view of a CCD it could appear as if it belonged
+    to an inactive CCD, thanks to dither, which caused the script to
+    crash.
+
 Updated Python modules
 
   ciao_contrib.runtool

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2013-2020 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013-2021 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 #
 
 toolname = "srcflux"
-__revision__ = "30 November 2020"
+__revision__ = "18 November 2021"
 
 import os
 
@@ -2025,7 +2025,17 @@ def merge_get_counts( infiles ):
         else: # ACIS
             cc = int(tab.get_column("chip_id").values[0])
             assert cc in range(10)
-            retval['exptime'].append( tab.get_key_value("LIVTIME{}".format(cc)))
+            etime = tab.get_key_value("LIVTIME{}".format(cc))
+            if etime is None:
+                # For sources right on the edge of the chip, they 
+                # can be inside the FOV (includes dither), but the 
+                # chip_id value itself is computed
+                # at the mean pointing, so it may be on another 
+                # chip, which is no turned on. If this happens, just
+                # set exposure time to LIVETIME (to be consistent w/ 
+                # individual obi)
+                etime = tab.get_key_value("LIVETIME")
+            retval['exptime'].append(etime)
 
     return retval
 

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -2110,6 +2110,18 @@ the source region.</DATA>
     </ADESC>
 
 
+    <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
+      <PARA>
+        Bug fix when merging results and a source is located at the very edge
+        of a CCD. This bug is trigger when a source is inside the field 
+        of view but the source location computed at the mean pointing
+        (RA_PNT, DEC_PNT), is located on an inactive CCD.  The bug would
+        cause the script to fail with a syntax error.  It has now been
+        corrected.
+      </PARA>
+    </ADESC>
+
+
     <ADESC title="Changes in the script 4.13.0 (December 2020) release">
       <PARA title="Merged Outputs">
         When multiple event files are specified, users will now also

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -2111,13 +2111,10 @@ the source region.</DATA>
 
 
     <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
-      <PARA>
-        Bug fix when merging results and a source is located at the very edge
-        of a CCD. This bug is trigger when a source is inside the field 
-        of view but the source location computed at the mean pointing
-        (RA_PNT, DEC_PNT), is located on an inactive CCD.  The bug would
-        cause the script to fail with a syntax error.  It has now been
-        corrected.
+      <PARA title="Fix a rare error when merging results">
+	If a source was at the edge of the field of view of a CCD
+	it could appear as if it belonged to an inactive CCD, thanks to
+	dither, which caused the script to crash.
       </PARA>
     </ADESC>
 
@@ -2318,6 +2315,6 @@ the source region.</DATA>
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>December 2021</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
From a helpdesk ticket 23691 ...

When merging results, srcflux uses the `chip_id` value in the .flux file to identify which LIVTIMEn keyword to use.  But for sources right at the edge of the chip, they can be inside the FOV (which includes dither), but have a chip_id value that corresponds to a chip that is not turned on.  This is because the `chip_id` value is compute at the mean (`RA_PNT`, `DEC_PNT`) aspect.

This causes srcflux to fail during the merging with an unhelpful message:

```bash
# srcflux (30 November 2020): ERROR unsupported operand type(s) for *: 'float' and 'NoneType'
```
because in `merge_get_counts` we 

```python
tab.get_key_value("LIVTIME{}".format(cc))
```
without checking that `cc` is an active chip.  In this case, crates returns `None`, leading to the error message above.

In this case we should set `exptime` to `LIVETIME` to be consistent with the per-obi behavior.


