### PR TITLE
Fix bug in coords.chandra

### DIFF
--- a/coords/chandra.py
+++ b/coords/chandra.py
@@ -66,7 +66,7 @@ def _setup_sim( keyword_list ):
 
         _f = float(0.0)
         dsim = (_f,_f,_f)
-        droll = -f
+        droll = _f
     
     return sim, dsim, droll
 


### PR DESCRIPTION
With the current version I get
```python
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Input In [107], in <cell line: 1>()
----> 1 cel_to_chandra(dict(fits.getheader(evt2, 'EVENTS')), [coo_10tau.ra.deg], [coo_10tau.dec.deg])

File ~/mambaforge/envs/i386ciao-4.14/lib/python3.9/site-packages/coords/chandra.py:231, in cel_to_chandra(keyword_list, ra_vals, dec_vals)
    227 except:
    228     rd_vals =  [ ( ra_vals,dec_vals ) ]
--> 231 pix, my_dettan, my_skytan, cdelt = _setup( keyword_list)
    233 # loop over ra,dec's 
    234 theta = []

File ~/mambaforge/envs/i386ciao-4.14/lib/python3.9/site-packages/coords/chandra.py:173, in _setup(keyword_list)
    170 crnom = [ keyword_list["RA_NOM"] ,keyword_list["DEC_NOM"] ]
    172 # Get SIM related info
--> 173 sim, dsim, droll = _setup_sim( keyword_list )
    175 if sim: 
    176     pix.aimpoint = sim

File ~/mambaforge/envs/i386ciao-4.14/lib/python3.9/site-packages/coords/chandra.py:69, in _setup_sim(keyword_list)
     67     _f = float(0.0)
     68     dsim = (_f,_f,_f)
---> 69     droll = -f
     71 return sim, dsim, droll

NameError: name 'f' is not defined
```

I assume this bug has gone unnoticed so far, because we usually pass in an event file that has all the keywords we want. In fact, the fact that I end up in this code branch is do to astupid typo, where I accidentially put in the wrong header. But anyway, should be fixed.