### PR TITLE
Correct URL of footprint server

### DIFF
--- a/ciao_contrib/cda/search.py
+++ b/ciao_contrib/cda/search.py
@@ -24,7 +24,7 @@ Routines that wrap up access to the Simple Image Access (SIA)
 endpoint at the Chandra Footprint Server. As of mid 2018
 the URL is
 
-    https://cxcfps.harvard.edu/cda/footprint/cdaview.html
+    https://cxcfps.cfa.harvard.edu/cda/footprint/cdaview.html
 
 but prior to that it was
 

--- a/share/doc/xml/find_chandra_obsid.xml
+++ b/share/doc/xml/find_chandra_obsid.xml
@@ -33,7 +33,7 @@
       </PARA>
       <PARA>
 	This tool makes use of the
-	<HREF link="https://cxcfps.harvard.edu/cda/footprint/">Chandra Footprint Service</HREF>,
+	<HREF link="https://cxcfps.cfa.harvard.edu/cda/footprint/">Chandra Footprint Service</HREF>,
 	which can also be searched using a web browser.
       </PARA>
       <PARA title="Single argument">


### PR DESCRIPTION
The URL in the code is correct, but the one given inthe comments is not. 

I'm trying to investigate a case where I did not get the correct answer from `find_chandra_obsid`. So, I looked into the docstring to see what exactly the tools does and how to debug. I want to execute the query manually so that I cna see if the error is due to the script (if it is, expect a PR or issue soon) or if it's an error on the footprint server side. Either way, I noticed that the URL given in the dics is wrong and the PR is to correct that.