### PR TITLE
fix #572

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -20,7 +20,8 @@ Updated scripts
   convert_xspec_user_model
 
     The script can now be used again with models that do not contain
-    C++ code.
+    C++ code. It will also refuse to run if given a module name that
+    matches any of the model names.
 
   specextract
 

--- a/bin/convert_xspec_user_model
+++ b/bin/convert_xspec_user_model
@@ -67,7 +67,7 @@ for a description of the model.dat format.
 """
 
 toolname = "convert_xspec_user_model"
-toolver  = "04 January 2023"
+toolver  = "06 January 2023"
 
 import sys
 import os
@@ -1565,10 +1565,8 @@ def convert_xspec_user_model(modulename, modelfile,
         #       should this error out?
         lname = mdl.clname.lower()
         if lname == modulename:
-            pstr = f"model class {mdl.clname} has the " + \
-                   "same name as the module, which may cause problems"
-            v1("WARNING: " + pstr)
-            probs.append(pstr)
+            raise ValueError(f"model class {mdl.clname} has the " + \
+                   "same name as the module, which is not allowed")
 
         if lname in known_models:
             pstr = f"model {mdl.name} has the same name as the existing model {lname}"

--- a/share/doc/xml/convert_xspec_user_model.xml
+++ b/share/doc/xml/convert_xspec_user_model.xml
@@ -561,7 +561,9 @@ undefined symbol: _gfortran_copy_string
     <ADESC title="Changes in the scripts 4.15.1 (January 2023) release">
       <PARA>
 	Fix a problem that meant the script could not be used on models
-	that did not include any C++ files.
+	that did not include any C++ files. The script will now also
+	refuse to create a module that matches any of the model names,
+	as that would cause confusion.
       </PARA>
     </ADESC>
 


### PR DESCRIPTION
Rather than warn about a name clash, just refuse to run when the module name matches a model name (after ignoring the case of the model).

Fix #572 