### PR TITLE
srcflux: bugfix when running bkgresp=no and multiple obsids

### DIFF
--- a/bin/srcflux
+++ b/bin/srcflux
@@ -18,7 +18,7 @@
 #
 
 toolname = "srcflux"
-__revision__ = "04 November 2022"
+__revision__ = "01 December 2022"
 
 import os
 
@@ -2200,8 +2200,8 @@ def merge_modelflux( stk_params, myparams ):
         combine_spectra.src_arf = a_good
         combine_spectra.src_rmf = r_good
         combine_spectra.bkg_spectra = b_good
-        combine_spectra.bkg_arfs = bkg_arf
-        combine_spectra.bkg_rmfs = bkg_rmf
+        combine_spectra.bkg_arfs = bkg_arf if len(bkg_arf) > 0 else ""
+        combine_spectra.bkg_rmfs = bkg_rmf if len(bkg_rmf) > 0 else ""
         combine_spectra.outroot = myparams.outroot+"{:04d}".format(snum+1)
         combine_spectra.clobber=True
         vv = combine_spectra()


### PR DESCRIPTION
From the threads regression tests, if using `bkgresp=no` (default is `yes`), an exception is thrown when setting the background ARF and RMF files in `combine_spectra`.  Need to set to a blank string instead of an empty list (which tries to set the parameter to a `None`).

Since it's not the default, not necessarily a showstopper for 4.15
