### PR TITLE
merging.py: fixed variable typo for handling CC-mode data

### DIFF
--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -1051,7 +1051,7 @@ def validate_obsinfo(infiles, colcheck=True):
                 continue
 
             if readmode == 'CONTINUOUS':
-                v1(f"Skipping {nifile} as it is a CC-mode observation.")
+                v1(f"Skipping {infile} as it is a CC-mode observation.")
                 blank_line = True
                 continue
 


### PR DESCRIPTION
reported in helpdesk, where CC-mode warning message errors out due to variable name typo.