### PR TITLE
cxcdm_wrapper: fix case of an empty table (0 columns)

### DIFF
--- a/ciao_contrib/cxcdm_wrapper.py
+++ b/ciao_contrib/cxcdm_wrapper.py
@@ -129,7 +129,8 @@ def get_block_info(bl):
         nc = tableGetNoCols(bl)
         if nc == 0:
             blinfo["type"] = "EMPTY-TABLE"
-
+            blinfo["nrows"] = 0
+            blinfo["columns"] = {}
         else:
             blinfo["type"] = "TABLE"
             blinfo["nrows"] = tableGetNoRows(bl)


### PR DESCRIPTION
This fixes #597 (trying to get keys from an empty file (0 columns).

```bash
echo 1 > a
dmcopy a a.fits
dmcopy "a.fits[cols -col1]" b.fits
python -c 'from ciao_contrib._tools.fileio import get_keys_from_file;print(get_keys_from_file("b.fits"))'
```
before the fix we got
```bash
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/export/miniconda/envs/contrib_test/lib/python3.10/site-packages/ciao_contrib/_tools/fileio.py", line 258, in get_keys_from_file
    return _get_key_values(bi)
  File "/export/miniconda/envs/contrib_test/lib/python3.10/site-packages/ciao_contrib/_tools/fileio.py", line 235, in _get_key_values
    keys['__NCOLS'] = len(blockinfo['columns'])
KeyError: 'columns'
```

now we get
```bash
{'HDUNAME': 'a', 'HISTNUM': 14, '__NCOLS': 0, '__NROWS': 0}
```


