### PR TITLE
cgs: append _combo_ to outroot to avoid name collison when running mktgresp and c_g_s with the same outroot

### DIFF
--- a/bin/combine_grating_spectra
+++ b/bin/combine_grating_spectra
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # 
-# Copyright (C) 2013,2014,2016,2018,2019 
+# Copyright (C) 2013,2014,2016,2018,2019, 2022 
 # Smithsonian Astrophysical Observatory
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 # 
 # This program is distributed in the hope that it will be useful,
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "combine_grating_spectra"
-__revision__ = "18 November 2019"
+__revision__ = "25 February 2022"
 
 from pycrates import read_file, write_file
 import numpy as np
@@ -365,28 +365,8 @@ def combine( tocombo, pars, add_pm, method=None, sign=None):
     the method="sum"
 
     """
-    #from ciao_contrib.runtool import combine_spectra
-    import ciao_contrib.runtool as rt
-    newtool = {
-        'istool' : True,
-        'req' : [
-                rt.ParValue("src_spectra", "f", "Input TYPE:I pha file", None),
-                rt.ParValue("outroot", "f", "Output root file name", None),
-                ],
-        'opt' : [                
-                rt.ParValue("src_arfs","f", "Input ARF files", None),
-                rt.ParValue("src_rmfs","f", "Input RMF files", None),
-                rt.ParValue("bkg_spectra","f", "Input RMF files", None),
-                rt.ParValue("bkg_arfs","f", "Input RMF files", None),
-                rt.ParValue("bkg_rmfs","f", "Input ARF files", None),
-                rt.ParValue("method", "s", "sum or average", "sum"),
-                rt.ParValue("bscale_method", "s", "how to combute bscale", "asca"),
-                rt.ParValue("exp_origin", "s", "pha or arf", "pha"),
-                rt.ParValue("clobber","b","Overwrite if file exists",False),
-                rt.ParRange("verbose","i","Debug level",0,0,5)
-                ]}
-
-    combine_spectra = rt.CIAOToolParFile( "combine_spectra", newtool["req"], newtool["opt"])
+    from ciao_contrib.runtool import make_tool
+    combine_spectra = make_tool("combine_spectra")
 
     outstk = []
     tt = filter_spectra( tocombo, pars["garm"], pars["order"], add_pm )
@@ -408,7 +388,7 @@ def combine( tocombo, pars, add_pm, method=None, sign=None):
             sgn = sign
         
         arm = tgpart[key.tg_part].lower()
-        combine_spectra.outroot = "{}{}_{}{}".format( pars["outroot"], arm, sgn, abs(key.tg_m))
+        combine_spectra.outroot = "{}combo_{}_{}{}".format( pars["outroot"], arm, sgn, abs(key.tg_m))
 
         vv = combine_spectra()
         if vv: verb0( vv )

--- a/share/doc/xml/combine_grating_spectra.xml
+++ b/share/doc/xml/combine_grating_spectra.xml
@@ -106,18 +106,18 @@ create 6 combined spectra:  HEG 1st order, HEG 2nd order, HEG 3rd order, MEG
 
 <VERBATIM>
 unix% /bin/ls capella6471*
-capella6471_heg_abs1.pha
-capella6471_heg_abs1_bkg.pha
-capella6471_heg_abs2.pha
-capella6471_heg_abs2_bkg.pha
-capella6471_heg_abs3.pha
-capella6471_heg_abs3_bkg.pha
-capella6471_meg_abs1.pha
-capella6471_meg_abs1_bkg.pha
-capella6471_meg_abs2.pha
-capella6471_meg_abs2_bkg.pha
-capella6471_meg_abs3.pha
-capella6471_meg_abs3_bkg.pha
+capella6471_combo_heg_abs1.pha
+capella6471_combo_heg_abs1_bkg.pha
+capella6471_combo_heg_abs2.pha
+capella6471_combo_heg_abs2_bkg.pha
+capella6471_combo_heg_abs3.pha
+capella6471_combo_heg_abs3_bkg.pha
+capella6471_combo_meg_abs1.pha
+capella6471_combo_meg_abs1_bkg.pha
+capella6471_combo_meg_abs2.pha
+capella6471_combo_meg_abs2_bkg.pha
+capella6471_combo_meg_abs3.pha
+capella6471_combo_meg_abs3_bkg.pha
 </VERBATIM>
 
 <PARA>
@@ -172,7 +172,7 @@ combined.
 
     <QEXAMPLE>
       <SYNTAX>
-        <LINE>% combine_grating_spectra infile="*/repro/*pha2.fits" \</LINE>
+        <LINE>unix% combine_grating_spectra infile="*/repro/*pha2.fits" \</LINE>
         <LINE>  outroot=capella garm=HEG order=1 add_plusminus=yes \</LINE>
         <LINE>  arf="*/repro/tg/*arf" rmf="*/repro/tg/*rmf" clob+ </LINE>
       </SYNTAX>
@@ -221,73 +221,73 @@ source PHA: capella_tmp04_heg_m1.pha
                RMF: None
 
 The following files were created:
-  capella_heg_m1.pha
-  capella_heg_m1_bkg.pha
-  capella_heg_m1.arf
-  capella_heg_m1.rmf
+  capella_combo_heg_m1.pha
+  capella_combo_heg_m1_bkg.pha
+  capella_combo_heg_m1.arf
+  capella_combo_heg_m1.rmf
 Prepared to combine 5 spectra
 
-source PHA: capella_tmp00_heg_p1.pha
+source PHA: capella_combo_tmp00_heg_p1.pha
        ARF: 10599/repro/tg/acisf10599_repro_heg_p1.arf
        RMF: 10599/repro/tg/acisf10599_repro_heg_p1.rmf
-    background PHA: capella_tmp00_heg_p1_bkg.pha
+    background PHA: capella_combo_tmp00_heg_p1_bkg.pha
                ARF: None
                RMF: None
-source PHA: capella_tmp01_heg_p1.pha
+source PHA: capella_combo_tmp01_heg_p1.pha
        ARF: 11931/repro/tg/acisf11931_repro_heg_p1.arf
        RMF: 11931/repro/tg/acisf11931_repro_heg_p1.rmf
-    background PHA: capella_tmp01_heg_p1_bkg.pha
+    background PHA: capella_combo_tmp01_heg_p1_bkg.pha
                ARF: None
                RMF: None
-source PHA: capella_tmp02_heg_p1.pha
+source PHA: capella_combo_tmp02_heg_p1.pha
        ARF: 5955/repro/tg/acisf05955_repro_heg_p1.arf
        RMF: 5955/repro/tg/acisf05955_repro_heg_p1.rmf
-    background PHA: capella_tmp02_heg_p1_bkg.pha
+    background PHA: capella_combo_tmp02_heg_p1_bkg.pha
                ARF: None
                RMF: None
-source PHA: capella_tmp03_heg_p1.pha
+source PHA: capella_combo_tmp03_heg_p1.pha
        ARF: 6471/repro/tg/acisf06471_repro_heg_p1.arf
        RMF: 6471/repro/tg/acisf06471_repro_heg_p1.rmf
-    background PHA: capella_tmp03_heg_p1_bkg.pha
+    background PHA: capella_combo_tmp03_heg_p1_bkg.pha
                ARF: None
                RMF: None
-source PHA: capella_tmp04_heg_p1.pha
+source PHA: capella_combo_tmp04_heg_p1.pha
        ARF: 9638/repro/tg/acisf09638_repro_heg_p1.arf
        RMF: 9638/repro/tg/acisf09638_repro_heg_p1.rmf
-    background PHA: capella_tmp04_heg_p1_bkg.pha
+    background PHA: capella_combo_tmp04_heg_p1_bkg.pha
                ARF: None
                RMF: None
 
 The following files were created:
-  capella_heg_p1.pha
-  capella_heg_p1_bkg.pha
-  capella_heg_p1.arf
-  capella_heg_p1.rmf
+  capella_combo_heg_p1.pha
+  capella_combo_heg_p1_bkg.pha
+  capella_combo_heg_p1.arf
+  capella_combo_heg_p1.rmf
 Combining plus and minus orders
 Prepared to combine 2 spectra
 
-source PHA: capella_heg_m1.pha
-       ARF: capella_heg_m1.arf
-       RMF: capella_heg_m1.rmf
-    background PHA: capella_heg_m1_bkg.pha
+source PHA: capella_combo_heg_m1.pha
+       ARF: capella_combo_heg_m1.arf
+       RMF: capella_combo_heg_m1.rmf
+    background PHA: capella_combo_heg_m1_bkg.pha
                ARF: None
                RMF: None
-source PHA: capella_heg_p1.pha
-       ARF: capella_heg_p1.arf
-       RMF: capella_heg_p1.rmf
-    background PHA: capella_heg_p1_bkg.pha
+source PHA: capella_combo_heg_p1.pha
+       ARF: capella_combo_heg_p1.arf
+       RMF: capella_combo_heg_p1.rmf
+    background PHA: capella_combo_heg_p1_bkg.pha
                ARF: None
                RMF: None
 
 The following files were created:
-  capella_heg_abs1.pha
-  capella_heg_abs1_bkg.pha
-  capella_heg_abs1.arf
-  capella_heg_abs1.rmf
-Created output source spectrum 'capella_heg_abs1.pha'
-    with background spectrum 'capella_heg_abs1_bkg.pha'
-    with source ARF 'capella_heg_abs1.arf'
-    with source RMF 'capella_heg_abs1.rmf'
+  capella_combo_heg_abs1.pha
+  capella_combo_heg_abs1_bkg.pha
+  capella_combo_heg_abs1.arf
+  capella_combo_heg_abs1.rmf
+Created output source spectrum 'capella_combo_heg_abs1.pha'
+    with background spectrum 'capella_combo_heg_abs1_bkg.pha'
+    with source ARF 'capella_combo_heg_abs1.arf'
+    with source RMF 'capella_combo_heg_abs1.rmf'
 </VERBATIM>
 
         <PARA>
@@ -345,15 +345,15 @@ spectra.  The final output will be
 </PARA>
 <VERBATIM>
 ...
-Created output source spectrum 'tw_hya_meg_abs1.pha'
-    with background spectrum 'tw_hya_meg_abs1_bkg.pha'
-    with source ARF 'tw_hya_meg_abs1.arf'
-    with source RMF 'tw_hya_meg_abs1.rmf'
+Created output source spectrum 'tw_hya_combo_meg_abs1.pha'
+    with background spectrum 'tw_hya_combo_meg_abs1_bkg.pha'
+    with source ARF 'tw_hya_combo_meg_abs1.arf'
+    with source RMF 'tw_hya_combo_meg_abs1.rmf'
 
-Created output source spectrum 'tw_hya_heg_abs1.pha'
-    with background spectrum 'tw_hya_heg_abs1_bkg.pha'
-    with source ARF 'tw_hya_heg_abs1.arf'
-    with source RMF 'tw_hya_heg_abs1.rmf'
+Created output source spectrum 'tw_hya_combo_heg_abs1.pha'
+    with background spectrum 'tw_hya_combo_heg_abs1_bkg.pha'
+    with source ARF 'tw_hya_combo_heg_abs1.arf'
+    with source RMF 'tw_hya_combo_heg_abs1.rmf'
 </VERBATIM>
       </DESC>
     </QEXAMPLE>
@@ -370,9 +370,9 @@ the tool to omit the background from the combined data products.  The final outp
 will now just be
 </PARA>
 <VERBATIM>
-Created output source spectrum 'tw_hya_heg_abs1.pha'
-    with source ARF 'tw_hya_heg_abs1.arf'
-    with source RMF 'tw_hya_heg_abs1.rmf'
+Created output source spectrum 'tw_hya_combo_heg_abs1.pha'
+    with source ARF 'tw_hya_combo_heg_abs1.arf'
+    with source RMF 'tw_hya_combo_heg_abs1.rmf'
 </VERBATIM>
 
 </DESC>
@@ -416,10 +416,10 @@ Created output source spectrum 'tw_hya_heg_abs1.pha'
              on the available inputs:              
            </PARA>
             <LIST>
-              <ITEM>${outroot}_${part}_${order}.pha : Source spectrum</ITEM>
-              <ITEM>${outroot}_${part}_${order}.arf : Source ARF file</ITEM>
-              <ITEM>${outroot}_${part}_${order}.rmf: Source RMF file</ITEM>
-              <ITEM>${outroot}_${part}_${order}_bkg.pha : Background spectrum</ITEM>
+              <ITEM>${outroot}_combo_${part}_${order}.pha : Source spectrum</ITEM>
+              <ITEM>${outroot}_combo_${part}_${order}.arf : Source ARF file</ITEM>
+              <ITEM>${outroot}_combo_${part}_${order}.rmf: Source RMF file</ITEM>
+              <ITEM>${outroot}_combo_${part}_${order}_bkg.pha : Background spectrum</ITEM>
             </LIST>
             <PARA>
             Where ${part} is the grating arm:  heg, meg, or leg. The
@@ -750,6 +750,15 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 </ADESC>
 
 
+  <ADESC title="Changes in the scripts 4.14.2 (March 2022) release">
+    <PARA>
+        The final output files now have "_combo_" appended to the output
+        root name.  This is to avoid a problem when using 
+        mktgresp and combine_grating_spectra using the same outroot.
+    </PARA>
+  </ADESC>
+
+
   <ADESC title="Changes in the scripts 4.12.1 (December 2019) release">
     <PARA>
       Internal cleanup. Removes TG_M and SPEC_NUM keywords from
@@ -803,7 +812,7 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>February 2022</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #567 
