### PR TITLE
convert_xspec_script: initial support for MDEFINE

### DIFF
--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -95,7 +95,7 @@ def check_clobber(fname):
 
 
 @lw.handle_ciao_errors(TOOLNAME, TOOLVER)
-def convert(infile, outfile, clean=False, clobber=False):
+def convert(infile, outfile, models=None, clean=False, clobber=False):
 
     if outfile != '-' and not clobber:
         check_clobber(outfile)
@@ -108,7 +108,7 @@ def convert(infile, outfile, clean=False, clobber=False):
         except OSError as oe:
             raise OSError(f"Unable to read from '{infile}'") from oe
 
-    out = xcm.convert(cts, clean=clean)
+    out = xcm.convert(cts, models=models, clean=clean)
     if outfile == '-':
         sys.stdout.write(out)
     else:
@@ -123,6 +123,9 @@ if __name__ == "__main__":
 
     parser.add_argument("infile", help="XCM file to convert (- for stdin)")
     parser.add_argument("outfile", help="Sherpa file to create (- for stdout)")
+
+    parser.add_argument("--models", action="append",
+                        help="Add models created by convert_xspec_user_model: modulename")
 
     parser.add_argument("--clean", dest="clean", action="store_true",
                         default=False,
@@ -161,5 +164,6 @@ if __name__ == "__main__":
         sys.exit(0)
 
     convert(args.infile, args.outfile,
+            models=args.models,
             clean=args.clean,
             clobber=args.clobber)

--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -2,7 +2,7 @@
 
 #
 # Copyright (C) 2020, 2021, 2023
-#           Smithsonian Astrophysical Observatory
+# Smithsonian Astrophysical Observatory
 #
 #
 # This program is free software; you can redistribute it and/or modify
@@ -52,7 +52,7 @@ from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "12 January 2023"
+TOOLVER = "05 May 2023"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)
@@ -68,7 +68,7 @@ The conversion is not guaranteed to match XSPEC perfectly.
 
 COPYRIGHT_STR = """
 Copyright (C) 2020, 2021, 2023
-          Smithsonian Astrophysical Observatory
+Smithsonian Astrophysical Observatory
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -52,7 +52,7 @@ from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "08 May 2023"
+TOOLVER = "09 May 2023"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)

--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -52,7 +52,7 @@ from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "09 May 2023"
+TOOLVER = "11 May 2023"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)

--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -52,7 +52,7 @@ from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "05 May 2023"
+TOOLVER = "08 May 2023"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)

--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -27,6 +27,7 @@ Usage:
 
   convert_xspec_script infile outfile
 
+      --models modname    (can be repeated)
       --clean
       --clobber
       --verbose n or -v n where n is 0, 1, 2, 3, 4, 5
@@ -52,7 +53,7 @@ from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "11 May 2023"
+TOOLVER = "15 May 2023"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -28,7 +28,7 @@
       <LINE/>
       <LINE>The supported command-line flags can be found using -h/--help:</LINE>
       <LINE/>
-      <LINE>--models    to include models created by convert_xspec_user_script</LINE>
+      <LINE>--models    to include models created by convert_xspec_user_script (can be used multiple times)</LINE>
       <LINE>--clean     if the script should start with a call to clean</LINE>
       <LINE>--clobber   will overwrite existing files</LINE>
       <LINE>--verbose   will change the amount of screen output</LINE>
@@ -237,9 +237,7 @@ set_source(1, m1(m2 * m3))
 
       <QEXAMPLE>
 	<SYNTAX>
-	  <LINE>&upr; echo "model phabs(apec)" | &tool; - -</LINE>
-	  <LINE>model phabs(apec)</LINE>
-	  <LINE>Unable to find parameter value for nH - skipping other parameters</LINE>
+	  <LINE>&upr; echo "model phabs(apec)" | &tool; - - --verbose 0</LINE>
 	  <LINE>from sherpa.astro.ui import *</LINE>
 	  <LINE/>
 	  <LINE/>
@@ -254,8 +252,56 @@ set_source(1, m1(m2 * m3))
 	<DESC>
 	  <PARA>
 	    Convert the input from stdin - in this case the string "model phabs(apec)" -
-	    and write the output to stdin.
+	    and write the output to stdin. Using the "--verbose 0" option means that
+	    messages from the script are not included in the screen output.
 	  </PARA>
+	</DESC>
+      </QEXAMPLE>
+
+      <QEXAMPLE>
+	<DESC>
+	  <PARA>
+	    Added in 4.15.2 is support for the MDEFINE command. Here we show the
+	    output from a simple additive model of two power laws:
+	  </PARA>
+<VERBATIM>
+mdefine dplaw E**p1 + f*E**p2
+
+model dplaw
+</VERBATIM>
+<PARA>
+  Converting this file will create the following Python script:
+</PARA>
+<VERBATIM>
+from sherpa.astro.ui import *
+
+
+# mdefine dplaw E**p1 + f*E**p2 : ADD
+# parameters: p1, f, p2, norm
+def model_dplaw(pars, elo, ehi):
+    p1 = pars[0]
+    f = pars[1]
+    p2 = pars[2]
+    norm = pars[3]
+    elo = np.asarray(elo)
+    ehi = np.asarray(ehi)
+    E = (elo + ehi) / 2
+    de = ehi - elo
+    return norm * (E**p1 + f*E**p2) * de
+
+
+
+# model dplaw
+load_user_model(model_dplaw, 'm1')
+add_user_pars('m1', ['p1', 'f', 'p2', 'norm'])
+
+# Parameter settings
+
+# Set up the model expressions
+#
+set_source(1, m1)
+</VERBATIM>
+
 	</DESC>
       </QEXAMPLE>
 
@@ -282,8 +328,120 @@ set_source(1, m1(m2 * m3))
 	<EQUATION>convert_xspec_user_model modname lmodel.dat</EQUATION>
 	add a
 	<EQUATION>--models modname</EQUATION>
-	option to the call to xspec_user_script.
+	option to the call to xspec_user_script. This argument can be
+	repeated if several sets of models are needed; for example
+	<EQUATION>--models mod1 --models mod2</EQUATION>.
       </PARA>
+    </ADESC>
+
+    <ADESC title="MDEFINE">
+      <PARA>
+	Support for the MDEFINE command has been added in the 4.15.2
+	release. The results should be reviewed carefully as there has
+	been limited testing, in particular differences between the
+	various XSPEC language features and Python.
+      </PARA>
+      <PARA title="Calling XSPEC functions">
+	MDEFINE expressions can call various unary and binary
+	functions, such as ATAN2, EXP, HEAVISIDE, and SMAX. Although
+	support is provided for these models, they are not guaranteed
+	to behave as they do in XSPEC, so please check the results
+	carefully!
+      </PARA>
+      <PARA title="Example">
+	With the following XCM script, based on the
+	<HREF link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmdefine.html">XSPEC MDEFINE examples</HREF>,
+      </PARA>
+<VERBATIM>
+mdefine junk a*e+b*log(e)/sin(e)
+mdefine junk3  0.2+B*e : mul
+mdefine mymod junk3(p1)*junk(p2,p3)
+
+model mymod
+</VERBATIM>
+<PARA>
+  running convert_xspec_script will display
+</PARA>
+<VERBATIM>
+  model mymod
+Unable to find parameter value for m1.p1 - skipping other parameters
+Found MDEFINE command: please consult 'ahelp convert_xspec_script'
+  - junk  ADD : check definition of model_junk()
+  - junk3  MUL : check definition of model_junk3()
+  - mymod  ADD : check definition of model_mymod()
+</VERBATIM>
+<PARA>
+  and create the output file
+</PARA>
+<VERBATIM>
+from sherpa.astro.ui import *
+
+
+# mdefine junk a*e+b*log(e)/sin(e) : ADD
+# parameters: a, b, norm
+def model_junk(pars, elo, ehi):
+    a = pars[0]
+    b = pars[1]
+    norm = pars[2]
+    elo = np.asarray(elo)
+    ehi = np.asarray(ehi)
+    E = (elo + ehi) / 2
+    de = ehi - elo
+    return norm * (a*E+b*np.log10(E)/np.sin(E)) * de
+
+
+
+# mdefine junk3 0.2+B*e : MUL
+# parameters: B
+def model_junk3(pars, elo, ehi):
+    B = pars[0]
+    elo = np.asarray(elo)
+    ehi = np.asarray(ehi)
+    E = (elo + ehi) / 2
+    return 0.2+B*E
+
+
+
+# mdefine mymod junk3(p1)*junk(p2,p3) : ADD
+# parameters: p1, p2, p3, norm
+def model_mymod(pars, elo, ehi):
+    p1 = pars[0]
+    p2 = pars[1]
+    p3 = pars[2]
+    norm = pars[3]
+    elo = np.asarray(elo)
+    ehi = np.asarray(ehi)
+
+
+    def junk3(*args):
+        pars = list(args)
+        out = model_junk3(pars, elo, ehi)
+        return out
+
+
+    def junk(*args):
+        pars = list(args)
+        pars.append(1.0)  # model is additive
+        out = model_junk(pars, elo, ehi)
+        out /= de  # model is additive
+        return out
+
+    E = (elo + ehi) / 2
+    de = ehi - elo
+    return norm * (junk3(p1)*junk(p2,p3)) * de
+
+
+
+# model mymod
+load_user_model(model_mymod, 'm1')
+add_user_pars('m1', ['p1', 'p2', 'p3', 'norm'])
+
+# Parameter settings
+
+# Set up the model expressions
+#
+set_source(1, m1)
+</VERBATIM>
     </ADESC>
 
     <ADESC title="Known Problems">
@@ -294,6 +452,8 @@ set_source(1, m1(m2 * m3))
 	include
       </PARA>
       <LIST>
+	<ITEM>not all parts of the various XSPEC expression languages - such
+	as MODEL and MDEFINE - are suppoted,</ITEM>
 	<ITEM>differences in how Sherpa and XSPEC work,</ITEM>
 	<ITEM>possible differences in your ~/.xspec/Xspec.init file
 	(as of CIAO 4.12 Sherpa now uses this file),</ITEM>
@@ -303,7 +463,12 @@ set_source(1, m1(m2 * m3))
       <PARA>
 	The script is also designed to parse the output of the
 	SAVE command from XSPEC. It can handle hand-edited files but
-	it is more likely to fail or work incorrectly.
+	it is more likely to fail or work incorrectly. For instance,
+	XSPEC commands must be included in full, so a line like
+	<EQUATION>mo (phabs)apec</EQUATION>
+	will not work, but
+	<EQUATION>model (phabs)apec</EQUATION>
+	will.
       </PARA>
       <PARA title="Tied parameters">
 	Comlplicated tie expressions, in particular those involving
@@ -312,7 +477,9 @@ set_source(1, m1(m2 * m3))
       <PARA title="Unsupported models">
 	Only additive, multiplicative, and convolution models are
 	recognized. Only models included in XSPEC 12.12.1c (used in
-	CIAO 4.15) are available.
+	CIAO 4.15) are available, although the --models argument,
+	added in the 4.15.2 release, can be used to add XSPEC
+	user models that have been converted with convert_xspec_user_model.
       </PARA>
       <PARA title="Unsupported commands">
 	Some commands are ignored by the script, but others will
@@ -343,21 +510,19 @@ set_source(1, m1(m2 * m3))
 	<EQUATION>--models javier</EQUATION> to the call to
 	convert_xspec_script.
       </PARA>
-
       <PARA title="Initial support of the MDEFINE command">
 	XSPEC allows user models to be created with the <HREF
 	link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmdefine.html">MDEFINE
 	command</HREF>. The Sherpa approach to creating user models is
 	somewhat different, which requires converting from the XSPEC
-	expression into one supported by Sherpa. This release does not
-	fully handle this, but it should allow scripts to be converted
-	with place-holders inserted for the model. Please contact the
-	CXC HelpDesk for help in finishing off the conversion.
-      </PARA>
-      <PARA>
-	There is currently support for simple multiplicative or
-	additive models that do not call other models, and do not call
-	either the unary or binary functions.
+	expression into one supported by Sherpa. This is the attempt
+	at supporting such models, and so the results should be
+	checked against XSPEC. Convolution models are currently
+	unsupported and models that call functions (such as ATAN2,
+	DIM, or HEAVISIDE) may not work as expected because of
+	differences between XSPEC and Python. Please contact the CXC
+	HelpDesk if there appear to be problems or differences to
+	XSPEC when using the output of this script.
       </PARA>
       <PARA title="Improvements in model parsing">
 	The XSPEC model language is different to Sherpa, for example

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -304,6 +304,19 @@ set_source(1, m1(m2 * m3))
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.15.2 (May 2023) release">
+      <PARA title="Initial support of the MDEFINE command">
+	XSPEC allows user models to be created with the <HREF
+	link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmdefine.html">MDEFINE
+	command</HREF>. The Sherpa approach to creating user models is
+	somewhat different, which requires converting from the XSPEC
+	expression into one supported by Sherpa. This release does not
+	fully handle this, but it should allow scripts to be converted
+	with place-holders inserted for the model. Please contact the
+	CXC HelpDesk for help in finishing off the conversion.
+      </PARA>
+    </ADESC>
+    
     <ADESC title="Changes in the scripts 4.15.1 (January 2023) release">
       <PARA>
 	Better handling of un-supported models. Please contact the
@@ -350,6 +363,6 @@ set_source(1, m1(m2 * m3))
     </BUGS>
 -->
 
-    <LASTMODIFIED>December 2023</LASTMODIFIED>
+    <LASTMODIFIED>May 2023</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -363,7 +363,7 @@ model mymod
   running convert_xspec_script will display
 </PARA>
 <VERBATIM>
-  model mymod
+model mymod
 Unable to find parameter value for m1.p1 - skipping other parameters
 Found MDEFINE command: please consult 'ahelp convert_xspec_script'
   - junk  ADD : check definition of model_junk()
@@ -500,9 +500,9 @@ set_source(1, m1)
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.15.2 (May 2023) release">
-      <PARA title="Allow files that reference user models">
-	If the XCM file references one or XSPEC user models, then the
-	--models argument can be used to tell the script about
+      <PARA title="Allow scripts that reference user models">
+	If the XCM scripts references one or XSPEC user models, then the
+	--models argument must be used to tell the script about
 	these models (this assumes that convert_xspec_user_script
 	was used to convert them). So if
 	<EQUATION>convert_xspec_user_model javier lmodel.dat</EQUATION>
@@ -524,6 +524,25 @@ set_source(1, m1)
 	HelpDesk if there appear to be problems or differences to
 	XSPEC when using the output of this script.
       </PARA>
+      <PARA title="Changes to the notice and ignore commands">
+	To match changes made in CIAO 4.15, calls to ignore and notice
+	in the XCM script will now display the change in the filter, such
+	as reporting
+      </PARA>
+<VERBATIM>
+dataset 1: 0:15.01 -> 0.32:15.01 Energy (keV)
+dataset 1: 0.32:15.01 -> 0.32:9.92 Energy (keV)
+</VERBATIM>
+      <PARA>
+	It turns out that Sherpa and XSPEC handle PHA files with
+	invalid grouping data (the GROUPING and QUALITY columns)
+	differently. When running the output of &tool;,
+	warning messages will be displayed when the filters
+	used by XSPEC do not match those used by Sherpa, saying
+      </PARA>
+<VERBATIM>
+WARNING: Spectrum 1: the grouping scheme does not match OGIP standards. The filtering may not exactly match XSPEC.
+</VERBATIM>
       <PARA title="Improvements in model parsing">
 	The XSPEC model language is different to Sherpa, for example
 	a model can be expressed as

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -315,8 +315,17 @@ set_source(1, m1(m2 * m3))
 	with place-holders inserted for the model. Please contact the
 	CXC HelpDesk for help in finishing off the conversion.
       </PARA>
+      <PARA title="Improvements in model parsing">
+	The XSPEC model language is different to Sherpa, for example
+	a mdel can be expressed as
+	<EQUATION>model constant*phabs( ( zpowerlw )etable{mytorus_Ezero_v00.fits} )</EQUATION>
+	which used to get converted to a model expression like
+	<EQUATION>set_source(1, m1 * m2 * ( * (m3) * m4))</EQUATION>
+	but will now create
+	<EQUATION>set_source(1, m1 * m2 * ((m3) * m4))</EQUATION>
+      </PARA>
     </ADESC>
-    
+
     <ADESC title="Changes in the scripts 4.15.1 (January 2023) release">
       <PARA>
 	Better handling of un-supported models. Please contact the

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -360,7 +360,7 @@ mdefine mymod junk3(p1)*junk(p2,p3)
 model mymod
 </VERBATIM>
 <PARA>
-  running convert_xspec_script will display
+  running &tool; will display
 </PARA>
 <VERBATIM>
 model mymod
@@ -508,7 +508,7 @@ set_source(1, m1)
 	<EQUATION>convert_xspec_user_model javier lmodel.dat</EQUATION>
 	was used to convert the extra models, then add
 	<EQUATION>--models javier</EQUATION> to the call to
-	convert_xspec_script.
+	&tool;.
       </PARA>
       <PARA title="Initial support of the MDEFINE command">
 	XSPEC allows user models to be created with the <HREF

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -315,6 +315,11 @@ set_source(1, m1(m2 * m3))
 	with place-holders inserted for the model. Please contact the
 	CXC HelpDesk for help in finishing off the conversion.
       </PARA>
+      <PARA>
+	There is currently support for simple multiplicative or
+	additive models that do not call other models, and do not call
+	either the unary or binary functions.
+      </PARA>
       <PARA title="Improvements in model parsing">
 	The XSPEC model language is different to Sherpa, for example
 	a mdel can be expressed as

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -337,8 +337,13 @@ set_source(1, m1(m2 * m3))
 	If the XCM file references one or XSPEC user models, then the
 	--models argument can be used to tell the script about
 	these models (this assumes that convert_xspec_user_script
-	was used to convert them).
+	was used to convert them). So if
+	<EQUATION>convert_xspec_user_model javier lmodel.dat</EQUATION>
+	was used to convert the extra models, then add
+	<EQUATION>--models javier</EQUATION> to the call to
+	convert_xspec_script.
       </PARA>
+
       <PARA title="Initial support of the MDEFINE command">
 	XSPEC allows user models to be created with the <HREF
 	link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmdefine.html">MDEFINE
@@ -356,7 +361,7 @@ set_source(1, m1(m2 * m3))
       </PARA>
       <PARA title="Improvements in model parsing">
 	The XSPEC model language is different to Sherpa, for example
-	a mdel can be expressed as
+	a model can be expressed as
 	<EQUATION>model constant*phabs( ( zpowerlw )etable{mytorus_Ezero_v00.fits} )</EQUATION>
 	which used to get converted to a model expression like
 	<EQUATION>set_source(1, m1 * m2 * ( * (m3) * m4))</EQUATION>

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -9,7 +9,8 @@
 ]>
 <cxchelptopics>
   <ENTRY key="convert_xspec_script" context="Tools::Utilities"
-	 refkeywords="xspec x-spec xcm script save
+	 refkeywords="xspec x-spec xcm script save mdefine mdef
+		      user usermodel model
 		      "
          seealsogroups=""
 	 >
@@ -27,6 +28,7 @@
       <LINE/>
       <LINE>The supported command-line flags can be found using -h/--help:</LINE>
       <LINE/>
+      <LINE>--models    to include models created by convert_xspec_user_script</LINE>
       <LINE>--clean     if the script should start with a call to clean</LINE>
       <LINE>--clobber   will overwrite existing files</LINE>
       <LINE>--verbose   will change the amount of screen output</LINE>
@@ -39,16 +41,17 @@
 	The &tool; tool will attempt to convert a XSPEC save file
 	(often ending in .xcm) into Sherpa commands. The resulting
 	file can then be run from sherpa or modified for further
-	analysis.
+	analysis. The results should be considered as the start of a
+	Sherpa analysis, as further work may be needed.
       </PARA>
 
       <PARA>
 	This script is *experimental* and will not work for all XSPEC
-	commands or datasets. The results should be considered as
-	the start of a Sherpa analysis, as further work may be needed.
+	commands or datasets.
 	Please contact the
 	<HREF link="https://cxc.harvard.edu/helpdesk/">CXC HelpDesk</HREF>
-	if you find there are scripts which this tool will not convert.
+	if you find there are scripts which this script will not convert,
+	or where the results do not appear to match XSPEC.
       </PARA>
     </DESC>
 
@@ -258,6 +261,31 @@ set_source(1, m1(m2 * m3))
 
     </QEXAMPLELIST>
 
+    <ADESC title="Using XSPEC user models">
+      <PARA>
+	If the MODEL or MDEFINE definitions include XSPEC user models
+	then:
+      </PARA>
+      <LIST>
+	<ITEM>
+	  the model must be converted to Sherpa with the script
+	  convert_xspec_user_model,
+	</ITEM>
+	<ITEM>
+	  and the --models option is used to tell the script what
+	  module, or modules, to be loaded.
+	</ITEM>
+      </LIST>
+      <PARA>
+	For any model that was created by convert_xspec_user_model
+	with the call
+	<EQUATION>convert_xspec_user_model modname lmodel.dat</EQUATION>
+	add a
+	<EQUATION>--models modname</EQUATION>
+	option to the call to xspec_user_script.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Known Problems">
       <PARA>
 	This script is intended to simplify analysis in Sherpa,
@@ -305,6 +333,12 @@ set_source(1, m1(m2 * m3))
     </ADESC>
 
     <ADESC title="Changes in the scripts 4.15.2 (May 2023) release">
+      <PARA title="Allow files that reference user models">
+	If the XCM file references one or XSPEC user models, then the
+	--models argument can be used to tell the script about
+	these models (this assumes that convert_xspec_user_script
+	was used to convert them).
+      </PARA>
       <PARA title="Initial support of the MDEFINE command">
 	XSPEC allows user models to be created with the <HREF
 	link="https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmdefine.html">MDEFINE

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -731,7 +731,7 @@ class MDefine:
     params: List[str]
     expr: str
     mtype: Term
-    erange: Optional[List[float]]  # how do I enforce only 2 values
+    erange: Optional[Tuple[float, float]]
 
 
 def is_model_convolution(mdl: Union[xspec.XSModel, MDefine]) -> bool:
@@ -1540,7 +1540,7 @@ def process_mdefine(xline: str, mdefines: List[MDefine]) -> MDefine:
         if nstoks > 1:
             emin = float(stoks[0])
             emax = float(stoks[1])
-            erange = [emin, emax]
+            erange = (emin, emax)
 
     return MDefine(name=name,
                    params=params,

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -98,7 +98,7 @@ class Response1D(sherpa.astro.instrument.Response1D):
         raise DataErr('norsp', pha.name)
 
 
-def notice(spectrum, lo, hi, ignore=False):
+def notice(spectrum: int, lo: int, hi: int, ignore: bool = False) -> None:
     """Apply XSPEC channel numbering to notice or ignore a range.
 
     Parameters
