### PR TITLE
mktgresp: back out additional of BPMASK change needed for frame store bad pixels

### DIFF
--- a/bin/mktgresp
+++ b/bin/mktgresp
@@ -21,7 +21,7 @@
 from __future__ import print_function
 
 toolname = "mktgresp"
-__revision__ = "10 February 2021"
+__revision__ = "10 March 2022"
 
 
 import os
@@ -364,10 +364,6 @@ def run_fullgarf( obsinfo, spectrum, outroot, dafile, osipfile ):
             mkgarf.asphistfile = outroot+"{}.asphist".format(ccd)
             mkgarf.outfile = get_outfile_name( outroot, spectrum, "{}.arf".format(ccd))
             mkgarf.detsubsys = "ACIS-{}".format(ccd)
-
-            # New ACIS badpix status bit 17 (frame store shadow) not
-            # included in standard bpixmask in 4.13.
-            mkgarf.detsubsys = mkgarf.detsubsys+";BPMASK=0x03ffff"
 
             oo = mkgarf()
             oo = filter_mkgarf_verbose(oo)

--- a/share/doc/xml/mktgresp.xml
+++ b/share/doc/xml/mktgresp.xml
@@ -403,7 +403,15 @@ parameter is angstroms.
     </PARAM>
     </PARAMLIST>
 
-    <ADESC title="Changes in the scripts 4.14.1 (March 2022) release">
+    <ADESC title="Changes in the scripts 4.14.2 (March 2022) release">
+        <PARA>
+            Remove the internal work-around to set the BPMASK
+            for ACIS data to account for the frame-store shadow
+            bad pixels.  (CIAO 4.14 fixes this in ardlib.)
+        </PARA>
+    </ADESC>
+
+    <ADESC title="Changes in the scripts 4.14.1 (January 2022) release">
       <PARA>
 	The default value for the verbose parameter has been changed
 	from 0 to 1.
@@ -427,6 +435,7 @@ parameter is angstroms.
 
 
     </ADESC>
+
 
     <ADESC title="Changes in the scripts 4.13.0 (December 2020) release">
       <PARA>
@@ -509,7 +518,7 @@ parameter is angstroms.
         for this tool</HREF>
         on the CIAO website for an up-to-date listing of known bugs.
       </PARA></BUGS>
-   <LASTMODIFIED>January 2022</LASTMODIFIED>
+   <LASTMODIFIED>March 2022</LASTMODIFIED>
 
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This is part of #562 