### PR TITLE
WIP:  srcflux: add aplimits tool to output

### DIFF
--- a/bin/srcflux
+++ b/bin/srcflux
@@ -959,6 +959,7 @@ def run_aprates( c_s, a_s, alpha, c_b, a_b, beta, exposure, conf, outfile ):
     that can be combined together later
     """
     aprates = make_tool("aprates")
+    aplimit = make_tool("aplimits")
 
     def write_null( outfile ):
         with open(outfile, "w") as fp:
@@ -966,6 +967,8 @@ def run_aprates( c_s, a_s, alpha, c_b, a_b, beta, exposure, conf, outfile ):
             fp.write("src_rate_err_lo,r,h,INDEF,,,\n")
             fp.write("src_rate_err_up,r,h,INDEF,,,\n")
             fp.write("src_rate_signif,r,h,INDEF,,,\n")
+            fp.write("min_counts_detect,i,h,INDEF,,,\n")
+            fp.write("upper_limit,r,h,INDEF,,,\n")
         return
 
     verb1( "Running aprates for {}".format(outfile) )
@@ -1006,6 +1009,39 @@ def run_aprates( c_s, a_s, alpha, c_b, a_b, beta, exposure, conf, outfile ):
     except Exception as ee:
         write_null(outfile)
         return
+
+    try:
+        aplimit.outfile = outfile.replace(".par", "_lims.par")
+        aplimit.T_s = exposure
+        aplimit.A_s = a_s
+        aplimit.m = c_b
+        aplimit.T_b = exposure
+        aplimit.A_b = a_b
+        aplimit.clobber = True
+        bb = aplimit()
+    except Exception as ee:
+        print(ee)
+        write_null(outfile)
+        return
+
+    from paramio import pget
+    src_rate_mode = pget(outfile, "src_rate_mode")
+    src_rate_err_lo = pget(outfile, "src_rate_err_lo")
+    src_rate_err_up = pget(outfile, "src_rate_err_up")
+    src_rate_signif = pget(outfile, "src_rate_signif")
+    
+    min_counts_detect = pget(aplimit.outfile, "min_counts_detect")
+    upper_limit = pget(aplimit.outfile, "upper_limit")
+
+    with open(outfile, "w") as fp:
+        fp.write(f"src_rate_mode,r,h,{src_rate_mode},,,\n")
+        fp.write(f"src_rate_err_lo,r,h,{src_rate_err_lo},,,\n")
+        fp.write(f"src_rate_err_up,r,h,{src_rate_err_up},,,\n")
+        fp.write(f"src_rate_signif,r,h,{src_rate_signif},,,\n")
+        fp.write(f"min_counts_detect,i,h,{min_counts_detect},,,\n")
+        fp.write(f"upper_limit,r,h,{upper_limit},,,\n")
+
+    gorm(aplimit.outfile)
 
     if aa:
         verb4(aa)
@@ -1091,13 +1127,13 @@ def add_aprates_to_output( myparams, at_energy, outfiles):
 
     verb1("Adding net rates to output")
 
-    def pull_par_into_crate( parname, cratename, desc, units="counts/s" ):
+    def pull_par_into_crate( parname, cratename, desc, dtype=float, units="counts/s" ):
         from paramio import pget
         from pycrates import CrateData
         cd = CrateData()
         cd.name = cratename
         vals = [pget(pp,parname) for pp in outfiles ]
-        vals = [ np.nan if x == 'INDEF' else float(x) for x in vals ]
+        vals = [ np.nan if x == 'INDEF' else dtype(x) for x in vals ]
         cd.values = vals
         cd.unit = units
         cd.desc = desc
@@ -1107,6 +1143,9 @@ def add_aprates_to_output( myparams, at_energy, outfiles):
     pull_par_into_crate( "src_rate_err_lo", "NET_RATE_APER_LO", "Lower limit on net count rate")
     pull_par_into_crate( "src_rate_err_up", "NET_RATE_APER_HI", "Upper limit on net count rate")
     pull_par_into_crate( "src_rate_signif", "SRC_SIGNIFICANCE", "Source significance", units="")
+    pull_par_into_crate( "min_counts_detect", "SRC_MIN_COUNTS_DETECT", "Detection Threshold", units="Counts", dtype=int)
+    pull_par_into_crate( "upper_limit", "SRC_UPPER_LIMIT", "Upper limit", units="")
+
     write_key( intab, "CONF", myparams.conf, 'Confidence intervals [0-1]' )
 
     intab.write()


### PR DESCRIPTION
This PR runs @hamogu `aplimits` tool and includes the output into the `srcflux` output `.flux` file.

The output values are currently being written as

- `min_counts_detect` added as `SRC_MIN_COUNTS_DETECT`
- `upper_limit` gets added as `SRC_UPPER_LIMIT` (there is already an `UPPER_LIMIT` column)

Based on discussion and doc update I think the later should be `SRC_RATE_UPPER_LIMIT` with units `cts/s`.

Questions:

- Should we add `prob_false_detect` and `prob_missed_detection` to the `srcflux.par` file and pass those values to `aplimits` or are the defaults sufficient?

TODO:
- [ ] Store the `prob_*` values (whether defaults or passed in), probably as header keywords in `.flux` file.
- [ ] Apply the psf fraction, `alpha`,  correction to the upper limits
- [ ] Doc updates

Anything else?