@@ -149,7 +149,7 @@ def notice(spectrum, lo, hi, ignore=False):
     d.notice(clo, chi, ignore=ignore)
 
 
-def ignore(spectrum, lo, hi):
+def ignore(spectrum: int, lo: int, hi: int) -> None:
     """Apply XSPEC channel numbering to ignore a range.
 
     Parameters
@@ -169,7 +169,7 @@ def ignore(spectrum, lo, hi):
     notice(spectrum, lo, hi, ignore=True)
 
 
-def subtract(spectrum):
+def subtract(spectrum: int) -> None:
     """Subtract the background (a no-op if there is no background).
 
     Parameters
@@ -184,7 +184,7 @@ def subtract(spectrum):
         v1(f"Dataset {spectrum} has no background data!")
 
 
-def _mklabel(func):
+def _mklabel(func: Callable) -> str:
     """Create a 'nice' symbol for the function.
 
     Is this worth it over just using __name__?
@@ -360,7 +360,10 @@ def xmax(x, y):
 
 # Routines used in converting a script.
 #
-def set_subtract(add_import, add_spacer, add, state) -> None:
+def set_subtract(add_import: Callable[[str], None],
+                 add_spacer: Callable[[], None],
+                 add: Callable[..., None],
+                 state: Dict[str, Any]) -> None:
     """Ensure the data is subtracted (as much as we can tell)."""
 
     if state['nodata'] or state['subtracted'] or not state['statistic'].startswith('chi'):
@@ -648,8 +651,8 @@ def parse_ranges(ranges: str) -> Tuple[str, List[Tuple[Optional[int], Optional[i
     return chantype, out
 
 
-def parse_notice_range(add_import: Callable,
-                       add: Callable,
+def parse_notice_range(add_import: Callable[[str], None],
+                       add: Callable[..., None],
                        datasets: List[int],
                        command: str,
                        tokens: List[str]) -> None:
@@ -793,7 +796,7 @@ class ModelExpression:
 
     def __init__(self,
                  expr: str,
-                 groups: List[Any],
+                 groups: List[str],
                  postfix: str,
                  names: Set[str],
                  mdefines: List[MDefine]) -> None:
@@ -1233,7 +1236,8 @@ def convert_model(expr, postfix, groups, names, mdefines):
 
         # What does an open-bracket mean?
         # It can imply multiplication, wrapping a term in
-        # a convolution model, or an actual bracket.
+        # a convolution model, or an actual bracket (which may
+        # or may not be needed).
         #
         if char == "(":
             if end == 0:
@@ -1760,8 +1764,8 @@ def convert(infile: Any,  # to hard to type this
             continue
 
         if command in ['abund', 'xsect']:
-            if ntoks == 1:
-                raise ValueError(f"Missing {command.upper()} option: '{xline}'")
+            if ntoks != 2:
+                raise ValueError(f"Expected 1 argument for {command.upper()}: '{xline}'")
 
             add(f'set_xs{command}', f"'{toks[1]}'")
             continue

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1562,7 +1562,7 @@ def convert_model(output : Output,
 
     for i, tok in enumerate(toks, 1):
         v2(f"  token {i} = '{tok}'")
-        v3(f"    bracket={fake_bracket} convolution={in_convolution}")
+        v3(f"    bracket={fake_bracket} convolution={in_convolution} prev_model_type={prev_model_type}")
 
         if tok == "(":
 
@@ -1571,6 +1571,13 @@ def convert_model(output : Output,
             #
             if prev_model_type is not None and \
                prev_model_type == Term.MUL:
+                tok = " * ("
+
+            elif i > 1 and toks[i - 2] == ")":
+                # Special case "(phabs)(apec)". I am concerned this
+                # could cause problems elsewhere, in particular with
+                # the fake_bracket rule, so let's see.
+                #
                 tok = " * ("
 
             add_token(tok)

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -2502,6 +2502,11 @@ def convert(infile: Any,  # to hard to type this
 
     # START
     #
+    # This isn't always needed but let's make it available anyway, to
+    # simplify the code.
+    #
+    out.add_import("import numpy as np")
+
     if explicit is None:
         out.add_import("from sherpa.astro.ui import *")
     else:

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1442,6 +1442,10 @@ def parse_mdefine_expr(expr: str, mdefines: List[MDefine]) -> List[str]:
     return pnames
 
 
+# TODO: ModelExpression creates it's own session with the XSPEC models
+# loaded. Perhaps this session should be used here and then sent to
+# ModelExpression?
+#
 def process_mdefine(xline: str, mdefines: List[MDefine]) -> MDefine:
     """Parse a mdefine line.
 
