### PR TITLE
Use `plot.backend` instead of `backend` to keep up with recent sherpa changes

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -18,6 +18,11 @@ Updated scripts
     particular recent versions of relxill and reltrans. Please contact
     the CXC helpdesk if you are having problems with this script.
 
+  correct_periscope_drift
+
+    The script has been updated to account for Sherpa plotting
+    updates.
+
   mktgresp
 
     As mkgrmf can now create a diagonal matrix for HRC data, the
@@ -25,4 +30,7 @@ Updated scripts
 
 Updated Python modules
 
-  TBD
+  sherpa_contrib.chart and sherpa_contrib.marx
+
+    The modules have been updated to account for Sherpa plotting
+    updates.

--- a/bin/correct_periscope_drift
+++ b/bin/correct_periscope_drift
@@ -45,7 +45,7 @@ from sherpa import plot
 
 
 TOOLNAME = "correct_periscope_drift"
-VERSION = "6 Feb 2020"
+VERSION = "2 Feb 2021"
 
 # Set up the logging/verbose code
 initialize_logger(TOOLNAME)
@@ -372,10 +372,10 @@ def make_fit_plot(evt_times, fit_data, mp, ax):
         mplot.plot(overplot=True)
         ylimits(-1 * fit_ymax, fit_ymax)
     except Exception:
-        plot.exceptions()
+        plot.backend.exceptions()
         raise
     else:
-        plot.end()
+        plot.backend.end()
 
 
 def make_data_plot(dset, model, fit_data, ax):
@@ -402,14 +402,14 @@ def make_data_plot(dset, model, fit_data, ax):
     dplot.title = 'Raw data and fit in {}'.format(ax)
 
     try:
-        plot.begin()
-        fplot.plot()
+        plot.backend.begin()
+        fplot.backend.plot()
         ylimits(-1 * data_ymax, data_ymax)
     except Exception:
-        plot.exceptions()
+        plot.backend.exceptions()
         raise
     else:
-        plot.end()
+        plot.backend.end()
 
 
 def ylimits(ymin, ymax):

--- a/bin/correct_periscope_drift
+++ b/bin/correct_periscope_drift
@@ -367,7 +367,7 @@ def make_fit_plot(evt_times, fit_data, mp, ax):
     mplot.y = mp.y
 
     try:
-        plot.begin()
+        plot.backend.begin()
         dplot.plot()
         mplot.plot(overplot=True)
         ylimits(-1 * fit_ymax, fit_ymax)
@@ -403,7 +403,7 @@ def make_data_plot(dset, model, fit_data, ax):
 
     try:
         plot.backend.begin()
-        fplot.backend.plot()
+        fplot.plot()
         ylimits(-1 * data_ymax, data_ymax)
     except Exception:
         plot.backend.exceptions()

--- a/sherpa_contrib/chart.py
+++ b/sherpa_contrib/chart.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009, 2010, 2015, 2016, 2019
+#  Copyright (C) 2009, 2010, 2015, 2016, 2019, 2022
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -39,7 +39,8 @@ Examples
 
 import sherpa.astro.ui as s
 
-from sherpa.plot import HistogramPlot, backend
+from sherpa.plot import HistogramPlot
+from sherpa import plot
 from sherpa.utils.err import IdentifierErr, ArgumentErr
 
 import numpy as np
@@ -300,9 +301,9 @@ def plot_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     hplot.title = 'ChaRT Spectrum: {}'.format(vals['model'])
 
     # LaTeX support depends on the backend
-    if backend.name == 'pylab':
+    if plot.backend.name == 'pylab':
         hplot.ylabel = 'Flux (photon cm$^{-2}$ s$^{-1}$)'
-    elif backend.name == 'chips':
+    elif plot.backend.name == 'chips':
         hplot.ylabel = 'Flux (photon cm^{-2} s^{-1})'
     else:
         hplot.ylabel = 'Flux (photon cm^-2 s^-1)'

--- a/sherpa_contrib/chart.py
+++ b/sherpa_contrib/chart.py
@@ -303,8 +303,6 @@ def plot_chart_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     # LaTeX support depends on the backend
     if plot.backend.name == 'pylab':
         hplot.ylabel = 'Flux (photon cm$^{-2}$ s$^{-1}$)'
-    elif plot.backend.name == 'chips':
-        hplot.ylabel = 'Flux (photon cm^{-2} s^{-1})'
     else:
         hplot.ylabel = 'Flux (photon cm^-2 s^-1)'
 

--- a/sherpa_contrib/marx.py
+++ b/sherpa_contrib/marx.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018, 2019
+#  Copyright (C) 2018, 2019, 2022
 #           Massachusetts Institute of Technology
 #
 #
@@ -37,7 +37,8 @@ Examples
 
 """
 
-from sherpa.plot import HistogramPlot, backend
+from sherpa.plot import HistogramPlot
+from sherpa import plot
 
 from crates_contrib.utils import write_columns
 
@@ -203,9 +204,9 @@ def plot_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     hplot.title = 'MARX Spectrum: {}'.format(vals['model'])
 
     # LaTeX support depends on the backend
-    if backend.name == 'pylab':
+    if plot.backend.name == 'pylab':
         hplot.ylabel = 'Flux (photon cm$^{-2}$ s$^{-1}$ keV$^{-1}$)'
-    elif backend.name == 'chips':
+    elif plot.backend.name == 'chips':
         hplot.ylabel = 'Flux (photon cm^{-2} s^{-1} keV^{-1})'
     else:
         hplot.ylabel = 'Flux (photon cm^-2 s^-1)'

--- a/sherpa_contrib/marx.py
+++ b/sherpa_contrib/marx.py
@@ -206,8 +206,6 @@ def plot_marx_spectrum(id=None, elow=None, ehigh=None, ewidth=None,
     # LaTeX support depends on the backend
     if plot.backend.name == 'pylab':
         hplot.ylabel = 'Flux (photon cm$^{-2}$ s$^{-1}$ keV$^{-1}$)'
-    elif plot.backend.name == 'chips':
-        hplot.ylabel = 'Flux (photon cm^{-2} s^{-1} keV^{-1})'
     else:
         hplot.ylabel = 'Flux (photon cm^-2 s^-1)'
 


### PR DESCRIPTION
Do not import sherpa plotting backend directly

With https://github.com/sherpa/sherpa/pull/1191 merged, sherpa now supports switching the plotting backend. That means that we shoud not import be backend directly, but use `plot.backend` instead. This change is backwards compatible.

fixes #579

Note: We could make sherpa support the current use, which would always give you the backend that was loaded when sherpa launched. That's probably OK for these scripts since they are typically run as command-line scripts and not in a longer Python session, but I really, really do not want sherpa to have such an easy way to keep references to non-active plotting backends around because things will break in non-obvious ways. That's why I removed e.g. `plot.begin` which was an internal copy to `plot.backend.begin` and would do bad stuff (technical term) if `plot.backend` is assigned something else (a module, an object).

fixes #579