### PR TITLE
get_dither_parameters: estimate dither parameters from asol file

### DIFF
--- a/bin/get_dither_parameters
+++ b/bin/get_dither_parameters
@@ -29,7 +29,7 @@ import ciao_contrib.logger_wrapper as lw
 from pycrates import read_file
 
 __toolname__ = "get_dither_parameters"
-__revision__ = "08 February 2023"
+__revision__ = "22 February 2023"
 
 lw.initialize_logger(__toolname__)
 verb0 = lw.get_logger(__toolname__).verbose0
@@ -71,7 +71,7 @@ def fold_vals(tmpfile, colname):
               "too short for period folding")
         return np.nan, np.nan
 
-    max_period = min(delta_t, 3000)
+    max_period = min(delta_t, 3500)
     _periods = np.arange(200, max_period)
 
     phase_lo = np.arange(_nphase)/float(_nphase)

--- a/bin/get_dither_parameters
+++ b/bin/get_dither_parameters
@@ -98,12 +98,6 @@ def fold_vals(tmpfile, colname):
 
     max_idx = np.argmax(sig_vals)
 
-    # ~ from crates_contrib.utils import write_columns
-    # ~ write_columns("fold.dat",
-    # ~ _periods, mean_vals, sig_vals,
-    # ~ colnames=["period", "mean", "sigma"],
-    # ~ clobber=True, format="fits")
-
     return range_vals[max_idx]/2.0, _periods[max_idx]
 
 
