### PR TITLE
blanksky f-string

### DIFF
--- a/bin/blanksky
+++ b/bin/blanksky
@@ -935,7 +935,7 @@ def doit():
             v1(f"Calculated scale factors for 'weight_method={method}':")
 
         for n in scale:
-            v1(f"    ACIS-{n[0]}: {n[1]} written to the 'BKGSCAL{0}' header keyword.")
+            v1(f"    ACIS-{n[0]}: {n[1]} written to the 'BKGSCAL{n[0]}' header keyword.")
 
     add_tool_history(outdir+outfile,toolname,pars)
 


### PR DESCRIPTION
all the regression tests are printing

```python
...stuff... 'BKGSCAL0' header keywords
```
regardless of chip.