### PR TITLE
mktgresp: remove workaround for HRC-I+HETG rmfs

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -18,6 +18,11 @@ Updated scripts
     particular recent versions of relxill and reltrans. Please contact
     the CXC helpdesk if you are having problems with this script.
 
+  mktgresp
+
+    As mkgrmf can now create a diagonal matrix for HRC data, the
+    work-around to handle the HRC-I + HETG case has been removed.
+
 Updated Python modules
 
   TBD

--- a/bin/mktgresp
+++ b/bin/mktgresp
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # 
-# Copyright (C) 2013,2016-2018, 2020, 2021 
+# Copyright (C) 2013,2016-2018, 2020, 2021, 2022 
 # Smithsonian Astrophysical Observatory
 # 
 # This program is free software; you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 # 
 
 toolname = "mktgresp"
-__revision__ = "10 March 2022"
+__revision__ = "15 August 2022"
 
 
 import os
@@ -219,8 +219,9 @@ def make_tg_rmf( obsinfo, pha, spectrum, outroot, wvgrid_arf, wvgrid_chan):
     part = map_part_to_name( spectrum.part )
     if det == "HRC-I":
         if part.lower() in ["meg", "heg"]:
-            det="ACIS-7"  # ACIS-7 for HETG
-            verb0("WARNING: There are no grating RMF calibration products for HRC-I.  Will create a diagonal RMF")
+            # TODO: If/when HRC-I + HETG lsfparams are released then 
+            # we should merge this with the else LEG section.
+            verb0("WARNING: There are no grating RMF calibration products for HRC-I+HEG/MEG.  Will create a diagonal RMF")
             mkgrmf.diagonalrmf = True
 
         else:    # leg

--- a/share/doc/xml/mktgresp.xml
+++ b/share/doc/xml/mktgresp.xml
@@ -403,6 +403,15 @@ parameter is angstroms.
     </PARAM>
     </PARAMLIST>
 
+    <ADESC title="Changes in the scripts 4.15.0 (December 2022) release">
+      <PARA>
+        Removed work-around for HRC-I + HETG response matrix.  Previously
+        needed to set detector to ACIS to create a diagonal matrix, 
+        now mkgrmf allows for creating HRC diagonal matrices. 
+      </PARA>
+    </ADESC>
+
+
     <ADESC title="Changes in the scripts 4.14.2 (April 2022) release">
         <PARA>
             Remove the internal work-around to set the BPMASK
@@ -518,7 +527,7 @@ parameter is angstroms.
         for this tool</HREF>
         on the CIAO website for an up-to-date listing of known bugs.
       </PARA></BUGS>
-   <LASTMODIFIED>March 2022</LASTMODIFIED>
+   <LASTMODIFIED>December 2022</LASTMODIFIED>
 
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #620 .  It needs to wait for the `mkgrmf` changes in 4.15.0.

