### PR TITLE
srcflux: add link to new plugin thread

### DIFF
--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -2196,6 +2196,11 @@ These include
 detections and count rates for false detections.</ITEM>
 </LIST>
 
+<PARA>
+See the <HREF link="https://cxc.cfa.harvard.edu/ciao/threads/srcflux_plugin/">Using srcflux plugins</HREF> thread
+for a detailed example.
+</PARA>
+
   </ADESC>
 
 


### PR DESCRIPTION
Just add a link to the new thread, now public.
