### PR TITLE
Chandra repro run sso_freeze for solar system observations

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -16,6 +16,13 @@ Updated scripts
     processing of the data, and we strongly recommend reading this,
     even with new observations that you decide not to reprocess!
 
+    The script now run sso_freeze on the event file and
+    aspect solution file if it finds a solar system ephemeris file
+    in the primary/ directory along with the definitive 
+    ephemeris (orbit*_eph1.fits). This will add additional 
+    object-centered coordinate columns to the event file and aspect 
+    solution file.
+
   combine_grating_spectra
 
     The output files now include the term "_combo_", which is appended

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -2589,7 +2589,12 @@ def process_sso(pars, is_gratings=False):
     
     v5("sso_freeze returned")
     v5(out)
-
+    
+    # It would be nice to set the ASOLFILE keyword to the sso asol
+    # since it has the same format. Unfortunately, the sso asol 
+    # has blockname="ocsol" instead of "ASPSOL" and that causes
+    # down stream tools (asphist) to error out.  Leave this 
+    # here for the day that's fixed.
     # ~ tab = pyc.read_file(out_evt1, mode="rw")
     # ~ tab.get_key("ASOLFILE").value = os.path.basename(out_asol1)
     # ~ tab.write()
@@ -2600,7 +2605,6 @@ def process_sso(pars, is_gratings=False):
     pars[evt] = out_evt1
     pars["cleanup_files"].append(out_evt1)
     
-
 
 #!############
 # main routine

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -489,6 +489,8 @@ def make_default_pars():
              "msk1_file":       "",
              "mtl1_file":       "",
              "stat1_file":      "",
+             "eph1_file":       [],
+             "sso_file":        None,
              "pbk0_file":       "",
              "bias0_file":      "",
              "asol1_file":      "",
@@ -966,6 +968,19 @@ def get_inputs(params):
             asollist.close()
 
             check_name_in_hdr( "asol1", newasol, params["hdr_asolfile"] )
+
+        ### If we find eph1 file that is not 'orbit' then this is a 
+        ### solar system object and well run sso_freeze
+        elif re.search(".*eph1.fits*", ff):
+            
+            if ff.startswith("orbit"):
+                params["eph1_file"].append(params["primarydir"] + ff)
+            else:
+                if params["sso_file"] is not None:
+                    verb0("There should only be 1 SSO eph1 file, skipping: "+ff)
+                    continue
+                params["sso_file"] = params["primarydir"] + ff
+                
 
 
     #!####################################################
@@ -2532,7 +2547,52 @@ def remake_fov1_file( pars ):
     v5("skyfov returned")
     v5(out)
 
+def process_sso(pars):
+    """
+    Run sso_freeze to add solar system object coordinates to the 
+    event file and the aspect solution file.    
+    """
+    from ciao_contrib.runtool import sso_freeze
 
+    sso_eph = pars["sso_file"]
+    if sso_eph is None:
+        return
+
+    evt1=pars["evt1_file"]
+    eph1=pars["eph1_file"]
+    asol1="@"+pars["asol1_file"]
+        
+    if len(eph1) == 0:
+        v0("WARNING: Could not find definitive orbit ephemeris file, orbit*eph1.fits, skipping sso_freeze")
+
+    tab = pyc.read_file(sso_eph)
+    obj = tab.get_key_value("OBJECT")        
+    v1("\nRunning sso_freeze to add solar system coordinates for object: "+obj)
+    
+    out_evt1 = os.path.join(pars["outdir"], pars["root"] + '_repro_sso_evt1.fits')
+    out_asol1 = os.path.join(pars["outdir"], pars["root"] + '_repro_sso_asol1.fits')
+
+    sso_freeze.infile = evt1
+    sso_freeze.scephemfile = eph1
+    sso_freeze.ssoephemfile = sso_eph
+    sso_freeze.asolfile = asol1
+    sso_freeze.outfile = out_evt1
+    sso_freeze.ocsolfile = out_asol1
+    sso_freeze.clobber = pars["clobber"]
+    sso_freeze.verbose = pars["verbose"]
+    out = sso_freeze()
+    
+    v5("sso_freeze returned")
+    v5(out)
+
+    # ~ tab = pyc.read_file(out_evt1, mode="rw")
+    # ~ tab.get_key("ASOLFILE").value = os.path.basename(out_asol1)
+    # ~ tab.write()
+    
+
+    pars["evt1_file"] = out_evt1
+    pars["cleanup_files"].append(out_evt1)
+    
 
 
 #!############
@@ -2573,6 +2633,7 @@ def main_body( pars):
     if pars["process_events"]:
         if pars["instrume"] == 'ACIS':
             pars = process_acis_events(pars)
+            process_sso(pars)
             if pars["grating"] == 'NONE':
                 pars = l2_acis_events(pars)
             else:
@@ -2581,6 +2642,7 @@ def main_body( pars):
                 pars = l2_tg_pha(pars)
         if pars["instrume"] == 'HRC':
             pars = process_hrc_events(pars)
