### PR TITLE
include the xsudmget files for XSpec user models

### DIFF
--- a/mk_script_tarfile
+++ b/mk_script_tarfile
@@ -52,7 +52,7 @@ def build_dist(version, dirname, outdir, python="python3.9"):
 
     # Copy directories over to this directory
     #
-    for basedir in ["bin", "share/doc/xml", "data", "config", "param"]:
+    for basedir in ["bin", "share/doc/xml", "share/xspec/install", "data", "config", "param"]:
         newdir = outdir / basedir
         newdir.mkdir(parents=True)
         nfiles = 0


### PR DESCRIPTION
Added the 'share/xspec/install' directory to be copied over into the tarball so that the `xsudmget` files are included in the tarball to support `convert_xspec_user_model`.