### PR TITLE
simulate_psf: add check for outfile.

### DIFF
--- a/bin/simulate_psf
+++ b/bin/simulate_psf
@@ -2,7 +2,7 @@
 #
 #
 #
-# Copyright (C) 2012, 2014, 2016, 2018, 2020, 2021
+# Copyright (C) 2012, 2014, 2016, 2018, 2020, 2021, 2022
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -26,7 +26,7 @@ import sys
 import subprocess
 
 toolname = "simulate_psf"
-__revision__ = "08 March 2021"
+__revision__ = "24 January 2022"
 
 
 from cxcdm import *
@@ -1356,7 +1356,8 @@ def main():
     # Cleanup temp files (rays, projrays, and images)
     cleanup_iterations( pars )
 
-    verb1( "\nFinal output PSF image is : "+outfile )
+    if outfile:
+        verb1( "\nFinal output PSF image is : "+outfile )
 
 
 


### PR DESCRIPTION
This is only needed internally for ChaRT which uses saotrace where
it creates the simulated rays, but does not run marx to create
an output file. No need for .xml or Changes update.