+            process_sso(pars)
             if pars["grating"] == 'NONE':
                 pars = l2_hrc_events(pars)
             else:

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -1984,12 +1984,11 @@ def process_tg_events(params):
         if out:
             v0(out)
 
-
-
+    params["evt1a_file"] = evt1a
+    process_sso(params, is_gratings=True)
 
     #!### Success ###
-    v1("The new evt1a file is: "+evt1a)
-    params["evt1a_file"] = evt1a
+    v1("The new evt1a file is: "+params["evt1a_file"])
 
     return params
 
@@ -2547,7 +2546,7 @@ def remake_fov1_file( pars ):
     v5("skyfov returned")
     v5(out)
 
-def process_sso(pars):
+def process_sso(pars, is_gratings=False):
     """
     Run sso_freeze to add solar system object coordinates to the 
     event file and the aspect solution file.    
@@ -2558,7 +2557,14 @@ def process_sso(pars):
     if sso_eph is None:
         return
 
-    evt1=pars["evt1_file"]
+    if is_gratings:
+        evt="evt1a_file"
+        out_evt1 = os.path.join(pars["outdir"], pars["root"] + '_repro_sso_evt1a.fits')
+    else:
+        evt="evt1_file"
+        out_evt1 = os.path.join(pars["outdir"], pars["root"] + '_repro_sso_evt1.fits')
+
+    evt1=pars[evt]
     eph1=pars["eph1_file"]
     asol1="@"+pars["asol1_file"]
         
@@ -2569,7 +2575,6 @@ def process_sso(pars):
     obj = tab.get_key_value("OBJECT")        
     v1("\nRunning sso_freeze to add solar system coordinates for object: "+obj)
     
-    out_evt1 = os.path.join(pars["outdir"], pars["root"] + '_repro_sso_evt1.fits')
     out_asol1 = os.path.join(pars["outdir"], pars["root"] + '_repro_sso_asol1.fits')
 
     sso_freeze.infile = evt1
@@ -2589,8 +2594,10 @@ def process_sso(pars):
     # ~ tab.get_key("ASOLFILE").value = os.path.basename(out_asol1)
     # ~ tab.write()
     
+    if is_gratings:
+        dmappend(pars[evt]+"[REGION]", out_evt1)
 
-    pars["evt1_file"] = out_evt1
+    pars[evt] = out_evt1
     pars["cleanup_files"].append(out_evt1)
     
 
@@ -2633,8 +2640,8 @@ def main_body( pars):
     if pars["process_events"]:
         if pars["instrume"] == 'ACIS':
             pars = process_acis_events(pars)
-            process_sso(pars)
             if pars["grating"] == 'NONE':
+                process_sso(pars)
                 pars = l2_acis_events(pars)
             else:
                 pars = process_tg_events(pars)
@@ -2642,8 +2649,8 @@ def main_body( pars):
                 pars = l2_tg_pha(pars)
         if pars["instrume"] == 'HRC':
             pars = process_hrc_events(pars)
-            process_sso(pars)
             if pars["grating"] == 'NONE':
+                process_sso(pars)
                 pars = l2_hrc_events(pars)
             else:
                 pars = process_tg_events(pars)

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -790,6 +790,20 @@ acisf084244478N003_2_bias0.fits.gz
       </PARAM>
     </PARAMLIST>
 
+<ADESC title="Changes in the scripts 4.14.2 (April 2022) release">
+  <PARA title="Solar System Object Observations">
+    chandra_repro will now run sso_freeze on the event file and
+    aspect solution file if it finds a solar system ephemeris file
+    in the primary/ directory along with the definitive 
+    ephemeris (orbit*_eph1.fits).  The solar system ephemeris file names
+    end with _eph1.fits and are prefixed with the object name (for example
+    commetXYZ or jupiter).  This will add additional object-centered 
+    coordinate columns to the event file and aspect solution files.
+  </PARA>
+</ADESC>
+
+
+
 <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
   <PARA>
     Updated the Level 2 event file keywords : CONTENT="EVT2"  and HDUCLAS2="ACCEPTED".


### PR DESCRIPTION
This closes #110 

There is no specific meta data in the data products that indicates that this an observation is of a solar system object :frowning_face: 

But `chandra_repro` is looping through the files in the primary directory so we can look for `eph1.fits` files.  All observations will have an `orbit*eph1.fits` file (coded to look for possibility for more than 1 since they are not cut on OBS_ID boundaries).  If `chandra_repro` finds a `eph1.fits` file that doesn't start with `orbit` then we assume we are in a solar-system object scenario.

The columns that `sso_freeze` adds to the event file are benign to other down-stream processing; except `tg_resolve_events` which only copies columns in the eventdef.  So there's a little logic needed to run this after `t_r_e` (when gratings are used -- about 10% of the sso observations to-date).

The sso aspect solution is a little problematic since `sso_freeze` sets the block name to `ocsol` which `asphist` doesn't recognize.  So we cannot change the `ASOLFILE` header keyword in the event files to the sso asol file.

Currently Draft since I need to update the ahelp, but that will cause a merge conflict with #595 .  I may just edit the ahelp on that branch to avoid the headache.


