### PR TITLE
'.dylib' vs '.so': changed approach to be more general

### DIFF
--- a/bin/convert_xspec_user_model
+++ b/bin/convert_xspec_user_model
@@ -67,7 +67,7 @@ for a description of the model.dat format.
 """
 
 toolname = "convert_xspec_user_model"
-toolver  = "20 March 2023"
+toolver  = "21 April 2023"
 
 import sys
 import os
@@ -734,12 +734,11 @@ def build_setup(modname, sources, fortransources, extrafiles,
     #
     # How clever should we be here?
     #
-    if os.uname().sysname == 'Darwin':
+    if sysconfig.get_config_var("WITH_DYLD"):
         suffix = ".dylib"
     else:
-        suffix = sysconfig.get_config_var("SHLIB_SUFFIX")
-        if suffix is None:
-            suffix = ".so"
+        suffix = ".so"
+
 
     def find_libname(head):
         libdir = Path(xspec_basedir) / 'lib'


### PR DESCRIPTION
use sysconfig.get_config_var('HAVE_DYLD') instead of basing decision on operating system