### PR TITLE
add warning message and Python 3.10+ workaround in minor lower-level functions 

### DIFF
--- a/ciao_contrib/_tools/fileio.py
+++ b/ciao_contrib/_tools/fileio.py
@@ -280,8 +280,11 @@ def get_keys_cols_from_file(fname):
         # get_block_info_from_file loses the ordering
         # of the columns, so need to reconstruct it
         colinfo = [None] * keys['__NCOLS']
-        for cinfo in bi['columns'].values():
-            colinfo[cinfo.pos - 1] = cinfo
+        try:
+            for cinfo in bi['columns'].values():
+                colinfo[cinfo.pos - 1] = cinfo
+        except IndexError as exc:
+            raise IndexError(f"check if '{fname}' has duplicate column names!") from exc
 
     else:
         colinfo = None

--- a/crates_contrib/utils.py
+++ b/crates_contrib/utils.py
@@ -336,7 +336,11 @@ def make_table_crate(*args, **kwargs):
     if nargs == 0:
         raise TypeError("make_table_crate() takes at least one argument (0 given)")
     elif nargs == 1:
-        isdict = isinstance(args[0], collections.Mapping)
+        try:
+            isdict = isinstance(args[0], collections.Mapping)
+        except AttributeError:
+            isdict = isinstance(args[0], collections.abc.Mapping)
+            
         if hasattr(args[0], "dtype") and hasattr(args[0].dtype, "names"):
             isstruct = args[0].dtype.names is not None
 


### PR DESCRIPTION
add warning in index error to look for duplicate column names in `_tools/fileio.py` which was coming from `obsinfo.ObsInfo` and a workaround for a Python 3.10 deprecation in `collections` in `crate_contrib/utils.py` as discussed in #699 