### PR TITLE
chandra_repro: print message reminding users to read vv report

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -492,6 +492,7 @@ def make_default_pars():
              "pbk0_file":       "",
              "bias0_file":      "",
              "asol1_file":      "",
+             "vv_file":         None,
              "pha2_file":       "",
              "tgmsk_file":      "",  #Only for grating, only when param set
              "recreate_tg_mask":  None,
@@ -1117,6 +1118,21 @@ def get_inputs(params):
             #!### In both cases above we write current bias file to list ###
             biaslist.write(newbias + '\n')
             biaslist.close()
+
+
+    # Look for the V&V report in the top level indir
+
+    toplevel_products=os.listdir(params["indir"])
+    
+    for ff in toplevel_products:
+        if ff.endswith("vv2.pdf.gz"):
+            gunzip(os.path.join(params["indir"],ff))
+            ff = ff.replace(".gz","")
+
+        if ff.endswith("vv2.pdf"):
+            path=os.path.join(params["outdir"], ff)
+            link_or_copy(os.path.join(params["indir"],ff), path)
+            params["vv_file"] = path
 
     #!### Verify we have required input files and copy handy files to outdir ###
     if not os.path.isfile(params["bpix1_file"]):
@@ -2584,6 +2600,9 @@ def main_body( pars):
 
     if pars["set_ardlib"]:
         v1("\nWARNING: Observation-specific bad pixel file set for session use:\n         "+pars["bpix1_file"]+'\n         Run \'punlearn ardlib\' when analysis of this dataset completed.')
+
+    if pars["vv_file"]:
+        v1("\nPlease be sure to read the Verification and Validation (V&V) report for this OBS_ID in:\n"+pars["vv_file"])
 
     v1('\nThe data have been reprocessed.\nStart your analysis with the new products in\n'+pars["outdir"]+'\n')
 


### PR DESCRIPTION
RFE: from Dave P:

> 
> I get the impression from people I speak with that not many Chandra users read (or even know about) the Verification and validation report pdf distributed with each Chandra observation. While we do our best to automatically process any complicated scenarios that can happen to data before the user gets it, sometimes the V&V report has critical information about the observation the user must address when reducing it. 
> 
> I was thinking about ways to highlight this report for users during the data reduction process and I think it could be nice to remind people about the existence of the V&V report in the terminal output from running chandra_repro. Before I send an email to all SDS members asking if they think this is a good idea, I was wondering how easy/hard this would be to implement.
> 
> Would it be straight-forward to provide information from the V&V report in the terminal output? At the minimum, we could at least have a statement that says something like 'Please see the V&V report located in $VV_file_location for information pertaining to data quality for this observation".  

There's a 2nd RFE to pull out the V&V comments -- but that's not possible w/o lots of other OTS.