@@ -185,7 +179,7 @@ def make_dy_dz(infile, tmpdir):
     the mean value and rotate by ROLL.
     """
 
-    def _rotate(ra_vals, dec_vals, dec_pnt, roll_pnt):
+    def _rotate(ra_vals, dec_vals, roll_vals):
         'Rotate ra/dec to dety, detz'
 
         # Subtract off the mean (center around 0)
@@ -193,31 +187,22 @@ def make_dy_dz(infile, tmpdir):
         dec_off = dec_vals - np.mean(dec_vals)
 
         # Scale ra by cos(dec)
-        cos_dec = np.cos(np.deg2rad(dec_pnt))
+        cos_dec = np.cos(np.deg2rad(dec_vals))
         ra_off *= cos_dec
 
         # Rotate ra/dec into dety,detz coordinates
-        cos_roll = np.cos(np.deg2rad(90+roll_pnt))
-        sin_roll = np.sin(np.deg2rad(90+roll_pnt))
+        cos_roll = np.cos(np.deg2rad(90+roll_vals))
+        sin_roll = np.sin(np.deg2rad(90+roll_vals))
         det_z = ra_off * cos_roll + dec_off * sin_roll
         det_y = -ra_off * sin_roll + dec_off * cos_roll
 
         return det_y, det_z
 
-    tab = read_file(infile+"[cols time,ra,dec]")
+    tab = read_file(infile+"[cols time,ra,dec,roll]")
 
     ra_vals = tab.get_column("ra").values
     dec_vals = tab.get_column("dec").values
-
-    roll_pnt = tab.get_key_value("roll_pnt")
-    if roll_pnt == 0.0:
-        # If older asol files, then _pnt are 0.0
-        roll_pnt = tab.get_key_value("roll_nom")
-
-    dec_pnt = tab.get_key_value("dec_pnt")
-    if dec_pnt == 0.0:
-        # If older asol files, then _pnt are 0.0
-        dec_pnt = tab.get_key_value("dec_nom")
+    roll_vals = tab.get_column("roll").values
 
     ontime = tab.get_key_value("TSTOP") - tab.get_key_value("TSTART")
     if ontime < 2000.0:
@@ -226,7 +211,7 @@ def make_dy_dz(infile, tmpdir):
               " 2.0 ksec which may lead to inaccurate dither " +
               "parameter estimates.")
 
-    det_y, det_z = _rotate(ra_vals, dec_vals, dec_pnt, roll_pnt)
+    det_y, det_z = _rotate(ra_vals, dec_vals, roll_vals)
 
     # We go ahead an get amplitude since we have the dety and detz values
     det_y_amp = get_amplitude(det_y)
@@ -235,7 +220,7 @@ def make_dy_dz(infile, tmpdir):
     if det_y_amp > 1.0 or det_z_amp > 1.0:
         # If amplitude it too big, then we've wrapped in ra so fix it.
         ra_vals[ra_vals < 180.0] += 360.0
-        det_y, det_z = _rotate(ra_vals, dec_vals, dec_pnt, roll_pnt)
+        det_y, det_z = _rotate(ra_vals, dec_vals, roll_vals)
 
         det_y_amp = get_amplitude(det_y)
         det_z_amp = get_amplitude(det_z)
@@ -283,11 +268,6 @@ def fft_vals(infile, column, tmpdir):
 
     period = np.zeros_like(freq)
     period[1:] = 1.0/freq[1:]
-
-    # ~ import matplotlib.pylab as plt
-    # ~ plt.plot(period,power)
-    # ~ plt.title(f"{column} plot")
-    # ~ plt.savefig(f"{column}.png")
 
     max_idx = np.argmax(power)
     return period[max_idx]

--- a/bin/get_dither_parameters
+++ b/bin/get_dither_parameters
@@ -1,0 +1,338 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2023 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+'Estimate dither parameters from the aspect solution file'
+
+
+import sys
+import os
+from tempfile import NamedTemporaryFile
+import numpy as np
+import ciao_contrib.logger_wrapper as lw
+from pycrates import read_file
+
+__toolname__ = "get_dither_parameters"
+__revision__ = "08 February 2023"
+
+lw.initialize_logger(__toolname__)
+verb0 = lw.get_logger(__toolname__).verbose0
+verb1 = lw.get_logger(__toolname__).verbose1
+verb2 = lw.get_logger(__toolname__).verbose2
+
+
+def get_amplitude(vals, lo_thresh=0.01, hi_thresh=0.99):
+    """Compute amplitude of dither
+
+    To avoid the dither "tails" we sort the data and
+    omit the bottom and top 1%
+
+    TODO: Maybe make lo/hi tool parameters?
+    """
+    sort_vals = np.sort(vals)
+    nvals = len(sort_vals)
+    q05 = int(lo_thresh*nvals)
+    q95 = int(hi_thresh*nvals)
+    peak_to_peak = sort_vals[q95] - sort_vals[q05]
+    amplitude = peak_to_peak/2.0
+    return amplitude
+
+
+def fold_vals(tmpfile, colname):
+    "Use period folding technique"
+
+    _nphase = 10  # Number of phase bins (kinda arbitrary)
+
+    tab = read_file(tmpfile)
+    time_vals = tab.get_column("time").values
+    detxy_vals = tab.get_column(colname).values
+
+    delta_t = tab.get_key_value("TSTOP") - tab.get_key_value("TSTART")
+    delta_t = int(delta_t)
+
+    if delta_t < 200:
+        verb0(f"Input file only covers {delta_t} seconds and is " +
+              "too short for period folding")
+        return np.nan, np.nan
+
+    max_period = min(delta_t, 3000)
+    _periods = np.arange(200, max_period)
+
+    phase_lo = np.arange(_nphase)/float(_nphase)
+    phase_hi = (1.0+np.arange(_nphase))/_nphase
+
+    mean_vals = []
+    sig_vals = []
+    range_vals = []
+    phase_array = np.zeros(_nphase)
+
+    for period in _periods:
+        phase_vals, _ = np.modf(time_vals/period)
+
+        for phase_bin in range(_nphase):
+            lo = phase_lo[phase_bin]
+            hi = phase_hi[phase_bin]
+            idx, = np.where(np.logical_and(phase_vals >= lo,
+                                           phase_vals < hi))
+            phase_array[phase_bin] = np.mean(detxy_vals[idx])
+
+        mean_vals.append(np.mean(phase_array))
+        sig_vals.append(np.std(phase_array))
+        range_vals.append(np.max(phase_array)-np.min(phase_array))
+
+    max_idx = np.argmax(sig_vals)
+
+    # ~ from crates_contrib.utils import write_columns
+    # ~ write_columns("fold.dat",
+    # ~ _periods, mean_vals, sig_vals,
+    # ~ colnames=["period", "mean", "sigma"],
+    # ~ clobber=True, format="fits")
+
+    return range_vals[max_idx]/2.0, _periods[max_idx]
+
+
+def fit_vals(tmpfile, colname):
+    """Fit the dety|detz values with a cosine+constant"""
+
+    from sherpa.astro.ui import load_arrays, set_staterror, set_stat
+    from sherpa.astro.ui import set_source, set_method, fit, freeze
+    from sherpa.utils.logging import SherpaVerbosity
+    from sherpa import models
+
+    verb1(f"Fitting for {colname}")
+
+    tab = read_file(tmpfile)
+    time_vals = tab.get_column("time").values*1.0  # make a copy
+    time_vals -= time_vals[0]
+    time_vals /= 1000.0   # ksec, cosine hard max of '10'
+
+    detxy = tab.get_column(colname).values
+
+    load_arrays(1, time_vals, detxy)
+
+    errs = np.zeros_like(detxy)+0.001
+    set_staterror(1, errs)
+    set_stat("leastsq")
+
+    wave = models.Cos('wave')
+    offset = models.Const1D('offset')
+
+    # Technically constant term is not needed because we freeze the
+    # value at 0, but left here incase we decide we want to
+    # thaw it at any point.
+    set_source(wave + offset)
+
+    # Sensible defaults for many observations
+    offset.c0 = 0
+    wave.ampl = 0.002
+    wave.period = 1.0
+
+    wave.ampl.min = 0.00001
+    wave.ampl.max = 0.01
+    wave.period.min = 0.1
+    wave.period.max = 3
+    wave.offset.min = 0
+    wave.offset.max = 3
+
+    freeze(offset.c0)
+
+    set_method("neldermead")
+    with SherpaVerbosity("WARN"):
+        fit()
+
+        # In testing we found when fit goes "bad", the amplitude
+        # becomes unrealistically small.  So check the amplitude
+        # and if too small, then try fit again.
+
+        if wave.ampl.val < 0.5*(max(detxy)-min(detxy))/2.0:
+            # If we have a bad fit, try again w/ different default
+            # period
+            verb1("Trying with different default period")
+            wave.period = 0.707
+            wave.ampl = 0.002
+            fit()
+
+        if wave.ampl.val < 0.5*(max(detxy)-min(detxy))/2.0:
+            # If we have a bad fit, try again w/ different
+            # fit method.
+            verb1("Trying with moncar")
+            wave.period = 0.707
+            wave.ampl = 0.002
+            set_method("moncar")
+            fit()
+
+    return wave.ampl.val, wave.period.val*1000.0
+
+
+def make_dy_dz(infile, tmpdir):
+    """Convert ra/dec into a detector-ish coordinates. Subtract off
+    the mean value and rotate by ROLL.
+    """
+
+    def _rotate(ra_vals, dec_vals, dec_pnt, roll_pnt):
+        'Rotate ra/dec to dety, detz'
+
+        # Subtract off the mean (center around 0)
+        ra_off = ra_vals - np.mean(ra_vals)
+        dec_off = dec_vals - np.mean(dec_vals)
+
+        # Scale ra by cos(dec)
+        cos_dec = np.cos(np.deg2rad(dec_pnt))
+        ra_off *= cos_dec
+
+        # Rotate ra/dec into dety,detz coordinates
+        cos_roll = np.cos(np.deg2rad(90+roll_pnt))
+        sin_roll = np.sin(np.deg2rad(90+roll_pnt))
+        det_z = ra_off * cos_roll + dec_off * sin_roll
+        det_y = -ra_off * sin_roll + dec_off * cos_roll
+
+        return det_y, det_z
+
+    tab = read_file(infile+"[cols time,ra,dec]")
+
+    ra_vals = tab.get_column("ra").values
+    dec_vals = tab.get_column("dec").values
+
+    roll_pnt = tab.get_key_value("roll_pnt")
+    if roll_pnt == 0.0:
+        # If older asol files, then _pnt are 0.0
+        roll_pnt = tab.get_key_value("roll_nom")
+
+    dec_pnt = tab.get_key_value("dec_pnt")
+    if dec_pnt == 0.0:
+        # If older asol files, then _pnt are 0.0
+        dec_pnt = tab.get_key_value("dec_nom")
+
+    ontime = tab.get_key_value("TSTOP") - tab.get_key_value("TSTART")
+    if ontime < 2000.0:
+        # If less than 2ksec, then FFTs become less useful
+        verb0(f"WARNING: ONTIME={ontime/1000.0:.4g} ksec is less than" +
+              " 2.0 ksec which may lead to inaccurate dither " +
+              "parameter estimates.")
+
+    det_y, det_z = _rotate(ra_vals, dec_vals, dec_pnt, roll_pnt)
+
+    # We go ahead an get amplitude since we have the dety and detz values
+    det_y_amp = get_amplitude(det_y)
+    det_z_amp = get_amplitude(det_z)
+
+    if det_y_amp > 1.0 or det_z_amp > 1.0:
+        # If amplitude it too big, then we've wrapped in ra so fix it.
+        ra_vals[ra_vals < 180.0] += 360.0
+        det_y, det_z = _rotate(ra_vals, dec_vals, dec_pnt, roll_pnt)
+
+        det_y_amp = get_amplitude(det_y)
+        det_z_amp = get_amplitude(det_z)
+
+    # Write values
+    from crates_contrib.utils import add_colvals
+    add_colvals(tab, "det_y", det_y, desc="pseudo dety coordinate")
+    add_colvals(tab, "det_z", det_z, desc="pseudo detz coordinate")
+
+    tmpfile = NamedTemporaryFile(dir=tmpdir, suffix="_dydz.fits",
+                                 delete=False)
+    tmpfile.close()
+    tmpfile = tmpfile.name
+    tab.write(tmpfile, clobber=True)
+
+    return tmpfile, det_y_amp, det_z_amp
+
+
+def fft_vals(infile, column, tmpdir):
+    """Determine the dither frequency
+
+    We find the frequency by taking the powerspectrum of the
+    DET coordinates.  In this rotated reference frame, there should only
+    be 1 strong frequency (as opposed to doing in RA|Dec where we would see
+    both frequencies (unless ROLL is ~n*90 degrees).
+
+    We also need to allow for case of finding no significant frequencies
+    """
+
+    from ciao_contrib.runtool import make_tool
+
+    _tmpfile = NamedTemporaryFile(dir=tmpdir, suffix="_power.fits",
+                                  delete=False)
+    _tmpfile.close()
+    _tmpfile = _tmpfile.name
+    apowerspectrum = make_tool("apowerspectrum")
+    apowerspectrum(f"{infile}[cols time,{column}]", "", _tmpfile,
+                   clobber=True, crop=True)
+
+    tab = read_file(_tmpfile)
+    freq = tab.get_column("frequency").values
+    power = tab.get_column("data").values
+    del tab
+    os.unlink(_tmpfile)
+
+    period = np.zeros_like(freq)
+    period[1:] = 1.0/freq[1:]
+
+    # ~ import matplotlib.pylab as plt
+    # ~ plt.plot(period,power)
+    # ~ plt.title(f"{column} plot")
+    # ~ plt.savefig(f"{column}.png")
+
+    max_idx = np.argmax(power)
+    return period[max_idx]
+
+
+@lw.handle_ciao_errors(__toolname__, __revision__)
+def doit():
+    'Main routine'
+
+    from ciao_contrib.param_soaker import get_params
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
+
+    tmpfile, det_y_amp, det_z_amp = make_dy_dz(pars["infile"],
+                                               pars["tmpdir"])
+
+    if pars["method"] == "fft":
+        dety_period = fft_vals(tmpfile, "det_y", pars["tmpdir"])
+        detz_period = fft_vals(tmpfile, "det_z", pars["tmpdir"])
+    elif pars["method"] == "fit":
+        det_y_amp, dety_period = fit_vals(tmpfile, "det_y")
+        det_z_amp, detz_period = fit_vals(tmpfile, "det_z")
+    elif pars["method"] == "fold":
+        det_y_amp, dety_period = fold_vals(tmpfile, "det_y")
+        det_z_amp, detz_period = fold_vals(tmpfile, "det_z")
+    else:
+        raise ValueError(f"Unknown value for method={pars['method']}")
+
+    os.unlink(tmpfile)
+
+    from ciao_contrib.param_wrapper import open_param_file as opf
+    import paramio as pio
+
+    pfile = opf(sys.argv, toolname=__toolname__)["fp"]
+    pio.pputd(pfile, "dety_amplitude", det_y_amp)
+    pio.pputd(pfile, "detz_amplitude", det_z_amp)
+    pio.pputd(pfile, "dety_period", dety_period)
+    pio.pputd(pfile, "detz_period", detz_period)
+    pio.paramclose(pfile)
+
+    verb1("Results:")
+    verb1("\tAmplitude [deg]\tPeriod [cycle/sec]")
+    verb1(f"DETY\t{det_y_amp:.6g}\t{dety_period:.3f}")
+    verb1(f"DETZ\t{det_z_amp:.6g}\t{detz_period:.3f}")
+
+
+if __name__ == '__main__':
+    doit()

--- a/bin/get_dither_parameters
+++ b/bin/get_dither_parameters
@@ -29,7 +29,7 @@ import ciao_contrib.logger_wrapper as lw
 from pycrates import read_file
 
 __toolname__ = "get_dither_parameters"
-__revision__ = "22 February 2023"
+__revision__ = "24 February 2023"
 
 lw.initialize_logger(__toolname__)
 verb0 = lw.get_logger(__toolname__).verbose0
@@ -296,6 +296,9 @@ def doit():
     else:
         raise ValueError(f"Unknown value for method={pars['method']}")
 
+    det_y_amp *= 3600.0   # convert to arcsec
+    det_z_amp *= 3600.0
+
     os.unlink(tmpfile)
 
     from ciao_contrib.param_wrapper import open_param_file as opf
@@ -309,9 +312,10 @@ def doit():
     pio.paramclose(pfile)
 
     verb1("Results:")
-    verb1("\tAmplitude [deg]\tPeriod [cycle/sec]")
-    verb1(f"DETY\t{det_y_amp:.6g}\t{dety_period:.3f}")
-    verb1(f"DETZ\t{det_z_amp:.6g}\t{detz_period:.3f}")
+    verb1("\tAmplitude\tPeriod")
+    verb1("\t[arcsec]\t[sec]")
+    verb1(f"DETY\t{det_y_amp:.3f}\t\t{dety_period:.3f}")
+    verb1(f"DETZ\t{det_z_amp:.3f}\t\t{detz_period:.3f}")
 
 
 if __name__ == '__main__':

--- a/ciao_contrib/runtool.py
+++ b/ciao_contrib/runtool.py
@@ -3199,6 +3199,13 @@ parinfo['geom'] = {
     }
 
 
+parinfo['get_dither_parameters'] = {
+    'istool': True,
+    'req': [ParValue("infile","f","Input aspect solution file",None)],
+    'opt': [ParSet("method","s","Method to estimate dither parameters",'fold',["fold","fit","fft"]),ParValue("dety_amplitude","r","Amplitude in DETY direction [deg]",None),ParValue("detz_amplitude","r","Amplitude in the DETZ direction [deg]",None),ParValue("dety_period","r","Period in DETY direction [cycle/sec]",None),ParValue("detz_period","r","Period in DETZ direction [cycle/sec]",None),ParValue("tmpdir","s","Directory for temporary files",'${ASCDS_WORK_PATH}'),ParRange("verbose","i","Amount of tool chatter",1,0,5)],
+    }
+
+
 parinfo['get_fov_limits'] = {
     'istool': True,
     'req': [ParValue("infile","f","The FOV file to use",None)],

--- a/ciao_contrib/runtool.py
+++ b/ciao_contrib/runtool.py
@@ -3202,7 +3202,7 @@ parinfo['geom'] = {
 parinfo['get_dither_parameters'] = {
     'istool': True,
     'req': [ParValue("infile","f","Input aspect solution file",None)],
-    'opt': [ParSet("method","s","Method to estimate dither parameters",'fold',["fold","fit","fft"]),ParValue("dety_amplitude","r","Amplitude in DETY direction [deg]",None),ParValue("detz_amplitude","r","Amplitude in the DETZ direction [deg]",None),ParValue("dety_period","r","Period in DETY direction [cycle/sec]",None),ParValue("detz_period","r","Period in DETZ direction [cycle/sec]",None),ParValue("tmpdir","s","Directory for temporary files",'${ASCDS_WORK_PATH}'),ParRange("verbose","i","Amount of tool chatter",1,0,5)],
+    'opt': [ParSet("method","s","Method to estimate dither parameters",'fold',["fold","fit","fft"]),ParValue("dety_amplitude","r","Amplitude in DETY direction [arcsec]",None),ParValue("detz_amplitude","r","Amplitude in the DETZ direction [arcsec]",None),ParValue("dety_period","r","Period in DETY direction [sec]",None),ParValue("detz_period","r","Period in DETZ direction [sec]",None),ParValue("tmpdir","s","Directory for temporary files",'${ASCDS_WORK_PATH}'),ParRange("verbose","i","Amount of tool chatter",1,0,5)],
     }
 
 

--- a/param/get_dither_parameters.par
+++ b/param/get_dither_parameters.par
@@ -1,0 +1,9 @@
+infile,f,a,"",,,"Input aspect solution file"
+method,s,h,"fold",fold|fit|fft,,"Method to estimate dither parameters"
+dety_amplitude,r,hl,,,,"Amplitude in DETY direction [deg]"
+detz_amplitude,r,hl,,,,"Amplitude in the DETZ direction [deg]"
+dety_period,r,hl,,,,"Period in DETY direction [cycle/sec]"
+detz_period,r,hl,,,,"Period in DETZ direction [cycle/sec]"
+tmpdir,s,h,"${ASCDS_WORK_PATH}",,,"Directory for temporary files"
+verbose,i,h,1,0,5,"Amount of tool chatter"
+mode,s,h,"ql",,,

--- a/param/get_dither_parameters.par
+++ b/param/get_dither_parameters.par
@@ -1,9 +1,9 @@
 infile,f,a,"",,,"Input aspect solution file"
 method,s,h,"fold",fold|fit|fft,,"Method to estimate dither parameters"
-dety_amplitude,r,hl,,,,"Amplitude in DETY direction [deg]"
-detz_amplitude,r,hl,,,,"Amplitude in the DETZ direction [deg]"
-dety_period,r,hl,,,,"Period in DETY direction [cycle/sec]"
-detz_period,r,hl,,,,"Period in DETZ direction [cycle/sec]"
+dety_amplitude,r,hl,,,,"Amplitude in DETY direction [arcsec]"
+detz_amplitude,r,hl,,,,"Amplitude in the DETZ direction [arcsec]"
+dety_period,r,hl,,,,"Period in DETY direction [sec]"
+detz_period,r,hl,,,,"Period in DETZ direction [sec]"
 tmpdir,s,h,"${ASCDS_WORK_PATH}",,,"Directory for temporary files"
 verbose,i,h,1,0,5,"Amount of tool chatter"
 mode,s,h,"ql",,,

--- a/share/doc/xml/get_dither_parameters.xml
+++ b/share/doc/xml/get_dither_parameters.xml
@@ -473,14 +473,14 @@ Finally, method=fft is by far the fastest method, but also the less precise.
 
     <PARA title="method=fold">
       The default method=fold algorithm works by period-folding the
-      TIME values over the range from 200 to 3000 second periods.  
+      TIME values over the range from 200 to 3500 second periods.  
       For each period, the DET_Y and DET_Z values are split up into
       10 phase bins and the mean DET_Y and DET_Z values is computed.
       The period with the maximum standard deviation of the phase bins
       is the estimated period in each direction.  The amplitude is
       one-half of the peak-to-peak min/max in the phase bins at that
       period.  The period search is skipped if the aspect solution file
-      is less than 200 seconds.  If the aspect solution is less than 3000 
+      is less than 200 seconds.  If the aspect solution is less than 3500 
       seconds, then the period search is limited to the duration
       of the aspect solution file.  Testing has shown this to be
       the most robust algorithm with moderate run-time.

--- a/share/doc/xml/get_dither_parameters.xml
+++ b/share/doc/xml/get_dither_parameters.xml
@@ -130,9 +130,10 @@ get_dither_parameters
             mode = ql
 
 Results:
-        Amplitude [deg] Period [cycle/sec]
-DETY    0.00222333      1000.000
-DETZ    0.00219419      708.000
+        Amplitude       Period
+        [arcsec]        [sec]
+DETY    8.004           1000.000
+DETZ    7.899           708.000
 </VERBATIM>
 
 <PARA>
@@ -148,10 +149,10 @@ Parameters for /home/user/cxcds_param4/get_dither_parameters.par
 
         infile = pcadf04425_000N001_asol1.fits.gz Input aspect solution file
        (method = fft)             Method to estimate dither parameters
-(dety_amplitude = 0.002223326988110537) Amplitude in DETY direction [deg]
-(detz_amplitude = 0.002194189232537938) Amplitude in the DETZ direction [deg]
-  (dety_period = 1000)            Period in DETY direction [cycle/sec]
-  (detz_period = 708)             Period in DETZ direction [cycle/sec]
+(dety_amplitude = 8.00398436876533) Amplitude in DETY direction [arcsec]
+(detz_amplitude = 7.899064790088977) Amplitude in the DETZ direction [arcsec]
+  (dety_period = 1000)            Period in DETY direction [sec]
+  (detz_period = 708)             Period in DETZ direction [sec]
        (tmpdir = ${ASCDS_WORK_PATH} -> /tmp) Directory for temporary files
       (verbose = 1)               Amount of tool chatter
          (mode = ql)              
@@ -185,9 +186,10 @@ get_dither_parameters
             mode = ql
 
 Results:
-        Amplitude [deg] Period [cycle/sec]
-DETY    0.00526569      1087.000
-DETZ    0.00544279      768.000
+        Amplitude       Period
+        [arcsec]        [sec]
+DETY    18.957          1087.000
+DETZ    19.594          768.000
 </VERBATIM>
         </DESC>
       </QEXAMPLE>
@@ -223,9 +225,10 @@ get_dither_parameters
             mode = ql
 
 Results:
-        Amplitude [deg] Period [cycle/sec]
-DETY    0.00109307      1001.000
-DETZ    0.00104274      708.000
+        Amplitude       Period
+        [arcsec]        [sec]
+DETY    3.935           1001.000
+DETZ    3.754           708.000
 </VERBATIM>
 
 <PARA>
@@ -262,9 +265,10 @@ get_dither_parameters
             mode = ql
 
 Results:
-        Amplitude [deg] Period [cycle/sec]
-DETY    4.3009e-06      2054.000
-DETZ    5.97107e-06     2769.000
+        Amplitude       Period
+        [arcsec]        [sec]
+DETY    0.015           2054.000
+DETZ    0.021           2769.000
 </VERBATIM>
 
 <PARA>
@@ -290,7 +294,7 @@ disabled and the values reported here are essentially noise.
 The calibration team will sometimes plan observations with non-standard
 dither patterns to maximize exposure of the calibration source over
 a large part of the detector to optimize the amount of calibration
-data they require.  This is a grating observation using the so-called "Big Dither"
+data they acquire.  This is a grating observation using the so-called "Big Dither"
 pattern; typical dither parameters have equal amplitude in DET_Y and DET_Z
 directions, thus making a square Lissajous pattern; these observations
 have a much larger dither amplitude in one-direction resulting in a
@@ -309,9 +313,10 @@ get_dither_parameters
             mode = ql
 
 Results:
-        Amplitude [deg] Period [cycle/sec]
-DETY    0.00218094      1000.000
-DETZ    0.0173028       2653.000
+        Amplitude       Period
+        [arcsec]        [sec]
+DETY    7.852           1000.000
+DETZ    62.290          2653.000
 </VERBATIM>
 
 <PARA>
@@ -343,32 +348,32 @@ Here the DET_Z axis is much larger than DETY.
   <CAPTION>Example of different estimation methods</CAPTION>
   <ROW>
     <DATA>method</DATA>
-    <DATA>DET_Y_Amp [deg]</DATA>
-    <DATA>DET_Z Amp [deg]</DATA>
+    <DATA>DET_Y_Amp [arcsec]</DATA>
+    <DATA>DET_Z Amp [arcsec]</DATA>
     <DATA>DET_Y Period [sec]</DATA>
     <DATA>DET_Z Period [sec]</DATA>
     <DATA>Run time [sec]</DATA>
   </ROW>
   <ROW>
     <DATA>fold</DATA>
-    <DATA>0.002223</DATA>
-    <DATA>0.002194</DATA>
+    <DATA>8.004</DATA>
+    <DATA>7.899</DATA>
     <DATA>1000</DATA>
     <DATA>708</DATA>
     <DATA>25.26</DATA>
   </ROW>
   <ROW>
     <DATA>fit</DATA>
-    <DATA>0.002259</DATA>
-    <DATA>0.002224</DATA>
+    <DATA>8.136</DATA>
+    <DATA>8.009</DATA>
     <DATA>1000.13</DATA>
     <DATA>707.66</DATA>
     <DATA>31.91</DATA>
   </ROW>
   <ROW>
     <DATA>fft</DATA>
-    <DATA>0.002334</DATA>
-    <DATA>0.002369</DATA>
+    <DATA>8.405</DATA>
+    <DATA>8.530</DATA>
     <DATA>1004.35</DATA>
     <DATA>704.80</DATA>
     <DATA>1.83</DATA>
@@ -428,11 +433,11 @@ Finally, method=fft is by far the fastest method, but also the less precise.
       
       </PARAM>
 
-      <PARAM name="dety_amplitude" type="real" def="" units="deg">
-        <SYNOPSIS>The estimated amplitude in the DET_Y direction in units of degrees</SYNOPSIS>
+      <PARAM name="dety_amplitude" type="real" def="" units="arcsec">
+        <SYNOPSIS>The estimated amplitude in the DET_Y direction in units of arcseconds</SYNOPSIS>
       </PARAM>
-      <PARAM name="detz_amplitude" type="real" def="" units="deg">
-        <SYNOPSIS>The estimated amplitude in the DET_Z direction in units of degrees</SYNOPSIS>
+      <PARAM name="detz_amplitude" type="real" def="" units="arcsec">
+        <SYNOPSIS>The estimated amplitude in the DET_Z direction in units of arcseconds</SYNOPSIS>
       </PARAM>
       <PARAM name="dety_period" type="real" def="" units="sec">
         <SYNOPSIS>The estimated period in the DET_Y direction in units of seconds</SYNOPSIS>

--- a/share/doc/xml/get_dither_parameters.xml
+++ b/share/doc/xml/get_dither_parameters.xml
@@ -25,10 +25,10 @@
       </PARA>
       <PARA>
         Most observations use the default dither parameters.  Prior to
-        September 2022 (TBR), the defaults were
+        October 2022, the defaults were
       </PARA>
       <TABLE>
-        <CAPTION>Default dither parameter prior to September 2022</CAPTION>
+        <CAPTION>Default dither parameter prior to October 2022</CAPTION>
         <ROW>
             <DATA>Instrument</DATA>
             <DATA>DET_Y Amp [deg]</DATA>
@@ -41,22 +41,22 @@
           <DATA>0.0022</DATA>
           <DATA>0.0022</DATA>
           <DATA>1000</DATA>
-          <DATA>707</DATA>
+          <DATA>707.1</DATA>
         </ROW>
         <ROW>
           <DATA>HRC</DATA>
-          <DATA>0.0022</DATA>
-          <DATA>0.0022</DATA>
-          <DATA>1000</DATA>
-          <DATA>707</DATA>
+          <DATA>0.00556</DATA>
+          <DATA>0.00556</DATA>
+          <DATA>1087</DATA>
+          <DATA>768.6</DATA>
         </ROW>      
       </TABLE>
   <PARA>
-  After September 2022, the default amplitude and dither were
+  As of October 2022, the default amplitude and dither for ACIS were
   doubled to allow for improved star tracking by the aspect camera.
   </PARA>
       <TABLE>
-        <CAPTION>Default dither parameter after to September 2022</CAPTION>
+        <CAPTION>Default dither parameter as of October 2022</CAPTION>
         <ROW>
             <DATA>Instrument</DATA>
             <DATA>DET_Y Amp [deg]</DATA>
@@ -73,16 +73,15 @@
         </ROW>
         <ROW>
           <DATA>HRC</DATA>
-          <DATA>0.0022</DATA>
-          <DATA>0.0022</DATA>
-          <DATA>1000</DATA>
-          <DATA>707</DATA>
+          <DATA>0.00556</DATA>
+          <DATA>0.00556</DATA>
+          <DATA>1087</DATA>
+          <DATA>768.6</DATA>
         </ROW>      
       </TABLE>
 
     <PARA>
-    However, prior to Observation cycle 24, users could request 
-    different dither parameters.  This was done most notably
+    However observers can request custom dither parameters.  This was done most notably
     for the various of Crab observations.  In addition some calibration 
     observations use non-standard dither patterns to improve 
     detector coverage.  There are also some anomalies where dither
@@ -90,15 +89,15 @@
     </PARA>
 
     <PARA>
-    At verbose=1 and higher the estimated dither parameters are 
-    printed to the terminal.  In addition the parameter values
-    are stored in the tools own parameter file.
+    The estimated dither parameter values are stored in the tool's own 
+    parameter file. In addition, at verbose=1 and higher the estimated 
+    dither parameters are printed to the terminal.  
     </PARA>
     
     <PARA title="Note on detector coordinates">
       Dither is defined in spacecraft, ie detector coordinates.
       DET_Z is in the direction of the SIM motion; that is the axis 
-      upon which the SIM moves to select the different instrument.
+      upon which the SIM moves to select the different instruments.
       DET_Y is moving side-to-side in the detector plane.  DET_X is 
       in the direction of the mirrors.    
     </PARA>

--- a/share/doc/xml/get_dither_parameters.xml
+++ b/share/doc/xml/get_dither_parameters.xml
@@ -1,0 +1,525 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+  <ENTRY context="Tools::Aspect" 
+    key="get_dither_parameters" 
+    refkeywords="dither aspect solution asol amplitude frequency period" 
+    seealsogroups="aspecttools timingtools">
+    <SYNOPSIS>
+        Determine the approximate dither period and amplitude used during an observation.
+    </SYNOPSIS>
+    <DESC>
+      <PARA>
+          `get_dither_parameters' uses the aspect solution file to 
+          determine the approximate dither parameters: period and
+          amplitude, used during an observation.  The actual values
+          are not computed and the planned values are not
+          stored in the data products; the planned values are
+          only available from the 
+          <HREF link="https://cda.harvard.edu/chaser/">Chaser</HREF>
+          Details page.          
+          Users doing timing analysis 
+          may need to know the dither parameters to understand if the 
+          timing signature they detect is instrumental or intrinsic to
+          the source.
+      </PARA>
+      <PARA>
+        Most observations use the default dither parameters.  Prior to
+        September 2022 (TBR), the defaults were
+      </PARA>
+      <TABLE>
+        <CAPTION>Default dither parameter prior to September 2022</CAPTION>
+        <ROW>
+            <DATA>Instrument</DATA>
+            <DATA>DET_Y Amp [deg]</DATA>
+            <DATA>DET_Z Amp [deg]</DATA>
+            <DATA>DET_Y Period [sec]</DATA>
+            <DATA>DET_Z Period [sec]</DATA>
+        </ROW>
+        <ROW>
+          <DATA>ACIS</DATA>
+          <DATA>0.0022</DATA>
+          <DATA>0.0022</DATA>
+          <DATA>1000</DATA>
+          <DATA>707</DATA>
+        </ROW>
+        <ROW>
+          <DATA>HRC</DATA>
+          <DATA>0.0022</DATA>
+          <DATA>0.0022</DATA>
+          <DATA>1000</DATA>
+          <DATA>707</DATA>
+        </ROW>      
+      </TABLE>
+  <PARA>
+  After September 2022, the default amplitude and dither were
+  doubled to allow for improved star tracking by the aspect camera.
+  </PARA>
+      <TABLE>
+        <CAPTION>Default dither parameter after to September 2022</CAPTION>
+        <ROW>
+            <DATA>Instrument</DATA>
+            <DATA>DET_Y Amp [deg]</DATA>
+            <DATA>DET_Z Amp [deg]</DATA>
+            <DATA>DET_Y Period [sec]</DATA>
+            <DATA>DET_Z Period [sec]</DATA>
+        </ROW>
+        <ROW>
+          <DATA>ACIS</DATA>
+          <DATA>0.0044</DATA>
+          <DATA>0.0044</DATA>
+          <DATA>2000</DATA>
+          <DATA>1414</DATA>
+        </ROW>
+        <ROW>
+          <DATA>HRC</DATA>
+          <DATA>0.0022</DATA>
+          <DATA>0.0022</DATA>
+          <DATA>1000</DATA>
+          <DATA>707</DATA>
+        </ROW>      
+      </TABLE>
+
+    <PARA>
+    However, prior to Observation cycle 24, users could request 
+    different dither parameters.  This was done most notably
+    for the various of Crab observations.  In addition some calibration 
+    observations use non-standard dither patterns to improve 
+    detector coverage.  There are also some anomalies where dither
+    was mistaken not enabled during a small number of observations.
+    </PARA>
+
+    <PARA>
+    At verbose=1 and higher the estimated dither parameters are 
+    printed to the terminal.  In addition the parameter values
+    are stored in the tools own parameter file.
+    </PARA>
+    
+    <PARA title="Note on detector coordinates">
+      Dither is defined in spacecraft, ie detector coordinates.
+      DET_Z is in the direction of the SIM motion; that is the axis 
+      upon which the SIM moves to select the different instrument.
+      DET_Y is moving side-to-side in the detector plane.  DET_X is 
+      in the direction of the mirrors.    
+    </PARA>
+
+
+    </DESC>
+    <QEXAMPLELIST>
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% get_dither_parameters pcadf04425_000N001_asol1.fits.gz method=fold
+        </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+              This is an example of an ACIS observations that used
+              the default, standard dither parameters.  The results are
+              printed to the screen:  
+          </PARA>
+<VERBATIM>
+get_dither_parameters
+          infile = pcadf04425_000N001_asol1.fits.gz
+          method = fold
+  dety_amplitude = 0
+  detz_amplitude = 0
+     dety_period = 0
+     detz_period = 0
+          tmpdir = /tmp
+         verbose = 1
+            mode = ql
+
+Results:
+        Amplitude [deg] Period [cycle/sec]
+DETY    0.00222333      1000.000
+DETZ    0.00219419      708.000
+</VERBATIM>
+
+<PARA>
+The tool also stores the outputs back into its own parameter file.  These
+can be retrieved using any of the standard parameter file tools such
+as plist, pget, or pdump:
+</PARA>
+
+<VERBATIM>
+% plist get_dither_parameters
+
+Parameters for /home/user/cxcds_param4/get_dither_parameters.par
+
+        infile = pcadf04425_000N001_asol1.fits.gz Input aspect solution file
+       (method = fft)             Method to estimate dither parameters
+(dety_amplitude = 0.002223326988110537) Amplitude in DETY direction [deg]
+(detz_amplitude = 0.002194189232537938) Amplitude in the DETZ direction [deg]
+  (dety_period = 1000)            Period in DETY direction [cycle/sec]
+  (detz_period = 708)             Period in DETZ direction [cycle/sec]
+       (tmpdir = ${ASCDS_WORK_PATH} -> /tmp) Directory for temporary files
+      (verbose = 1)               Amount of tool chatter
+         (mode = ql)              
+</VERBATIM>
+
+        </DESC>
+      </QEXAMPLE>
+
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% get_dither_parameters pcadf08908_000N001_asol1.fits.gz meth=fold
+        </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+This is an example of an HRC observation that used the standard dither
+parameters.  The terminal output looks like:
+          </PARA>
+<VERBATIM>
+get_dither_parameters
+          infile = pcadf08908_000N001_asol1.fits.gz
+          method = fold
+  dety_amplitude = 0
+  detz_amplitude = 0
+     dety_period = 0
+     detz_period = 0
+          tmpdir = /tmp
+         verbose = 1
+            mode = ql
+
+Results:
+        Amplitude [deg] Period [cycle/sec]
+DETY    0.00526569      1087.000
+DETZ    0.00544279      768.000
+</VERBATIM>
+        </DESC>
+      </QEXAMPLE>
+
+
+
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% get_dither_parameters pcadf05555_001N001_asol1.fits.gz meth=fold
+        </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+              This is an observation of the Crab nebula.  The 
+              observer chose to reduce the size of the dither pattern;
+              they also used a sub-array and a custom window to reduce
+              the size of the field of view (to reduce readout time
+              and lessen telemetry saturation).  The output for this 
+              observation looks like
+          </PARA>
+<VERBATIM>
+get_dither_parameters
+          infile = pcadf05555_001N001_asol1.fits.gz
+          method = fold
+  dety_amplitude = 0
+  detz_amplitude = 0
+     dety_period = 0
+     detz_period = 0
+          tmpdir = /tmp
+         verbose = 1
+            mode = ql
+
+Results:
+        Amplitude [deg] Period [cycle/sec]
+DETY    0.00109307      1001.000
+DETZ    0.00104274      708.000
+</VERBATIM>
+
+<PARA>
+  In this case the dither period remained the same as the default values
+  but the amplitudes where reduced to 5% of the default values.
+</PARA>
+
+        </DESC>
+      </QEXAMPLE>
+
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% get_dither_parameters pcadf03832_002N001_asol1.fits.gz me=fold
+        </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+This observation was planned to use the standard dither parameters, however
+there was an error in planning/commanding that actually disabled dither.
+The output looks like:              
+          </PARA>
+<VERBATIM>
+get_dither_parameters
+          infile = pcadf03832_002N001_asol1.fits.gz
+          method = fold
+  dety_amplitude = 0
+  detz_amplitude = 0
+     dety_period = 0
+     detz_period = 0
+          tmpdir = /tmp
+         verbose = 1
+            mode = ql
+
+Results:
+        Amplitude [deg] Period [cycle/sec]
+DETY    4.3009e-06      2054.000
+DETZ    5.97107e-06     2769.000
+</VERBATIM>
+
+<PARA>
+The amplitude values are tiny (typical values are on the order of 10 arcsec)
+and the periods are much longer than what is shown as planned in
+Chaser.
+</PARA>
+<PARA>
+Consulting the V&amp;V report we read that in fact dither had been 
+disabled and the values reported here are essentially noise.
+</PARA>
+
+        </DESC>
+      </QEXAMPLE>
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% get_dither_parameters pcadf18840_000N001_asol1.fits.gz met=fold
+        </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+The calibration team will sometimes plan observations with non-standard
+dither patterns to maximize exposure of the calibration source over
+a large part of the detector to optimize the amount of calibration
+data they require.  This is a grating observation using the so-called "Big Dither"
+pattern; typical dither parameters have equal amplitude in DET_Y and DET_Z
+directions, thus making a square Lissajous pattern; these observations
+have a much larger dither amplitude in one-direction resulting in a
+rectangular pattern.
+          </PARA>
+<VERBATIM>
+get_dither_parameters
+          infile = pcadf18840_000N001_asol1.fits.gz
+          method = fold
+  dety_amplitude = 0
+  detz_amplitude = 0
+     dety_period = 0
+     detz_period = 0
+          tmpdir = /tmp
+         verbose = 1
+            mode = ql
+
+Results:
+        Amplitude [deg] Period [cycle/sec]
+DETY    0.00218094      1000.000
+DETZ    0.0173028       2653.000
+</VERBATIM>
+
+<PARA>
+Here the DET_Z axis is much larger than DETY.  
+</PARA>
+
+        </DESC>
+      </QEXAMPLE>
+
+      <QEXAMPLE>
+        <SYNTAX>
+          <LINE>
+% get_dither_parameters pcadf04425_000N001_asol1.fits.gz method=fold
+         </LINE>
+          <LINE>
+% get_dither_parameters pcadf04425_000N001_asol1.fits.gz method=fit
+         </LINE>
+          <LINE>
+% get_dither_parameters pcadf04425_000N001_asol1.fits.gz method=ffft
+         </LINE>
+        </SYNTAX>
+        <DESC>
+          <PARA>
+              Here we have examples of the three different 
+              estimation methods.  The results are summarized below
+          </PARA>
+
+<TABLE>
+  <CAPTION>Example of different estimation methods</CAPTION>
+  <ROW>
+    <DATA>method</DATA>
+    <DATA>DET_Y_Amp [deg]</DATA>
+    <DATA>DET_Z Amp [deg]</DATA>
+    <DATA>DET_Y Period [sec]</DATA>
+    <DATA>DET_Z Period [sec]</DATA>
+    <DATA>Run time [sec]</DATA>
+  </ROW>
+  <ROW>
+    <DATA>fold</DATA>
+    <DATA>0.002223</DATA>
+    <DATA>0.002194</DATA>
+    <DATA>1000</DATA>
+    <DATA>708</DATA>
+    <DATA>25.26</DATA>
+  </ROW>
+  <ROW>
+    <DATA>fit</DATA>
+    <DATA>0.002259</DATA>
+    <DATA>0.002224</DATA>
+    <DATA>1000.13</DATA>
+    <DATA>707.66</DATA>
+    <DATA>31.91</DATA>
+  </ROW>
+  <ROW>
+    <DATA>fft</DATA>
+    <DATA>0.002334</DATA>
+    <DATA>0.002369</DATA>
+    <DATA>1004.35</DATA>
+    <DATA>704.80</DATA>
+    <DATA>1.83</DATA>
+  </ROW>
+</TABLE>
+
+<PARA>
+The default method=fold option is the most robust with the middle 
+amount of time to compute.  method=fit is more accurate for this case but
+is slower and can have problems converging to reliable estimates.
+Finally, method=fft is by far the fastest method, but also the less precise.
+</PARA>
+        </DESC>
+      </QEXAMPLE>
+
+
+     </QEXAMPLELIST>
+    <PARAMLIST>
+      <PARAM filetype="input" name="infile" reqd="yes" type="file">
+        <SYNOPSIS>
+        Aspect solution file, pcadf*asol1.fits
+       </SYNOPSIS>
+        <DESC>
+          <PARA>
+            This tool takes as input the aspect solution file for the
+            observation.  These are usually located in the primary
+            or repro directories and have file names that look like
+            pcadf{obs_id}_{obi_num}N{version}_asol1.fits or
+            pcadf{obs_id}_repro_asol1.fits.  For some very early
+            observations that have not been through Repro-5, there
+            may be one or more aspect solution files that have names
+            that look like pcadf{tstart}N{version}_asol1.fits.
+          </PARA>
+          <PARA>
+             This tool does not accept stacks of aspect solution files.
+             If there is more than one asol file, then they should be
+             merged using dmmerge.
+          </PARA>
+        </DESC>
+      </PARAM>
+
+      <PARAM name="method" reqd="no" type="string" def="fold">
+        <SYNOPSIS>Choice of algorithm to estimate dither parameters: fold, fit, fft</SYNOPSIS>
+        <DESC>
+        
+      <LIST>
+        <CAPTION>method options:</CAPTION>
+        <ITEM>fold : period folding algorithm</ITEM>
+        <ITEM>fit : least-squares fit </ITEM>
+        <ITEM>fft : powerspectrum (fft) search for maximum power.</ITEM>
+      </LIST>
+      
+      <PARA>
+      The details of each algorithm are discussed below.
+      </PARA>
+        </DESC>
+      
+      </PARAM>
+
+      <PARAM name="dety_amplitude" type="real" def="" units="deg">
+        <SYNOPSIS>The estimated amplitude in the DET_Y direction in units of degrees</SYNOPSIS>
+      </PARAM>
+      <PARAM name="detz_amplitude" type="real" def="" units="deg">
+        <SYNOPSIS>The estimated amplitude in the DET_Z direction in units of degrees</SYNOPSIS>
+      </PARAM>
+      <PARAM name="dety_period" type="real" def="" units="sec">
+        <SYNOPSIS>The estimated period in the DET_Y direction in units of seconds</SYNOPSIS>
+      </PARAM>
+      <PARAM name="detz_period" type="real" def="" units="sec">
+        <SYNOPSIS>The estimated period in the DET_Z direction in units of seconds</SYNOPSIS>
+      </PARAM>
+
+     <PARAM name="tmpdir" filetype="output" type="file" reqd="no" def="${ASCDS_WORK_PATH}">
+        <SYNOPSIS>Temporary working directory</SYNOPSIS>
+        <DESC>
+          <PARA>
+                Directory used to store temporary file created by the script.
+          </PARA>
+        </DESC>
+      </PARAM>
+
+     <PARAM name="verbose" min="0" max="5" def="1" type="integer" reqd="no">
+        <SYNOPSIS>Controls the amount of information printed to the terminal</SYNOPSIS>
+      </PARAM>
+      <PARAM name="clobber" def="no" type="boolean" reqd="no">
+        <SYNOPSIS>Delete the output outfile if it already exists?</SYNOPSIS>
+      </PARAM>
+
+
+
+    </PARAMLIST>
+
+    <ADESC title="Description of Algorithms"> 
+    <PARA>
+      The get_dither_parameters tool estimates the dither parameters by
+      examining the RA and Dec values in the aspect solution file.
+      The RA and Dec values are rotated by the spacecraft ROLL to
+      convert them into detector coordinates: DET_Y and DET_Z.  
+      From there three algorithms are available to estimate the 
+      dither parameters.
+    </PARA>
+
+    <PARA title="method=fold">
+      The default method=fold algorithm works by period-folding the
+      TIME values over the range from 200 to 3000 second periods.  
+      For each period, the DET_Y and DET_Z values are split up into
+      10 phase bins and the mean DET_Y and DET_Z values is computed.
+      The period with the maximum standard deviation of the phase bins
+      is the estimated period in each direction.  The amplitude is
+      one-half of the peak-to-peak min/max in the phase bins at that
+      period.  The period search is skipped if the aspect solution file
+      is less than 200 seconds.  If the aspect solution is less than 3000 
+      seconds, then the period search is limited to the duration
+      of the aspect solution file.  Testing has shown this to be
+      the most robust algorithm with moderate run-time.
+    </PARA>
+    <PARA title="method=fit">
+      This method uses sherpa to model the DET_Y and separately the DET_Z
+      values as a constant plus a cosine function.  The data are fit
+      using the least-squares statistic; error estimates are not used.
+      The data are fit using the neldermead optimization algorithm.
+      In the event of a poor fit (as derived from abnormally small
+      amplitudes) the fit is repeated with different intial guesses 
+      and then finally with the most robust but slowest moncar optimization
+      method.  Generally this is the most precise algorithm but it 
+      is significantly slower than the other methods and can sometimes
+      converge on poor estimates.
+    </PARA>
+    <PARA title="method=fft">
+      This method uses the apowerspectrum tool to compute the 
+      power spectrum of the DET_Y and DET_Z values.  The 
+      period is taken to be the period bin with the maximum power.
+      The amplitude is estimated by sorting the values and 
+      computing the range of the values in the 1% and 99% quantiles;
+      this is to avoid the "tail" that can be seen at the start or
+      end of some aspect solution files.  The powerspectrum is
+      the fastest algorithm but is less precise and is not robust for
+      aspect solution files with short duration.
+    </PARA>
+    </ADESC>
+
+
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+    <LASTMODIFIED>February 2023</LASTMODIFIED>
+  </ENTRY>
+</cxchelptopics>


### PR DESCRIPTION
new script to estimate the dither parameters:  amplitude and period, from the aspect solution file.    

The values are estimates/approximates only.

We don't try to estimate the phase (probably doable but not very interesting).

Needs lots of testing especially with
- short observations , ~1ksec to check if powerspectrum works
- observation w/o dither (eg Crab)
- calibrations "Big" dither observations where Y and Z values are very different
- any other non-standard dither configurations
