### PR TITLE
Note the blanksky_image change

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -2,6 +2,10 @@
 
 Updated scripts
 
+  blanksky_image
+
+    The default for the clobber parameter has been changed to "no".
+
   mktgresp
 
     The default value for the verbose parameter has been changed to 1


### PR DESCRIPTION
The ahelp file does not need updating as it claims the default
is "no".