### PR TITLE
tweak to support libraries on MacOS

### DIFF
--- a/bin/convert_xspec_user_model
+++ b/bin/convert_xspec_user_model
@@ -67,7 +67,7 @@ for a description of the model.dat format.
 """
 
 toolname = "convert_xspec_user_model"
-toolver  = "13 January 2023"
+toolver  = "20 March 2023"
 
 import sys
 import os
@@ -734,9 +734,12 @@ def build_setup(modname, sources, fortransources, extrafiles,
     #
     # How clever should we be here?
     #
-    suffix = sysconfig.get_config_var("SHLIB_SUFFIX")
-    if suffix is None:
-        suffix = ".so"
+    if os.uname().sysname == 'Darwin':
+        suffix = ".dylib"
+    else:
+        suffix = sysconfig.get_config_var("SHLIB_SUFFIX")
+        if suffix is None:
+            suffix = ".so"
 
     def find_libname(head):
         libdir = Path(xspec_basedir) / 'lib'


### PR DESCRIPTION
On MacOS, `sysconfig.get_config_var(SHLIB_SUFFIX)` returns `.so` even though pretty much all shared libraries have the `.dylib` extension.  As is, the script will error out on any MacOS system before getting to try any linkers set in `LDFLAGS`.