### PR TITLE
blanksky_image param file updated 'clobber' default value to 'no'

### DIFF
--- a/param/blanksky_image.par
+++ b/param/blanksky_image.par
@@ -2,6 +2,6 @@ bkgfile,f,a,"",,,"blanksky background event file"
 outroot,f,a,"",,,"root of output files"
 imgfile,f,a,"",,,"reference image file"
 tmpdir,s,h,"${ASCDS_WORK_PATH}",,,"Directory for temporary files"
-clobber,b,h,yes,,,"OK to overwrite existing output file?"
+clobber,b,h,no,,,"OK to overwrite existing output file?"
 verbose,i,h,1,0,5,"Debug Level(0-5)"
 mode,s,h,"ql",,,


### PR DESCRIPTION
addresses #563 to change clobber default to 'no'.
