### PR TITLE
docs chandra_repro - add "" to coordinate example

### DIFF
--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -266,10 +266,10 @@ acisf084244478N003_2_bias0.fits.gz
             source to use for the 0th order location.  In this example
             we run chandra_repro with the RA and Dec coordinates for
             the source specified in decimal degrees.  Users can also
-            supply the coordinates in sexagesimal notation, eg
+            supply the coordinates in sexagesimal notation, e.g.
 <SYNTAX>
 <LINE>
-tg_zo_position=5:35:15.7594,-5:23:10.191
+tg_zo_position="5:35:15.7594,-5:23:10.191"
 </LINE>
 </SYNTAX>
             </PARA>


### PR DESCRIPTION
The example just a few lines above has tg_zo_position wrapped in "" to avoid confusing the shell. I suggest to apply that consistently also in the line below that.