### PR TITLE
Improve URL access (hopefully)

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -34,6 +34,13 @@ Updated scripts
 
 Updated Python modules
 
+  coords.resolver
+
+    The identify_name should better handle the case of unknown names
+    or one of the name servers being temporarily down when the
+    ciao-install version of CIAO does not work with the system SSL
+    libraries.
+
   sherpa_contrib.profiles
 
     The module has been updated to account for Sherpa plotting

--- a/share/doc/xml/identify_name.xml
+++ b/share/doc/xml/identify_name.xml
@@ -53,8 +53,8 @@ from coords.resolver import identify_name
 	<SYNTAX>
 	  <LINE>&pr; from coords.resolver import identify_name</LINE>
 	  <LINE>&pr; (ra, dec, csys) = identify_name('sirius')</LINE>
-	  <LINE>&pr; print("RA={} Dec={} system={}".format(ra, dec, csys))</LINE>
-          <LINE>RA=101.28854 Dec=-16.71314 system=ICRS</LINE>
+	  <LINE>&pr; print(f"RA={ra} Dec={dec} system={csys}")</LINE>
+          <LINE>RA=101.2885408 Dec=-16.71314278 system=ICRS</LINE>
 	</SYNTAX>
 	<DESC>
 	  <PARA>
@@ -76,6 +76,15 @@ from coords.resolver import identify_name
       </QEXAMPLE>
 
     </QEXAMPLELIST>
+
+    <ADESC title="Changes in the scripts 4.15.1 (January 2023) release">
+      <PARA>
+	The identify_name should better handle the case of unknown
+	names or one of the name servers being temporarily down when
+	the ciao-install version of CIAO does not work with the system
+	SSL libraries.
+      </PARA>
+    </ADESC>
 
     <ADESC title="Changes in the scripts 4.12.2 (April 2020) release">
       <PARA>
@@ -104,7 +113,7 @@ from coords.resolver import identify_name
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>April 2020</LASTMODIFIED>
+    <LASTMODIFIED>January 2023</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
So, if the SSL library doesn't work for your system then we end up trying an "unverified" SSL context in the URL code. Unfortunately we did not handle that call in the same way we did to the original urlopen call, which could lead to the odd behavior we saw in #703. Even if it didn't, this version should be *slightly* better.