### PR TITLE
change SCRIPTVER/SCRIPTMOD keywords to SCRPTVER/SCRPTMOD

### DIFF
--- a/bin/specextract
+++ b/bin/specextract
@@ -34,7 +34,7 @@ Script:
 __version__ = "CIAO 4.14"
 
 toolname = "specextract"
-__revision__ = "10 February 2022"
+__revision__ = "15 April 2022"
 
 
 ##########################################################################
@@ -1704,8 +1704,8 @@ def groupspec(args):
 
 def add_history_scriptver(fn,toolname,params,toolversion,modname,modversion):
     add_tool_history(fn, toolname, params, toolversion=toolversion)
-    edit_headers(0, fn, "SCRIPTVER", f"{toolname} - {toolversion}")
-    edit_headers(0, fn, "SCRIPTMOD", f"{modname} - {modversion}")
+    edit_headers(0, fn, "SCRPTVER", f"{toolname} - {toolversion}")
+    edit_headers(0, fn, "SCRPTMOD", f"{modname} - {modversion}")
     
     
         


### PR DESCRIPTION
As noted by @kglotfelty, FITS header keywords should be <= 8 characters, or the DM writes them as a pair of DTYPE/DVAL keywords which is not optimal.