### PR TITLE
numpy 1.24 fixes

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "08 November 2022"
+version = "22 January 2023"
 
 # import standard python modules as required
 #
@@ -344,14 +344,14 @@ def make_obspar(infile, outfile):
             else:
                 comment = '"{}"'.format(key.desc)
             
-            if isinstance(key.value, (str,np.str)):
+            if isinstance(key.value, (str,)):
                 dtype="s"
                 val='"{}"'.format(val)
-            elif isinstance(key.value, (int,np.integer)):
+            elif isinstance(key.value, (int, np.int64, np.uint64)):
                 dtype="i"
             elif isinstance(key.value, (float,)):
                 dtype="r"
-            elif isinstance(key.value, (bool,np.bool_)):
+            elif isinstance(key.value, (bool, np.bool_)):
                 dtype="b"
                 val = "yes" if key.value else "no"
             else:

--- a/bin/monitor_photom
+++ b/bin/monitor_photom
@@ -26,7 +26,7 @@ import sys
 import ciao_contrib.logger_wrapper as lw
 
 toolname = "monitor_photom"
-__revision__ = "11 June 2019"
+__revision__ = "22 January 2023"
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -102,7 +102,7 @@ def cosmic_ray_removal( dat ):
                 #
                 # Median is taken from current image +/-2 images
                 #
-                samp = np.zeros(5, dtype=np.float)
+                samp = np.zeros(5, dtype=float)
                 n_samp = 0
 
                 for j in plus_minus_two:
@@ -155,9 +155,9 @@ def stack_dark_current_data(dat, img_corr, rc0 ):
     n_r = range(len(r))
 
     # output arrays
-    dark = np.zeros( [n, sz, sz], dtype=np.float)
-    i_dark = np.zeros( [n, sz, sz], dtype=np.long)  # Not used anywhere, keep for now
-    n_dark = np.zeros( [sz, sz], dtype=np.long )
+    dark = np.zeros( [n, sz, sz], dtype=float)
+    i_dark = np.zeros( [n, sz, sz], dtype=np.int32)  # Not used anywhere, keep for now
+    n_dark = np.zeros( [sz, sz], dtype=np.int32 )
 
     verb1("Stacking dark current data...")
     for i in range(n):
@@ -205,7 +205,7 @@ def make_median_dark_current( dat, img_corr, n_dark, dark, pars ):
     verb1( "Average counts  (e-) = {}".format( avg_cts))
     verb1( "Warm dark limit (e-) = {}".format(warm_dark_limit))
 
-    median_dark = np.zeros( [sz, sz], dtype=np.float) - 9999.0
+    median_dark = np.zeros( [sz, sz], dtype=float) - 9999.0
     sz_range = range(sz)
 
     for c0 in sz_range:

--- a/bin/statmap
+++ b/bin/statmap
@@ -28,7 +28,7 @@ from pycrates import read_file
 
 import ciao_contrib.logger_wrapper as lw
 toolname = "statmap"
-__revision__ = "05 July 2022"
+__revision__ = "22 January 2023"
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
 verb0 = lgr.verbose0
@@ -138,7 +138,7 @@ def replace_mapid_with_stats(stat_vals, mapfile):
 
     verb2(f"Reading mapfile '{mapfile}'")
     mapimg = read_file(mapfile).get_image().values.copy()
-    outvals = np.zeros_like(mapimg).astype(np.float)
+    outvals = np.zeros_like(mapimg).astype(float)
 
     unique_pixel_vals = np.unique(mapimg)
     npix = len(unique_pixel_vals)

--- a/ciao_contrib/_tools/aspsol.py
+++ b/ciao_contrib/_tools/aspsol.py
@@ -120,13 +120,13 @@ class AspectSolution(object):
         n_dec = (declim[1] - declim[0]) * 3600.0 / xy
         n_roll = (rollim[1] - rollim[0]) * 3600.0 / roll
 
-        nbins = np.ceil(n_ra * n_dec * n_roll).astype(np.int)
+        nbins = np.ceil(n_ra * n_dec * n_roll).astype(int)
         if nbins <= 10000:
             return 10000
 
         else:
             # would base 2 be better than base 10 here?
-            # l = np.ceil(np.log10(nbins)).astype(np.int)
+            # l = np.ceil(np.log10(nbins)).astype(int)
             # return 10 ** l
-            l = np.ceil(np.log2(nbins)).astype(np.int)
+            l = np.ceil(np.log2(nbins)).astype(int)
             return 2 ** l

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -1188,7 +1188,7 @@ def get_imap_nbins(maxsize, npixels):
     If maxsize < 1, which is valid, then return npixels.
     """
 
-    ms = np.ceil(maxsize).astype(np.int)
+    ms = np.ceil(maxsize).astype(int)
     xs = [i for i in range(ms, 0, -1) if npixels % i == 0]
     if xs == []:
         # We should not be able to get here and hit this situation, but

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -1663,7 +1663,7 @@ def list_observations(instrume, ranom, decnom, obsinfos):
     """
 
     nobs = len(obsinfos)
-    nchar = np.floor(np.log10(nobs)).astype(np.int) + 1
+    nchar = np.floor(np.log10(nobs)).astype(int) + 1
 
     if nobs == 1:
         suffix = ''

--- a/ciao_contrib/region/fov.py
+++ b/ciao_contrib/region/fov.py
@@ -48,7 +48,7 @@ __all__ = (
 # not very robust
 def _is_int(ival):
     "Are we near enough an integer for display purposes?"
-    return np.int(ival) == ival
+    return int(ival) == ival
 
 
 class AxisRange:
@@ -98,7 +98,7 @@ class AxisRange:
 
         # Use an integer if we can
         if _is_int(size):
-            w = np.int(size)
+            w = int(size)
         else:
             w = size
 

--- a/ciao_contrib/smooth.py
+++ b/ciao_contrib/smooth.py
@@ -61,7 +61,7 @@ def mk_gauss(sigma, hwidth):
     if hwidth <= 0:
         raise ValueError("Gaussian hwidth parameter must be > 0, sent {0}".format(hwidth))
 
-    hw = np.int(np.ceil(hwidth * sigma))
+    hw = int(np.ceil(hwidth * sigma))
     if hw == 0:
         kernel = np.ones((1, 1))
 
@@ -86,7 +86,7 @@ def mk_tophat(radius):
     if radius < 0:
         raise ValueError("Top-hat radius parameter must be >= 0, sent {0}".format(radius))
 
-    hw = np.int(np.ceil(radius))
+    hw = int(np.ceil(radius))
     if hw == 0:
         kernel = np.ones((1, 1))
 


### PR DESCRIPTION
Various fixes for numpy deprecation of certain datatypes

`np.int` -> `int`
`np.str` -> `str`
`np.float` -> `float`

Note that `int32`, `int16`, `float32`, `float64`, and `bool_` are OK and left alone.

Running tests now.  Will change from draft when tests are good.

