### PR TITLE
Improve aplimits

### DIFF
--- a/bin/aplimits
+++ b/bin/aplimits
@@ -289,8 +289,9 @@ class APLimitsMarginalize(APLimits):
         # width = sqrt(variance)
         # -10 * std to + 20 * std
         # It's asymmetric because the function is for small numbers.
-        # choice of 10, 20 and 100 points is made by looking at functions
-        # plotted for typical values.
+        # choice of 1000 points is made by looking at functions
+        # for typical input values and checking how many point we need to get
+        # reasonable precision.
         x = np.linspace(max(0, loc_peak - 10 * width), loc_peak + 20 * width, 1000)
         # For very small backgrounds, loc_peak << width
         # In that case, we have to make sure that the region around the peak is well

--- a/bin/aplimits
+++ b/bin/aplimits
@@ -42,7 +42,7 @@ they are taken from different sources:
 - The PDF of the gamma distribution
   https://en.wikipedia.org/wiki/Gamma_distribution
   (not to be confused with the Gamma function) is implemented here in Python
-  following the ideas the scipy's C code uses.
+  following the ideas in scipy's C code.
 '''
 
 import os
@@ -65,7 +65,14 @@ v3 = lw.make_verbose_level(TOOLNAME, 3)
 # Numerical routines
 #
 def xlogy(x, y):
-    '''Following the idea of the Cython implementation in scipy'''
+    '''Return x * log(y) in a numerically robust way
+
+    The simple `x * np.log(y)` may fail if x and/or y are
+    0 due to the way that NaNs are propagated. This little
+    helper function treats those special cases.
+
+    Following the idea of the Cython implementation in scipy.
+    '''
     if x == 0 and not np.isnan(y):
         return 0
     elif np.isfinite(x) and y == 0:
@@ -77,7 +84,10 @@ def xlogy(x, y):
         return x * np.log(y)
 
 def gamma_pdf(x, alpha, beta):
+    '''Probabillity-density function for the Gamma distribution
 
+    (Not to be confused with the related Gamma function.)
+    '''
     # Rescaling x -> x/b (see scipy docs)
     # for easier numeric evaluation
     x = x * beta
@@ -93,14 +103,14 @@ class APLimits():
     Parameters
     ----------
     lamb : float
-        background intensity in units of counts / area / time
+        background intensity in the source aperture in units of counts / time
     taus : float
         Exposure time in source region
     taub : float
         Exposure time in background region. Since lamb is already normalized to the exposure time,
         this setting has no effect in this class.
     r : float
-        Ratio of background to source area. Since lamb is already normalized to the exposure time,
+        Ratio of background to source area. Since lamb is already normalized to the area,
         this setting has no effect in this class.
     maxfev : int
         maximum number of function evaluations in bisection
@@ -121,13 +131,29 @@ class APLimits():
         return i
 
     def beta(self, lams, sstar, lamb=None):
-        '''
+        '''Probability of a detection, i.e. one minus the probability of a Type II error
+
         In the derived class, lamb is not a class attribute, but is a
         variable that is integrated over. In that case, we need to pass
         in lamb.
 
         In this class, lamb is an attribute of the class and not
         passed in.
+
+        In Kashyap et al. (2010) this is eqn 5 implemented for a Poisson
+        case. The equation in footnote 13 in that paper (about 2/3 down -
+        equations within a footnote are not numbered)
+        can be obtained as `beta(0, sstar, lamb)` and the general case is
+        equivalent to the formula in footnote 14 (bottom of footnote).
+
+        Parameters
+        ----------
+        lams : float
+            Source intensity
+        sstar : int
+            Detection threshold value
+        lamb: float or None
+            Background intensity (if None, `self.lamb` is used)
         '''
         if lamb is None:
             lamb = self.lamb
@@ -145,6 +171,8 @@ class APLimits():
         -------
         upper_limit : float
             Upper limit
+        sstar : int
+            Minimum number of counts needed to claim a detection
         '''
         if alpha <=0 or alpha >= 1:
             raise ValueError('alpha is a probability, which must be between 0 and 1.')
@@ -158,7 +186,7 @@ class APLimits():
         # In practice, that won't happen (alpha is typically 0.1 or 0.01)
         # but we want the algorithm to work for every case.
         if self.rootfunc(0, sstar, beta) > 0:
-            return 0
+            return 0, 1
 
         # We use a bisect method for root finding,
         # so we first need to establish a bracketing interval.
@@ -172,7 +200,6 @@ class APLimits():
             v1('Numerical root finding did not converge.')
         return out[0][0], sstar
 
-
 class APLimitsMarginalize(APLimits):
     '''Calculate upper limit for a detection following Kashyap et al. (2010)
 
