### PR TITLE
specextract: truncated outroot when combine=yes

### DIFF
--- a/bin/specextract
+++ b/bin/specextract
@@ -1292,20 +1292,19 @@ def spectra(args):
 
         try:
             phafile = extract_spectra(full_outroot,fullfile,ptype,channel,
-                                      ewmap,binwmap,instrument,clobber,verbose)
-
-            ## update extracted readout streak spectrum effective exposure time ##
-            if streakspec == "yes" and srcbkg == "src":
-                readout_streak_spec(specfile=phafile,infile=fullfile,src_x=float(args["skyx"]),src_y=float(args["skyy"]))
-
-            try:
-                pardict[key_id].update({"phafile" : phafile})
-            except NameError:
-                pardict = {key_id : {"phafile" : phafile}}
-                
+                                      ewmap,binwmap,instrument,clobber,verbose)            
         except OSError as exc:
             raise IOError(f"Failed to extract spectrum for {fullfile}") from exc
 
+        ## update extracted readout streak spectrum effective exposure time ##
+        if streakspec == "yes" and srcbkg == "src":
+            readout_streak_spec(specfile=phafile,infile=fullfile,src_x=float(args["skyx"]),src_y=float(args["skyy"]))
+
+        try:
+            pardict[key_id].update({"phafile" : phafile})
+        except NameError:
+            pardict = {key_id : {"phafile" : phafile}}
+        
         ## add nH values to phafile header ##
         if nrao_nh is not None:
             # Galactic neutral hydrogen column density at the source position using

--- a/bin/specextract
+++ b/bin/specextract
@@ -34,7 +34,7 @@ Script:
 __version__ = "CIAO 4.15"
 
 toolname = "specextract"
-__revision__ = "15 November 2022"
+__revision__ = "17 November 2022"
 
 
 ##########################################################################
@@ -1891,7 +1891,7 @@ def coadd(outroot,spec_src_stk,spec_bkg_stk,
             verbose = 1
         
         combine_spectra.punlearn()
-        combine_spectra.outroot = f"{outroot}_combined"
+        combine_spectra.outroot = f"{outroot}combined"
         combine_spectra.clobber = clobber
         combine_spectra.verbose = verbose
 
@@ -1952,7 +1952,7 @@ def clobber_file_check(specextract_args,combine):
                 fileclobber.append(fn)
     
     if combine == "yes":
-        combine_outroot = "{}_combined".format(specextract_args[0]["full_outroot"].rstrip(f"_{specextract_args[0]['key_id']}"))
+        combine_outroot = "{}combined".format(specextract_args[0]["full_outroot"].rstrip(f"{specextract_args[0]['key_id']}"))
 
         combine_extension = ["src.pi","src.arf","src.rmf","bkg.pi","bkg.arf","bkg.rmf"]
         
@@ -2381,7 +2381,7 @@ def run_specextract(args):
     ###########################
 
     if combine == "yes":
-        combine_outroot = specdicts["src1"]["full_outroot"].rstrip("_src1")
+        combine_outroot = specdicts["src1"]["full_outroot"].rstrip("src1")
 
         coadd(combine_outroot,
               src_spec,bkg_spec,


### PR DESCRIPTION
When combine=yes, the outroot of the combined file is erroneously truncated by one character due to unexpected behavior of rstrip with underscores on string variables.  If the rstrip is applied directly to a string, the behavior is as expected.