### PR TITLE
Handle 4.14.4 release of convert_xspec_user_model

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -33,7 +33,7 @@ Using CIAO tools from ds9 (dax)
 
   The list of Image Processing -> Non-Linear Filters includes the
   new dmimgfilt filters: ridge, plain, q10, q90, and jitter.
-  
+
   Changes to Sherpa fitting routines to clean up the textual output.
 
 New scripts
@@ -88,15 +88,15 @@ Updated scripts
 
     A problem when multiple SSO eph1 files are found has been
     fixed.
-    
+
     Work around a DM bug when tg_zo_position=detect which prevented
     tgdetect2 from choosing the tg_find_zo algorithm.
 
   convert_xspec_user_model
 
-    The script has been updated to improve support for user models, in
-    particular recent versions of relxill and reltrans. Please contact
-    the CXC helpdesk if you are having problems with this script.
+    The script has been updated to account for changes in the
+    interface to the XSPEC model library. Please contact the CXC
+    helpdesk if you are having problems with this script.
 
   correct_periscope_drift
 
@@ -141,6 +141,6 @@ Updated Python modules
     updates.
 
   coordinates.gratings
-  
+
     A new class, TGPixlib, to help convert from sky coordinates to grating
     coordinates: dispersion angles and energy.

--- a/bin/convert_xspec_user_model
+++ b/bin/convert_xspec_user_model
@@ -67,7 +67,7 @@ for a description of the model.dat format.
 """
 
 toolname = "convert_xspec_user_model"
-toolver  = "03 November 2022"
+toolver  = "10 November 2022"
 
 import sys
 import os
@@ -924,9 +924,18 @@ def build_module_init(modname, pycode, mdls,
     else:
         normpar = ""
 
+    # Do we need to import warnings? We could do this by checking what
+    # condition leads to this (ie the model flags) but for now just check
+    # if warnings.warn is used
+    #
+    use_warnings = pycode.find("warnings.warn") > -1
+    warning_str = "import warnings" if use_warnings else ""
+
     out = PYTHON_HEADER
     out += f'''
 """Sherpa interfaces to XSPEC models."""
+
+{warning_str}
 
 from sherpa.models.parameter import {normpar}hugeval
 from sherpa.astro.xspec import {xsnames}, XSParameter, get_xsversion
@@ -982,10 +991,18 @@ get_xsversion()
     conv = re.subn(r"\{t2\}", "        ", pycode)
     if conv[1] > 0:
         pycode = conv[0]
-        v2(f"NOTE: had to correct the python code {conv[1]} times")
+        v2(f"NOTE: had to correct the python code {conv[1]} times [t2 replacement]")
+
+    # Fix an error in Sherpa 4.15.0 and earlier
+    # - warnings.warn string not correctly interpolated when generated.
+    #
+    conv = re.subn(r"warnings.warn\('support for models like {mdl.clname.lower\(\)}",
+                   "warnings.warn(f'support for models like {self.__class__.__name__.lower()}", pycode)
+    if conv[1] > 0:
+        pycode = conv[0]
+        v2(f"NOTE: had to correct the python code {conv[1]} times [warn f-string]")
 
     out += pycode
-
     save(outfile, out)
 
 
@@ -1319,12 +1336,14 @@ def convert_xspec_user_model(modulename, modelfile,
 
     extrafiles = []
 
-    v2(f"{toolname}: {toolver}")
-    v2(f"  name:       {modulename}")
-    v2(f"  modelfile:  {modelfile}")
-    # v2(f"  extrafiles: {extrafiles}")
-    v2(f"  clobber:    {clobber}")
-    v2("")
+    # These used to be v2 but I find them useful so make them v1.
+    #
+    v1(f"{toolname}: {toolver}")
+    v1(f"  name:       {modulename}")
+    v1(f"  modelfile:  {modelfile}")
+    # v1(f"  extrafiles: {extrafiles}")
+    v1(f"  clobber:    {clobber}")
+    v1("")
 
     # When local is False ensure that the modulename is "unique". We
     # want to allow the user to re-use the same module name (e.g.

--- a/share/doc/xml/convert_xspec_user_model.xml
+++ b/share/doc/xml/convert_xspec_user_model.xml
@@ -549,6 +549,13 @@ undefined symbol: _gfortran_copy_string
 
     <ADESC title="Changes in the scripts 4.15.0 (December 2022) release">
       <PARA>
+	The script has been updated to work with Sherpa in CIAO 4.15,
+	as the interface to the XSPEC model library was updated.
+      </PARA>
+    </ADESC>
+
+    <ADESC title="Changes in the scripts 4.14.4 (November 2022) release">
+      <PARA>
 	Support for models that use *.cpp files has been added, such
 	as recent versions of relxill, and the order that files are
 	compiled has been switched to alphabetical, as this appears to


### PR DESCRIPTION
Rework the changes section and add the extra changes found when working on the 4.14.4 release. The script also know reports some basic start-up info (script name, version, ...) at verbose=1 rather than verbose=2.