### PR TITLE
Remove __future__ for print and some unused imports

### DIFF
--- a/bin/combine_grating_spectra
+++ b/bin/combine_grating_spectra
@@ -18,13 +18,10 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 # 
 
-from __future__ import print_function
-
 toolname = "combine_grating_spectra"
 __revision__ = "25 February 2022"
 
-from pycrates import read_file, write_file
-import numpy as np
+from pycrates import read_file
 import stk
 import os
 import sys

--- a/bin/combine_spectra
+++ b/bin/combine_spectra
@@ -17,8 +17,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from __future__ import print_function
-
 
 toolname = "combine_spectra"
 __revision__ = "07 April 2020"

--- a/bin/ds9_functs
+++ b/bin/ds9_functs
@@ -18,8 +18,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
 import sys
 import os
 import subprocess as sp

--- a/bin/gti_align
+++ b/bin/gti_align
@@ -19,9 +19,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
-
 import os
 import sys
 

--- a/bin/mktgresp
+++ b/bin/mktgresp
@@ -18,8 +18,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 # 
 
-from __future__ import print_function
-
 toolname = "mktgresp"
 __revision__ = "10 March 2022"
 

--- a/bin/monitor_photom
+++ b/bin/monitor_photom
@@ -17,14 +17,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from __future__ import print_function
 
-import stk
 import pycrates as pc
 import numpy as np
 
 import sys
-import os
 
 import ciao_contrib.logger_wrapper as lw
 

--- a/bin/multi_chip_gti
+++ b/bin/multi_chip_gti
@@ -17,9 +17,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from __future__ import print_function
-
-
 
 toolname = "multi_chip_gti"
 __revision__ = "13 Sep 2016"

--- a/bin/obsid_search_csc
+++ b/bin/obsid_search_csc
@@ -16,8 +16,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from __future__ import print_function
-
 
 toolname = "obsid_search_csc"
 __revision__ = "18 November 2019"

--- a/bin/psfsize_srcs
+++ b/bin/psfsize_srcs
@@ -17,8 +17,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from __future__ import print_function
-
 
 toolname = "psfsize_srcs"
 __revision__ = "13 Sep 2016"

--- a/bin/r4_header_update
+++ b/bin/r4_header_update
@@ -25,8 +25,6 @@ add repro4 related header keywords to file
 
 """
 
-from __future__ import print_function
-
 toolname = "r4_header_update"
 version = "13 Sep 2016"
 

--- a/bin/readout_bkg
+++ b/bin/readout_bkg
@@ -16,9 +16,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from __future__ import print_function
-
-
 
 toolname = "readout_bkg"
 __revision__ = "13 Sep 2016"

--- a/bin/reg2tgmask
+++ b/bin/reg2tgmask
@@ -17,8 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
 toolname = "reg2tgmask"
 __revision__ = "28 November 2018"
 

--- a/bin/search_csc
+++ b/bin/search_csc
@@ -17,8 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
 toolname = "search_csc"
 __revision__ = "18 November 2019"
 

--- a/bin/tgmask2reg
+++ b/bin/tgmask2reg
@@ -16,7 +16,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-from __future__ import print_function
 
 toolname = "tgmask2reg"
 __revision__ = "06 March 2018"

--- a/bin/tgsplit
+++ b/bin/tgsplit
@@ -17,8 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
 toolname = "tgsplit"
 __revision__ = "21 Jan 2020"
 


### PR DESCRIPTION
I was in the process of writing a new tool and wanted to use one of the existing ones as template, when I stumbled on those harmless, but no longer needed lines.
So, I figured, I might as well remove them.