### PR TITLE
The Sesame resolver appeared to have changed behavior.

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,3 +1,13 @@
+## 4.14.2 - April 2022
+
+Updated Python modules
+
+  coords.resolver
+
+    Fixed an issue when using the Sesame resolver when the CADC service
+    is down.
+
+
 ## 4.14.1 - January 2022
 
 Updated scripts

--- a/coords/resolver.py
+++ b/coords/resolver.py
@@ -249,10 +249,11 @@ def identify_name_sesame(name):
 
     """
 
-    # Note: just want first response, search NED first, and select "XML" output.
+    # I used to use ~NSV but that sudenly stopped working, so switched
+    # to ~SNV.
     #
     tname = quote_plus(name)
-    url = 'https://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/-ox/~NSV?' + tname
+    url = 'https://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/-ox/~SNV?' + tname
 
     rsp = query_url(name, url, "Sesame")
 


### PR DESCRIPTION
This was found because the CADC service was down recently and so the fall-through behavior - calling Sesame - was failing.