@@ -2043,7 +2047,7 @@ def convert(infile: Any,  # to hard to type this
                 for mdl in mdls:
                     try:
                         for par in mdl.pars:
-                            assert isinstance(par, xspec.XSModel)  # for mypy
+                            assert isinstance(par, sherpa.models.parameter.Parameter)  # for mypy
                             if par.hidden:
                                 continue
 
@@ -2071,7 +2075,7 @@ def convert(infile: Any,  # to hard to type this
                     pars = []
                     try:
                         for par in mdl.pars:
-                            assert isinstance(par, xspec.XSModel)  # for mypy
+                            assert isinstance(par, sherpa.models.parameter.Parameter)  # for mypy
                             if par.hidden:
                                 continue
 
@@ -2107,19 +2111,19 @@ def convert(infile: Any,  # to hard to type this
                         lmin = float(toks[3])
                         lmax = float(toks[4])
 
-                        args = [par[0], toks[0]]
-                        kwargs = {}
+                        pargs = [pname, toks[0]]
+                        pkwargs = {}
 
                         if pmin is None or lmin != pmin:
-                            kwargs['min'] = toks[3]
+                            pkwargs['min'] = toks[3]
 
                         if pmax is None or lmax != pmax:
-                            kwargs['max'] = toks[4]
+                            pkwargs['max'] = toks[4]
 
                         if toks[1].startswith('-'):
-                            kwargs['frozen'] = True
+                            pkwargs['frozen'] = True
 
-                        add('set_par', *args, **kwargs)
+                        add('set_par', *pargs, **pkwargs)
 
             continue
 

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1255,8 +1255,14 @@ def convert_model(expr, postfix, groups, names, mdefines):
                     # Assume this is an "actual" model evaluation
                     process.open_sep(" ")
 
+                elif len(process.lastterm[-1]) > 0:
+                    # We don't add a * if it's a "((" situation
+                    process.open_sep(" * ")  # TODO: could this be "*"?
+
                 else:
-                    process.open_sep(" * ")
+                    # We do not know at this point whether this
+                    # bracket can be dropped.
+                    process.open_sep()
 
             start = end + 1
             continue

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1009,7 +1009,7 @@ def parse_backgrnd(output: Output,
         if toks[0] == 'none':
             state['nobackgrounds'].append(1)
         else:
-            output.add_call('load_background', f"'{toks[0]}'")
+            output.add_call('load_bkg', f"'{toks[0]}'")
 
         return
 
@@ -1020,7 +1020,7 @@ def parse_backgrnd(output: Output,
     if toks[1] == 'none':
         state['nobackgrounds'].append(datanum)
     else:
-        output.add_call('load_background', f"'{toks[1]}'")
+        output.add_call('load_bkg', str(datanum), f"'{toks[1]}'")
 
 
 def parse_response(output: Output,

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1933,7 +1933,7 @@ def convert(infile: Any,  # to hard to type this
             # into a user model.
             #
             madd("")
-            madd(f"# mdefine {mdefine.name} {mdefine.expr} : {mdefine.mtype}")
+            madd(f"# mdefine {mdefine.name} {mdefine.expr} : {mdefine.mtype.name}")
             madd(f"def model_{mdefine.name}(pars, elo, ehi):")
             for idx, par in enumerate(mdefine.params):
                 madd(f"    {par} = args[{idx}]")

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1924,15 +1924,15 @@ def convert(infile: Any,  # to hard to type this
         #
         # Let's just assume the source already exists.
         #
-        if command == 'background':
+        if command == 'backgrnd':
             if state['subtracted']:
-                raise ValueError("XCM file is too complex: calling BACKGROUND after METHOD is not supported.")
+                raise ValueError("XCM file is too complex: calling BACKGRND after METHOD is not supported.")
 
             if ntoks < 2:
-                raise ValueError(f"Missing BACKGROUND options: '{xline}'")
+                raise ValueError(f"Missing BACKGRND options: '{xline}'")
 
             if ntoks > 3:
-                raise ValueError(f"Unsupported BACKGROUND syntax: '{xline}'")
+                raise ValueError(f"Unsupported BACKGRND syntax: '{xline}'")
 
             if ntoks == 2:
                 if toks[1] == 'none':
@@ -1943,7 +1943,7 @@ def convert(infile: Any,  # to hard to type this
 
             groupnum, datanum = parse_dataid(toks[1])
             if groupnum is not None:
-                raise ValueError(f"Unsupported BACKGROUND syntax: '{xline}'")
+                raise ValueError(f"Unsupported BACKGRND syntax: '{xline}'")
 
             if toks[2] == 'none':
                 state['nobackgrounds'].append(datanum)

--- a/sherpa_contrib/xspec/xcm.py
+++ b/sherpa_contrib/xspec/xcm.py
@@ -1509,6 +1509,17 @@ def tokenize_model_expr(session: Session,
             out.append("*")
 
         usymbol = symbol.upper()
+
+        # Is this a table model? We include the { in case a user has
+        # created a local model starting [ame]table.... (it that is
+        # possible).
+        #
+        if usymbol.startswith("ATABLE{") or \
+           usymbol.startswith("MTABLE{") or \
+           usymbol.startswith("ETABLE{"):
+            out.append(symbol)  # no case change because of file names
+            return
+
         if usymbol not in KNOWN_MODELS:
             raise ValueError(f"Unrecognized model '{symbol}' in '{expr}'")
 


### PR DESCRIPTION
The idea was to add support for the MDEFINE keyword. It got a bit out of hand:

- Allow model expressions to refer to compiled user models; this requires that `convert_xspec_user_model modname <model.dat>` was used to process the code, and then `--models modname` is added to the `convert_xspec_script` call
- the parsing and evaluation of the model language has been reworked and will hopefully remove some edge cases (e.g. random extra "( * " statements and some cases where an extra space is removed), but I can not guarantee that this hasn't just broken something somewhere else. We can still have too many brackets, but it should not affect the results...
- support for MDEFINE
  - this should at least allow any valid MDEFINE line to be read in
  - it doesn't guarantee that the model will wok
    - convolution models are explicitly known not to work
    - models that call XSPEC functions (e.g. HEAVISIDE) should work but it's likely at least one function doesn't match XSPECs behavior
    - everything else is "it should work but  the user should review the results", in part because of differences between XSPEC and Python languages
- there's some internal changes related to filtering; the most obvious is that notice/ignore calls should now generate the same logging output that the ui.notice/ignore calls create (namely telling you how the filter has changed).
  - there's also an attempt to support some files which can have different groups when read in by XSPEC and Sherpa, in a "XSPEC appears to be silently correcting an invalid file" case but in such a way that we don't have an exact mapping between the channel ranges. If you have a file like this you should now get a warning (whereas before the script would have failed, so if no-one asked about this then they can't have hit this situation!)
  - there's some slight changes to the output script - we now create a warning call rather than a boring print statement in some cases

I am not particularly happy with the ergonomics or name of the `--models` option, but not sure I can be bothered to change it. Any suggestions?

For my reference: the [MDEFINE](https://heasarc.gsfc.nasa.gov/docs/xanadu/xspec/manual/XSmdefine.html) command.