### PR TITLE
simulate_psf fix pileup frametime

### DIFF
--- a/bin/simulate_psf
+++ b/bin/simulate_psf
@@ -776,11 +776,13 @@ def run_marx2fits( pars, obi_info, output_dir ):
     dev_null = open("/dev/null", "wb")
 
     if "yes" == pars["pileup"]:
-        cmd = "marxpileup MarxOutputDir={0} > /dev/null".format(output_dir)
+        cmd = "marxpileup MarxOutputDir={0} FrameTime={1} > /dev/null".format(output_dir, obi_info["exptime"])
         verb3(">>> "+cmd)
 
         try:
-            subprocess.check_call( ['marxpileup', 'MarxOutputDir='+output_dir], stdout=dev_null)
+            subprocess.check_call( ['marxpileup', 'MarxOutputDir='+output_dir,
+                                    'FrameTime={}'.format(obi_info["exptime"])],
+                                    stdout=dev_null)
         except:
             raise Exception("Problem running {0}".format(cmd))
 

--- a/bin/simulate_psf
+++ b/bin/simulate_psf
@@ -2,7 +2,7 @@
 #
 #
 #
-# Copyright (C) 2012, 2014, 2016, 2018, 2020, 2021, 2022
+# Copyright (C) 2012, 2014, 2016, 2018, 2020-2023
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -26,7 +26,7 @@ import sys
 import subprocess
 
 toolname = "simulate_psf"
-__revision__ = "07 March 2022"
+__revision__ = "09 March 2023"
 
 
 from cxcdm import *
@@ -94,6 +94,11 @@ def check_setup( pars ):
         if is_none( pars["_saotrace_install"] ):
             raise Exception("SAOTrace path not provided in parameter saotrace_install")
 
+        if not os.path.exists(os.path.join(pars["_saotrace_install"],"lib","perl5")):
+            raise Exception("Missing SAOTrace perl libraries")
+        os.environ["PERL5LIB"] = os.path.join(pars["_saotrace_install"],"lib","perl5")
+
+        
     if "marx" in [pars["simulator"], pars["projector"]]:
         if is_none( pars["marx_root"]):
             raise Exception("MARX_ROOT is not provided in parameter marx_root")

--- a/share/doc/xml/simulate_psf.xml
+++ b/share/doc/xml/simulate_psf.xml
@@ -988,7 +988,7 @@ $ marx @@${outroot}_iNNNN_marx.par
         
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.15.2 (XXXX 2023) release">
+    <ADESC title="Changes in the scripts 4.15.2 (April 2023) release">
       <PARA>
         When simulating pileup (pileup=yes), the wrong frame time was
         used.  For observations done with full-frame (1024 rows) the 

--- a/share/doc/xml/simulate_psf.xml
+++ b/share/doc/xml/simulate_psf.xml
@@ -988,6 +988,18 @@ $ marx @@${outroot}_iNNNN_marx.par
         
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.15.2 (XXXX 2023) release">
+      <PARA>
+        When simulating pileup (pileup=yes), the wrong frame time was
+        used.  For observations done with full-frame (1024 rows) the 
+        error is small, but for subarray data, the PSFs could be 
+        substantially over estimating the amount of pileup.  While
+        pileup is non-linear, the approximate error is on the order of
+        3.2 seconds divided by the frame time of the observation given
+        by the EXPTIME keyword.  This has now been fixed.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.14.2 (April 2022) release">
         <PARA>
             Added the numrays parameters to allow users to request

--- a/share/doc/xml/simulate_psf.xml
+++ b/share/doc/xml/simulate_psf.xml
@@ -801,7 +801,11 @@
                 </PARA>            
                 <PARA>
                   ${outroot}_iNNNN_marx.par : The MARX parameter file, if 
-                  marx was used as the simulator and projector.                
+                  marx was used as the simulator and projector.  Users can
+                  re-run marx using the exact same parameters like this
+<SYNTAX><LINE>
+$ marx @@${outroot}_iNNNN_marx.par
+</LINE></SYNTAX>
                 </PARA>
 
             </DESC>          
@@ -1079,7 +1083,7 @@
       </PARA>
     </BUGS>
 
-   <LASTMODIFIED>December 2022</LASTMODIFIED>
+   <LASTMODIFIED>March 2023</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes a problem where the (potentially, very) wrong frame time was used when simulating pileup.

It also folds in changes for ChaRT using SAOTrace v2.0.5 on a RHE8 server along with a doc tweak to show how to use the marx.par file (#740 ) 
.