@@ -183,11 +210,9 @@ class APLimitsMarginalize(APLimits):
     taus : float
         Exposure time in source region
     taub : float
-        Exposure time in background region. Since lamb is already normalized to the exposure time,
-        this setting has no effect in this class.
+        Exposure time in background region.
     r : float
-        Ratio of background to source area. Since lamb is already normalized to the exposure time,
-        this setting has no effect in this class.
+        Ratio of background to source area.
     maxfev : int
         maximum number of function evaluations in bisection
     '''
@@ -211,6 +236,7 @@ class APLimitsMarginalize(APLimits):
         self.taub = taub
         self.r = r
         self.maxfev = maxfev
+
 
     def lamb_posterior(self, lamb):
         '''Estimate posterior distribution for lamb_b
@@ -265,7 +291,7 @@ class APLimitsMarginalize(APLimits):
         # It's asymmetric because the function is for small numbers.
         # choice of 10, 20 and 100 points is made by looking at functions
         # plotted for typical values.
-        x = np.linspace(max(0, loc_peak - 10 * width), loc_peak + 20 * width, 100)
+        x = np.linspace(max(0, loc_peak - 10 * width), loc_peak + 20 * width, 1000)
         # For very small backgrounds, loc_peak << width
         # In that case, we have to make sure that the region around the peak is well
         # sampled. Without the following added points, the peak can be missed and thus
@@ -274,7 +300,7 @@ class APLimitsMarginalize(APLimits):
         #       it is still necessary to ensure that that region is sampled well.
         if loc_peak < 3 * width:
             # Region around peak not well sampled by np.linspace. Add points.
-            x_around_peak = np.linspace(0, 20 * loc_peak, 100, endpoint=False)
+            x_around_peak = np.linspace(0, 20 * loc_peak, 1000, endpoint=False)
             x = np.concatenate([x, x_around_peak])
             x.sort()
         # igam does not accept numpy arrays, so need to call one by one and put in list
@@ -361,6 +387,8 @@ def aplimits(prob_false_detection=.1, prob_missed_detection=.5, T_s=1, A_s=1,
     lambs : float
         Upper limit for the source intensity (in cts/time), integrated over the
         source aperture.
+    sstar : int
+        Minimum number of counts needed to claim a detection
 
     Note
     ----

--- a/share/doc/xml/aplimits.xml
+++ b/share/doc/xml/aplimits.xml
@@ -107,7 +107,7 @@
         This tool calculates the upper limit on the source flux, given
         properties of the detection method (type I and II errors and source
         region size and exposure time) and background level. This calculation is valid 
-	for all source regions in an observation (assuming a smooth
+	      for all source regions in an observation (assuming a smooth
         background and constant exposure time). This is conceptually different
         from aprates, which instead looks at the source count rate in one
         specific region and then derives the credible interval for the flux of a
@@ -115,23 +115,23 @@
         credible interval includes 0 and sometimes the upper end of the interval
         is taken as upper limit on the source flux. That is not mathematically
         correct, since "upper limit" and "upper end of credible interval"
-        describe different statistical concepts, even though in the derived
-        numbers are can be similar; see
+        describe different statistical concepts, even though the derived
+        numbers can be similar; see
         <HREF link="https://ui.adsabs.harvard.edu/abs/2010ApJ...719..900K">Kashyap et al. (2010)</HREF>
         for a more detailed discussion.
       </PARA>
       <PARA title="3.) What are the units for area and exposure time?">
         To calculate the upper limit, the tool needs to know the number of expected
         background counts in the source area. Because of that the formulas do not
-        depend directly on the exposure time or apeture area.
+        depend directly on the exposure time or aperture area.
         Instead, the source aperture area is
         only used to get the number of expected background counts (if bkg_rate is given)
         or the ratio to the background area (if the number of counts m in the background
         aperture is given). So, it is sufficient to use consistent units for areas,
-        e.g., A_s and A_b can be given in pixels or arcsec**2, so long as both numbers
+        e.g., A_s and A_b can be given in pixels or arcsec^2, so long as both numbers
         use the same units (and if source and background aperture are the same size,
         they can both be left at their default 1.0).
-        Similarly, bkg_rate can be "per pixel" or "per arcsec" as long as the unit
+        Similarly, bkg_rate can be "per pixel" or "per arcsec^2" as long as the unit
         is consistent with A_s.
         The same is true for the units of exposure time:
         T_s and bkg_rate (or T_b) just need to be


### PR DESCRIPTION
I analyzed a failure in the regression tests that I wrote.
I relaized that the difference is entirely due to numerics, so this PR increases the number of stps taken in the numerical integration. 

Since I'm at it and I installed a new spell checking tool in my editor recently, I also fixed a few speling mistakes and added more docs to the code to help me next time I'm forced to think about each step again.