### PR TITLE
combine_spectra: Fix origin of exposure time

### DIFF
--- a/bin/combine_spectra
+++ b/bin/combine_spectra
@@ -19,7 +19,7 @@
 #
 
 toolname = "combine_spectra"
-__revision__ = "07 April 2020"
+__revision__ = "09 December 2022"
 
 import sys
 import os
@@ -106,8 +106,8 @@ class Spectrum():
             self.arffile = self._get_filename_if_not_none( infile,tab, "ancrfile", pc.read_file)
         else:
             #make sure can read it
-            tab=pc.read_file( self.arffile )
-            if not tab.column_exists("specresp"):
+            arf = pc.read_file( self.arffile )
+            if not arf.column_exists("specresp"):
                 raise IOError("File '{}' does not appear to be an ARF".format(self.arffile))
 
         if exppref == "pha" or is_none(self.arffile):

--- a/share/doc/xml/combine_spectra.xml
+++ b/share/doc/xml/combine_spectra.xml
@@ -361,7 +361,7 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
        </LIST>
 </ADESC>
 
-  <ADESC title="Changes in the script 4.15.1 (April 2023) release">
+  <ADESC title="Changes in the script 4.15.1 (January 2023) release">
       <PARA>
       The combine_spectra script has been updated fix a bug where the
       exposure time was taken from the ARF, even if the user set

--- a/share/doc/xml/combine_spectra.xml
+++ b/share/doc/xml/combine_spectra.xml
@@ -361,6 +361,13 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
        </LIST>
 </ADESC>
 
+  <ADESC title="Changes in the script 4.15.1 (April 2023) release">
+      <PARA>
+      The combine_spectra script has been updated fix a bug where the
+      exposure time was taken from the ARF, even if the user set
+      exp_origin='pha'.
+    </PARA>
+  </ADESC>
 
   <ADESC title="Changes in the script 4.12.2 (April 2020) release">
     <PARA>


### PR DESCRIPTION
The exposure time was taken from the ARF, even when exp_origin='pha' was set (the default),
simple because an ARF exits.
In Chandra, we probably never noticed, but I run into a problem when applying
this script to NICER spectra, where the ARF does not have all the header
information that the PHA would have.
The bug is somewhat obvious in the code and can be tested with any ARF file that does not have an EXPOSURE keyword.
One would get
```
OSError: The file 'NICER_SOMETHING.pi' is missing the 'EXPOSURE' keyword.
```
However, the usual wrapping of the errors in scripts makes it somewhat harder to get to see the details of the error.