### PR TITLE
srcflux: add aplimits plugin and update Changes

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -6,7 +6,7 @@ team at PSU. These are labeled below. Please see
 
   https://cxc.cfa.harvard.edu/ciao/guides/srcflux_for_ae_users.html
 
-for more information on using srcflux as a replacement for
+for more information on using srcflux as a substitute for
 acis_extract.
 
 The ahelp files for the contributed scripts have been re-organized,
@@ -127,6 +127,22 @@ Updated scripts
      - Extract radial profiles (per obsid)
      - Perform blind deconvolution using arestore (per obsid)
      - Estimate source extent (per obsid)
+     - Get upper limits on missed detections and count rates for false
+       detections using the new aplimits tools (per obsid)
+
+    Additional changes to srcflux include
+
+      - With psfmethod=marx, the PSFs will now be simulated in parallel
+        (based on the 'parallel' and 'nproc' parameters).
+      - The default background region inner radius has been increased.
+        Previously it was the same as the source radius; it is now
+        1.7 times the source radius.  This improves the background
+        estimate around very bright sources; events spread by
+        the PSF could bias the background estimate.
+      - When merging observations, a new "INSIDE_FOV" column is added
+        to the merged .flux output file. It is an array of boolean values
+        (True|False) which indicates which observations the source was
+        imaged in.
 
 Updated Python modules
 

--- a/data/sample_srcflux_plugins.py
+++ b/data/sample_srcflux_plugins.py
@@ -372,7 +372,7 @@ def aplimits_srcflux_obsid_plugin(infile, outroot, band, elo, ehi, src_num):
     """
     Sample plugin: aplimits
     
-    This plugin runs the new `aplimits` script to compute
+    This plugin runs the `aplimits` script to compute
     upper limits and rate limits on false detections.    
     """
 

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -2191,7 +2191,9 @@ These include
 <ITEM>Compute hardness ratios (per obsid)</ITEM>
 <ITEM>Extract radial profiles (per obsid)</ITEM>
 <ITEM>Perform blind deconvolution using arestore (per obsid)</ITEM>
-<ITEM>Extimate source extent (per obsid)</ITEM>
+<ITEM>Estimate source extent (per obsid)</ITEM>
+<ITEM>Run the new `aplimits` tool to get upper limits for missed 
+detections and count rates for false detections.</ITEM>
 </LIST>
 
   </ADESC>

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -2192,7 +2192,7 @@ These include
 <ITEM>Extract radial profiles (per obsid)</ITEM>
 <ITEM>Perform blind deconvolution using arestore (per obsid)</ITEM>
 <ITEM>Estimate source extent (per obsid)</ITEM>
-<ITEM>Run the new `aplimits` tool to get upper limits for missed 
+<ITEM>Run the `aplimits` tool to get upper limits for missed 
 detections and count rates for false detections.</ITEM>
 </LIST>
 


### PR DESCRIPTION
This is a replacement for #675 

Instead of putting the `aplimits` code directly into `srcflux`, this provides a sample plugin so that users who want to use it can run it that way.

