### PR TITLE
Map making tools

### DIFF
--- a/bin/centroid_map
+++ b/bin/centroid_map
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2019-2020 Smithsonian Astrophysical Observatory
+# Copyright (C) 2019-2020, 2023
+# Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,11 +26,11 @@ import numpy as np
 import ciao_contrib.logger_wrapper as lw
 from pycrates import read_file
 
-TOOLNAME = "centroid_map"
-__REVISION__ = "25 February 2020"
+__TOOLNAME__ = "centroid_map"
+__REVISION__ = "24 August 2023"
 
 
-LGR = lw.initialize_logger(TOOLNAME)
+LGR = lw.initialize_logger(__TOOLNAME__)
 VERB0 = LGR.verbose0
 VERB1 = LGR.verbose1
 VERB2 = LGR.verbose2
@@ -68,9 +69,6 @@ class InputImage():
         func = self._map_scale_function(scale)
         self.imgvals = func(self.imgvals)
 
-        ##self.imgvals = np.sqrt(np.abs(self.imgvals))
-        ##self.imgvals = self.imgvals**2
-
         self.xlen = self.imgvals.shape[1]
         self.ylen = self.imgvals.shape[0]
 
@@ -91,13 +89,16 @@ class InputImage():
     @staticmethod
     def _map_scale_function(scale):
         'Map scaling function to numpy function'
-        
+
+        def square(x):
+            return x*x
+
         if 'linear' == scale:
             func = np.abs
         elif 'sqrt' == scale:
             func = np.sqrt
         elif 'squared' == scale:
-            func = lambda x: x*x
+            func = square
         elif 'asinh' == scale:
             func = np.arcsinh
         else:
@@ -138,36 +139,12 @@ def centroid_map(mapfile, img, outfile):
     img.write_new_sites(outvals, outfile)
 
 
-def make_tool_vtbin():
-    'replace with `make_tool` when vtbin is available'
-
-    import ciao_contrib.runtool as rt
-    newtool = {
-        'istool': True,
-        'req': [
-                rt.ParValue("infile", "f", "input image", None),
-                rt.ParValue("outfile", "f", "output filename", None),
-               ],
-        'opt': [
-                rt.ParValue("binimg", "f", "output bin image name", None),
-                rt.ParValue("shape", "s", "shape for local max", "box"),
-                rt.ParValue("radius", "r", "radius of local max", 2.5),
-                rt.ParValue("sitefile", "f", "Input site file", None),
-                rt.ParValue("clobber", "b", "Overwrite if file exists", False),
-                rt.ParRange("verbose", "i", "Debug level", 0, 0, 5)
-               ]}
-    gfm = rt.CIAOToolParFile("vtbin", newtool["req"], newtool["opt"])
-    return gfm
-
-
-@lw.handle_ciao_errors(TOOLNAME, __REVISION__)
+@lw.handle_ciao_errors(__TOOLNAME__, __REVISION__)
 def main():
     'Main routine'
     # Load parameters
     from ciao_contrib.param_soaker import get_params
-    from ciao_contrib.runtool import dmcopy
-
-    pars = get_params(TOOLNAME, "rw", sys.argv,
+    pars = get_params(__TOOLNAME__, "rw", sys.argv,
                       verbose={"set": lw.set_verbosity, "cmd": VERB1})
 
     infile = pars["infile"]
@@ -185,7 +162,9 @@ def main():
     img = InputImage(infile, scale=pars["scale"])
 
     # Compute tessellation
-    vtbin = make_tool_vtbin()
+    from ciao_contrib.runtool import dmcopy
+    from ciao_contrib.runtool import vtbin
+
     mapfile = CIAOTemporaryFile()
     vtbin(infile=infile, outfile=mapfile.name, site=sitefile, clobber=True)
 
@@ -194,43 +173,36 @@ def main():
 
     # Loop of iterations
     for niter in range(numiter):
-        VERB1("Working iteration {}".format(niter))
+        VERB1(f"Working iteration {niter}")
         # Compute centroid in each voronoi cell
         sitefile = CIAOTemporaryFile()
         centroid_map(mapfile.name, img, sitefile.name)
 
-        # compute tesselation to create new voronoi cells
+        # compute tessellation to create new voronoi cells
         mapfile = CIAOTemporaryFile()
         vtbin(infile=infile, outfile=mapfile.name, site=sitefile.name,
               clobber=True)
 
         # check to see if no change (converged) then exit
         newvals = read_file(mapfile.name).get_image().values.copy()
-        diff = np.argwhere(np.equal(oldvals, newvals) == False)
+        diff = np.argwhere(np.not_equal(oldvals, newvals))
         oldvals = newvals
-        VERB2("Number of pixels different: {}".format(len(diff)))
-        if 0 == len(diff):
-            VERB0("Converged at step {}. Done.".format(niter))
+        ndiff = len(diff)
+        VERB2(f"Number of pixels different: {ndiff}")
+        if 0 == ndiff:
+            VERB0(f"Converged at step {niter}. Done.")
             break
 
         if int(pars["verbose"]) >= 2:
-            dmcopy(sitefile.name, outfile+f".i{niter:03d}",clobber=True)
-
+            dmcopy(sitefile.name, outfile+f".i{niter:03d}", clobber=True)
 
     # Rename last temp file to final output file
-    from ciao_contrib.runtool import dmcopy
-    dmcopy(mapfile.name+"[1][centroid_map]", outfile, clobber=True)
+    dmcopy(mapfile.name+"[1][CENTROID_MAP]", outfile, clobber=True)
 
     # Add history
     from ciao_contrib.runtool import add_tool_history
-    add_tool_history(outfile, TOOLNAME, pars, toolversion=__REVISION__)
+    add_tool_history(outfile, __TOOLNAME__, pars, toolversion=__REVISION__)
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as E:
-        print("\n# "+TOOLNAME+" ("+__REVISION__+"): ERROR "+str(E)+"\n",
-              file=sys.stderr)
-        sys.exit(1)
-    sys.exit(0)
+    main()

--- a/bin/centroid_map
+++ b/bin/centroid_map
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2019-2020 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Adaptive bin by iterative centroid mapping"""
+
+import sys
+import os
+import numpy as np
+import ciao_contrib.logger_wrapper as lw
+from pycrates import read_file
+
+TOOLNAME = "centroid_map"
+__REVISION__ = "25 February 2020"
+
+
+LGR = lw.initialize_logger(TOOLNAME)
+VERB0 = LGR.verbose0
+VERB1 = LGR.verbose1
+VERB2 = LGR.verbose2
+VERB3 = LGR.verbose3
+VERB5 = LGR.verbose5
+
+
+class CIAOTemporaryFile():
+    """
+    A little class to make sure that tmpfiles are forcefully
+    removed at destruction.
+    """
+
+    def __init__(self, *args, **kwargs):
+        'create temp file'
+        from tempfile import NamedTemporaryFile
+        self.tmpfile = NamedTemporaryFile(dir=os.environ["ASCDS_WORK_PATH"],
+                                          delete=False, *args, **kwargs)
+        self.name = self.tmpfile.name
+
+    def __del__(self):
+        'when object is deleted, so is temp file'
+        self.tmpfile.close()
+        if os.path.exists(self.name):
+            os.remove(self.name)
+
+
+class InputImage():
+    'Object to hold input image'
+
+    def __init__(self, infile, scale):
+        'load image and compute coordinates'
+        self.input_image = read_file(infile)
+        self.imgvals = self.input_image.get_image().values
+        self.imgvals = np.abs(self.imgvals)
+        func = self._map_scale_function(scale)
+        self.imgvals = func(self.imgvals)
+
+        ##self.imgvals = np.sqrt(np.abs(self.imgvals))
+        ##self.imgvals = self.imgvals**2
+
+        self.xlen = self.imgvals.shape[1]
+        self.ylen = self.imgvals.shape[0]
+
+        # Make matrix w/ constant Y values
+        xx = list(np.arange(self.xlen))*self.ylen
+        xx = np.array(xx)
+        self.xx = xx.reshape(self.imgvals.shape)
+
+        # Make matrix w/ constant X values
+        yy = list(np.arange(self.ylen))*self.xlen
+        yy = np.array(yy)
+        self.yy = yy.reshape(self.imgvals.shape[::-1]).T
+
+        # Weight imagevals by X and Y
+        self.wx = self.xx * self.imgvals
+        self.wy = self.yy * self.imgvals
+
+    @staticmethod
+    def _map_scale_function(scale):
+        'Map scaling function to numpy function'
+        
+        if 'linear' == scale:
+            func = np.abs
+        elif 'sqrt' == scale:
+            func = np.sqrt
+        elif 'squared' == scale:
+            func = lambda x: x*x
+        elif 'asinh' == scale:
+            func = np.arcsinh
+        else:
+            raise RuntimeError(f"Unsupported scale value: {scale}")
+        return func
+
+    def write_new_sites(self, outvals, outfile):
+        'Write output with the centroids'
+        self.input_image.name = "centroid_map"
+        self.input_image.get_image().values = outvals
+        self.input_image.write(outfile, clobber="yes")
+
+
+def centroid_map(mapfile, img, outfile):
+    'Main routine, called multiple times'
+
+    mapvals = read_file(mapfile).get_image().values
+    outvals = np.zeros_like(mapvals)
+    assert mapvals.shape == img.imgvals.shape, "Image sizes must match"
+
+    # Operate over map values
+    unq = np.unique(mapvals)
+
+    for uu in unq:
+        if 0 == uu:
+            continue
+        idx = np.where(mapvals == uu)
+        w = np.sum(img.imgvals[idx])
+        if 0 == w:
+            # If sum is 0, use unweighted value
+            cx = np.average(img.xx[idx])
+            cy = np.average(img.yy[idx])
+        else:
+            cx = np.sum(img.wx[idx])/w
+            cy = np.sum(img.wy[idx])/w
+        outvals[int(cy)][int(cx)] = uu
+
+    img.write_new_sites(outvals, outfile)
+
+
+def make_tool_vtbin():
+    'replace with `make_tool` when vtbin is available'
+
+    import ciao_contrib.runtool as rt
+    newtool = {
+        'istool': True,
+        'req': [
+                rt.ParValue("infile", "f", "input image", None),
+                rt.ParValue("outfile", "f", "output filename", None),
+               ],
+        'opt': [
+                rt.ParValue("binimg", "f", "output bin image name", None),
+                rt.ParValue("shape", "s", "shape for local max", "box"),
+                rt.ParValue("radius", "r", "radius of local max", 2.5),
+                rt.ParValue("sitefile", "f", "Input site file", None),
+                rt.ParValue("clobber", "b", "Overwrite if file exists", False),
+                rt.ParRange("verbose", "i", "Debug level", 0, 0, 5)
+               ]}
+    gfm = rt.CIAOToolParFile("vtbin", newtool["req"], newtool["opt"])
+    return gfm
+
+
+@lw.handle_ciao_errors(TOOLNAME, __REVISION__)
+def main():
+    'Main routine'
+    # Load parameters
+    from ciao_contrib.param_soaker import get_params
+    from ciao_contrib.runtool import dmcopy
+
+    pars = get_params(TOOLNAME, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": VERB1})
+
+    infile = pars["infile"]
+    outfile = pars["outfile"]
+    sitefile = pars["sitefile"]
+    if 0 == len(sitefile) or "none" == sitefile.lower():
+        sitefile = None
+    numiter = int(pars["numiter"])
+
+    # Clobber output
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    outfile_clobber_checks(pars["clobber"], outfile)
+
+    # Load image
+    img = InputImage(infile, scale=pars["scale"])
+
+    # Compute tessellation
+    vtbin = make_tool_vtbin()
+    mapfile = CIAOTemporaryFile()
+    vtbin(infile=infile, outfile=mapfile.name, site=sitefile, clobber=True)
+
+    # Save original values
+    oldvals = read_file(mapfile.name).get_image().values.copy()
+
+    # Loop of iterations
+    for niter in range(numiter):
+        VERB1("Working iteration {}".format(niter))
+        # Compute centroid in each voronoi cell
+        sitefile = CIAOTemporaryFile()
+        centroid_map(mapfile.name, img, sitefile.name)
+
+        # compute tesselation to create new voronoi cells
+        mapfile = CIAOTemporaryFile()
+        vtbin(infile=infile, outfile=mapfile.name, site=sitefile.name,
+              clobber=True)
+
+        # check to see if no change (converged) then exit
+        newvals = read_file(mapfile.name).get_image().values.copy()
+        diff = np.argwhere(np.equal(oldvals, newvals) == False)
+        oldvals = newvals
+        VERB2("Number of pixels different: {}".format(len(diff)))
+        if 0 == len(diff):
+            VERB0("Converged at step {}. Done.".format(niter))
+            break
+
+        if int(pars["verbose"]) >= 2:
+            dmcopy(sitefile.name, outfile+f".i{niter:03d}",clobber=True)
+
+
+    # Rename last temp file to final output file
+    from ciao_contrib.runtool import dmcopy
+    dmcopy(mapfile.name+"[1][centroid_map]", outfile, clobber=True)
+
+    # Add history
+    from ciao_contrib.runtool import add_tool_history
+    add_tool_history(outfile, TOOLNAME, pars, toolversion=__REVISION__)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as E:
+        print("\n# "+TOOLNAME+" ("+__REVISION__+"): ERROR "+str(E)+"\n",
+              file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)

--- a/bin/hexgrid
+++ b/bin/hexgrid
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2014 Smithsonian Astrophysical Observatory
+# Copyright (C) 2014-2023 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -17,51 +17,47 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
-
-toolname = "hexgrid"
-__revision__ = "15 January 2019"
+'Create a map in the form a hexagonal grid'
 
 
 import sys
 import os
 import numpy as np
-import pycrates as pc
-from region import *
-from cxcdm import *
+
+from region import polygon
 from crates_contrib.masked_image_crate import MaskedIMAGECrate
-
-
 import ciao_contrib.logger_wrapper as lw
-lgr = lw.initialize_logger(toolname)
-verb0 = lgr.verbose0
-verb1 = lgr.verbose1
-verb2 = lgr.verbose2
-verb3 = lgr.verbose3
-verb5 = lgr.verbose5
 
 
-class HexagonGrid( ):
+__toolname__ = "hexgrid"
+__revision__ = "24 August 2023"
+
+verb0 = lw.initialize_logger(__toolname__).verbose0
+verb1 = lw.initialize_logger(__toolname__).verbose1
+verb2 = lw.initialize_logger(__toolname__).verbose2
+verb3 = lw.initialize_logger(__toolname__).verbose3
+verb5 = lw.initialize_logger(__toolname__).verbose5
+
+
+class HexagonGrid():
     """
     Create a map or grid of hexagons
-    
+
     Creates an image whose pixel values indicate which hexagon
     a pixel belongs to.
-    
-    >>> hh = HexagonGrid( 10, 1024, 1024)
+
+    >>> hh = HexagonGrid(10, 1024, 1024)
     >>> outvals = hh.make_map()
-    
     """
 
-    def __init__(self, sidelen, lx, ly, x0, y0 ):
+    def __init__(self, sidelen, xlen, ylen, x0, y0):
         """
         Setup the hexagon properties
         """
 
         self.sidelen = sidelen
-        self.lx = lx
-        self.ly = ly
+        self.xlen = xlen
+        self.ylen = ylen
         self.x0 = x0
         self.y0 = y0
 
@@ -69,29 +65,29 @@ class HexagonGrid( ):
         # Hexagon are aligned so that the "long" axis is parallel
         # to the X-axis.
         #
-        self.dx = 3 * sidelen 
-        self.dy = 2 * sidelen * np.sin(np.deg2rad(60))
 
-        self.x0 = np.mod( self.x0, self.dx )-1  # -1 => 0 based indexing
-        self.y0 = np.mod( self.y0, self.dy )-1
+        xdelta = 3 * self.sidelen
+        ydelta = 2 * self.sidelen * np.sin(np.deg2rad(60))
+
+        self.x0 = np.mod(self.x0, xdelta)-1  # -1 => 0 based indexing
+        self.y0 = np.mod(self.y0, ydelta)-1
 
         #
         # Create arrays for a polygon centered around 0,0.  It is shifted
         # to each hex point later
         #
-        s60 = np.sin(np.deg2rad(60))
-        c60 = np.cos(np.deg2rad(60))
-        self.px = np.array( [ -1, -c60, c60, 1, c60, -c60, -1 ] )*sidelen
-        self.py = np.array( [ 0, s60, s60, 0, -s60, -s60, 0 ] ) *sidelen
+        s60 = np.sin(np.deg2rad(60.0))
+        c60 = np.cos(np.deg2rad(60.0))
+        self.px = np.array([-1, -c60, c60, 1, c60, -c60, -1]) * sidelen
+        self.py = np.array([0, s60, s60, 0, -s60, -s60, 0]) * sidelen
 
         # Counter for the number of hexagons that are created
         self.counter = 0
 
         # The output array
-        self.stipple = np.zeros([ly,lx])
+        self.stipple = np.zeros([ylen, xlen])
 
-
-    def _fill_hexagon(self, xx,yy):
+    def _fill_hexagon(self, xx, yy):
         """
         Note: we do everything in logical coords
         """
@@ -103,105 +99,98 @@ class HexagonGrid( ):
         #
         pxx = self.px+xx
         pyy = self.py+yy
-        pxy = zip( pxx.tolist(), pyy.tolist() )
-        pp = [ ",".join(map(str,p)) for p in pxy ]
-        pp = ",".join(pp)
-        rr = regParse("polygon({})".format(pp))
 
-        for iy in range( int(yy-self.sidelen), int(yy+self.sidelen+1)):
-            if iy < 0 or iy >= self.ly:
+        poly = polygon(pxx, pyy)
+
+        for iy in range(int(yy-self.sidelen), int(yy+self.sidelen+1)):
+            if iy < 0 or iy >= self.ylen:
                 continue
-            for ix in range( int(xx-self.sidelen), int(xx+self.sidelen+1)):
-                if ix < 0 or ix >= self.lx:
+            for ix in range(int(xx-self.sidelen), int(xx+self.sidelen+1)):
+                if ix < 0 or ix >= self.xlen:
                     continue
-            
-                if regInsideRegion( rr, ix, iy ):
-                    self.stipple[iy,ix] = self.counter
+
+                if poly.is_inside(ix, iy):
+                    self.stipple[iy, ix] = self.counter
 
     def make_map(self):
         """
         Create the hexagon map
-        
+
         The hexagon grid is created by looping over pixels in
         a box around each hexagon.  There are two offset rows
-        (stried) that need to be checked 
+        (stried) that need to be checked
         """
+        xdelta = 3 * self.sidelen
+        ydelta = 2 * self.sidelen * np.sin(np.deg2rad(60))
 
-        ##x0 = 0 # self.sidelen/2.0
-        ##y0 = 0 # self.sidelen/2.0
-        for yy in np.arange( self.y0-self.dy,self.ly+self.dy,self.dy):
-            for xx in np.arange( self.x0-self.dx, self.lx+self.dx,self.dx ):
+        for yy in np.arange(self.y0-ydelta, self.ylen+ydelta, ydelta):
+            for xx in np.arange(self.x0-xdelta, self.xlen+xdelta, xdelta):
                 # 1st stride
-                self._fill_hexagon(xx,yy)
+                self._fill_hexagon(xx, yy)
                 # 2nd stride
-                self._fill_hexagon(xx+1.5*self.sidelen, yy+self.dy/2.0)
-        
+                self._fill_hexagon(xx+1.5*self.sidelen, yy+ydelta/2.0)
+
         return self.stipple
 
 
-@lw.handle_ciao_errors( toolname, __revision__)
+@lw.handle_ciao_errors(__toolname__, __revision__)
 def main():
+    'Main routine'
+
     # get parameters
     from ciao_contrib.param_soaker import get_params
-    from ciao_contrib.runtool import dmmaskbin
-    from ciao_contrib.runtool import add_tool_history
-
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
-        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
 
     from ciao_contrib._tools.fileio import outfile_clobber_checks
-    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
-    outfile_clobber_checks(pars["clobber"], pars["binimg"] )
+    outfile_clobber_checks(pars["clobber"], pars["outfile"])
+    outfile_clobber_checks(pars["clobber"], pars["binimg"])
 
     #
     # Load image, don't care about the pixel values, just image size
     #
-    inimg = MaskedIMAGECrate(pars["infile"],mode="r")
+    inimg = MaskedIMAGECrate(pars["infile"], mode="r")
     xx = inimg.get_image().values
-    ly = len(xx)
-    lx = len(xx[0])
+    ylen = len(xx)
+    xlen = len(xx[0])
 
     #
     # Create full map
     #
-    hh = HexagonGrid( float(pars["sidelen"]), lx, ly, float(pars["xref"]), float(pars["yref"]) )
-    stipple = hh.make_map()
+    hexmap = HexagonGrid(float(pars["sidelen"]), xlen, ylen,
+                         float(pars["xref"]), float(pars["yref"]))
+    stipple = hexmap.make_map()
 
     #
     # Check pixels in image are inside subspace
     #
-    for _ix in range(lx):
-        for _iy in range(ly):
-            if not inimg.valid(_ix,_iy):
+    for _ix in range(xlen):
+        for _iy in range(ylen):
+            if not inimg.valid(_ix, _iy):
                 stipple[_iy][_ix] = 0
 
+    # Write output
+    if os.path.exists(pars["outfile"]):
+        os.remove(pars["outfile"])
 
-    #
-    # Want to use pycrates to write, but doesn't support linear wcs
-    #
-    if os.path.exists( pars["outfile"] ):
-        os.remove( pars["outfile"])
+    inimg.get_image().values = stipple
+    inimg.name = "HEXMAP"
+    inimg.write(pars["outfile"], clobber=True)
 
-    dm_img = dmImageOpen(pars["infile"]+"[opt type=i4]")
-    out_img = dmBlockCreateCopy( dmDatasetCreate(pars["outfile"]), "HEXMAP", dm_img)
-    out_dd = dmImageGetDataDescriptor( out_img )
-    dmImageSetData( out_dd, stipple )
-    dmImageClose( out_img )
-    dmImageClose( dm_img)
-    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+    from ciao_contrib.runtool import add_tool_history
+    add_tool_history(pars["outfile"], __toolname__, pars,
+                     toolversion=__revision__)
 
-    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
-        dmmaskbin( pars["infile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
-        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
-
+    # Apply to input image
+    if len(pars["binimg"]) > 0 and "none" != pars["binimg"].lower():
+        # pylint: disable=no-name-in-module
+        from ciao_contrib.runtool import dmmaskbin
+        dmmaskbin(pars["infile"], pars["outfile"]+"[opt type=i4]",
+                  pars["binimg"], clobber=True)
+        add_tool_history(pars["binimg"], __toolname__, pars,
+                         toolversion=__revision__)
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as E:
-        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
-        sys.exit(1)
-    sys.exit(0)
-
+    main()

--- a/bin/hexgrid
+++ b/bin/hexgrid
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2014 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from __future__ import print_function
+
+
+toolname = "hexgrid"
+__revision__ = "15 January 2019"
+
+
+import sys
+import os
+import numpy as np
+import pycrates as pc
+from region import *
+from cxcdm import *
+from crates_contrib.masked_image_crate import MaskedIMAGECrate
+
+
+import ciao_contrib.logger_wrapper as lw
+lgr = lw.initialize_logger(toolname)
+verb0 = lgr.verbose0
+verb1 = lgr.verbose1
+verb2 = lgr.verbose2
+verb3 = lgr.verbose3
+verb5 = lgr.verbose5
+
+
+class HexagonGrid( ):
+    """
+    Create a map or grid of hexagons
+    
+    Creates an image whose pixel values indicate which hexagon
+    a pixel belongs to.
+    
+    >>> hh = HexagonGrid( 10, 1024, 1024)
+    >>> outvals = hh.make_map()
+    
+    """
+
+    def __init__(self, sidelen, lx, ly, x0, y0 ):
+        """
+        Setup the hexagon properties
+        """
+
+        self.sidelen = sidelen
+        self.lx = lx
+        self.ly = ly
+        self.x0 = x0
+        self.y0 = y0
+
+        #
+        # Hexagon are aligned so that the "long" axis is parallel
+        # to the X-axis.
+        #
+        self.dx = 3 * sidelen 
+        self.dy = 2 * sidelen * np.sin(np.deg2rad(60))
+
+        self.x0 = np.mod( self.x0, self.dx )-1  # -1 => 0 based indexing
+        self.y0 = np.mod( self.y0, self.dy )-1
+
+        #
+        # Create arrays for a polygon centered around 0,0.  It is shifted
+        # to each hex point later
+        #
+        s60 = np.sin(np.deg2rad(60))
+        c60 = np.cos(np.deg2rad(60))
+        self.px = np.array( [ -1, -c60, c60, 1, c60, -c60, -1 ] )*sidelen
+        self.py = np.array( [ 0, s60, s60, 0, -s60, -s60, 0 ] ) *sidelen
+
+        # Counter for the number of hexagons that are created
+        self.counter = 0
+
+        # The output array
+        self.stipple = np.zeros([ly,lx])
+
+
+    def _fill_hexagon(self, xx,yy):
+        """
+        Note: we do everything in logical coords
+        """
+        self.counter += 1
+
+        #
+        # Shift polygon verticies to current location and make
+        # a region
+        #
+        pxx = self.px+xx
+        pyy = self.py+yy
+        pxy = zip( pxx.tolist(), pyy.tolist() )
+        pp = [ ",".join(map(str,p)) for p in pxy ]
+        pp = ",".join(pp)
+        rr = regParse("polygon({})".format(pp))
+
+        for iy in range( int(yy-self.sidelen), int(yy+self.sidelen+1)):
+            if iy < 0 or iy >= self.ly:
+                continue
+            for ix in range( int(xx-self.sidelen), int(xx+self.sidelen+1)):
+                if ix < 0 or ix >= self.lx:
+                    continue
+            
+                if regInsideRegion( rr, ix, iy ):
+                    self.stipple[iy,ix] = self.counter
+
+    def make_map(self):
+        """
+        Create the hexagon map
+        
+        The hexagon grid is created by looping over pixels in
+        a box around each hexagon.  There are two offset rows
+        (stried) that need to be checked 
+        """
+
+        ##x0 = 0 # self.sidelen/2.0
+        ##y0 = 0 # self.sidelen/2.0
+        for yy in np.arange( self.y0-self.dy,self.ly+self.dy,self.dy):
+            for xx in np.arange( self.x0-self.dx, self.lx+self.dx,self.dx ):
+                # 1st stride
+                self._fill_hexagon(xx,yy)
+                # 2nd stride
+                self._fill_hexagon(xx+1.5*self.sidelen, yy+self.dy/2.0)
+        
+        return self.stipple
+
+
+@lw.handle_ciao_errors( toolname, __revision__)
+def main():
+    # get parameters
+    from ciao_contrib.param_soaker import get_params
+    from ciao_contrib.runtool import dmmaskbin
+    from ciao_contrib.runtool import add_tool_history
+
+    # Load parameters
+    pars = get_params(toolname, "rw", sys.argv, 
+        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
+    outfile_clobber_checks(pars["clobber"], pars["binimg"] )
+
+    #
+    # Load image, don't care about the pixel values, just image size
+    #
+    inimg = MaskedIMAGECrate(pars["infile"],mode="r")
+    xx = inimg.get_image().values
+    ly = len(xx)
+    lx = len(xx[0])
+
+    #
+    # Create full map
+    #
+    hh = HexagonGrid( float(pars["sidelen"]), lx, ly, float(pars["xref"]), float(pars["yref"]) )
+    stipple = hh.make_map()
+
+    #
+    # Check pixels in image are inside subspace
+    #
+    for _ix in range(lx):
+        for _iy in range(ly):
+            if not inimg.valid(_ix,_iy):
+                stipple[_iy][_ix] = 0
+
+
+    #
+    # Want to use pycrates to write, but doesn't support linear wcs
+    #
+    if os.path.exists( pars["outfile"] ):
+        os.remove( pars["outfile"])
+
+    dm_img = dmImageOpen(pars["infile"]+"[opt type=i4]")
+    out_img = dmBlockCreateCopy( dmDatasetCreate(pars["outfile"]), "HEXMAP", dm_img)
+    out_dd = dmImageGetDataDescriptor( out_img )
+    dmImageSetData( out_dd, stipple )
+    dmImageClose( out_img )
+    dmImageClose( dm_img)
+    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+
+    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
+        dmmaskbin( pars["infile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
+        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
+
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as E:
+        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+

--- a/bin/map2reg
+++ b/bin/map2reg
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2019, 2023 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+'Convert a map file into a region file'
+
+
+import os
+import sys
+from tempfile import NamedTemporaryFile
+
+import numpy as np
+
+from ciao_contrib.runtool import make_tool
+import ciao_contrib.logger_wrapper as lw
+
+__toolname__ = "map2reg"
+__revision__ = "28 August 2023"
+
+
+__lgr__ = lw.initialize_logger(__toolname__)
+verb0 = __lgr__.verbose0
+verb1 = __lgr__.verbose1
+verb2 = __lgr__.verbose2
+verb3 = __lgr__.verbose3
+verb5 = __lgr__.verbose5
+
+# Okay, I don't like globals, but better than passing around
+img = None
+infile = None
+
+
+def set_nproc(pars):
+    'Set number of processors'
+
+    if "no" == pars["parallel"]:
+        pars["nproc"] = 1
+    else:
+        if pars["nproc"] != "INDEF":
+            pars["nproc"] = int(pars["nproc"])
+        else:
+            pars["nproc"] = 999   # Hack, else history gets stuck with a pset
+
+
+def get_region(n_at):
+    """
+    Apply threshold at the map value (n_at)
+
+    Find location of max pixel (will be some arbitrary pixel in map)
+
+    Lasso to create region  -- this only works for contigious regions
+
+    """
+    verb2(n_at)
+
+    pixels = np.argwhere(img.get_image().values == n_at)
+
+    if len(pixels) == 0:
+        return None
+
+    ypos, xpos = pixels[0] + 1  # Image coords are +1 from array index
+
+    tmpfile = NamedTemporaryFile(dir=os.environ["ASCDS_WORK_PATH"],
+                                 suffix="lasso.reg", delete=False)
+
+    lasso = make_tool("dmimglasso")
+    lasso.infile = infile
+    lasso.outfile = tmpfile.name
+    lasso.clobber = True
+    lasso.low_value = n_at - 0.5
+    lasso.high_value = n_at + 0.5
+    lasso.value = "absolute"
+    lasso.coord = "logical"
+    lasso.xpos = xpos
+    lasso.ypos = ypos
+    lasso()
+
+    return lasso.outfile
+
+
+@lw.handle_ciao_errors(__toolname__, __revision__)
+def main():
+    """
+    Main routine
+    """
+
+    # Load parameters
+    from ciao_contrib.param_soaker import get_params
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
+
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    outfile_clobber_checks(pars["clobber"], pars["outfile"])
+
+    set_nproc(pars)
+
+    # Load map file
+    from pycrates import read_file
+    global img
+    global infile
+    infile = pars["infile"]
+    img = read_file(infile)
+
+    # Get list values to iterate over
+    uniq_vals = np.unique(img.get_image().values)
+    uniq_vals = uniq_vals[uniq_vals > 0]
+
+    # Create regions
+    from sherpa.utils import parallel_map
+    outreg = parallel_map(get_region, uniq_vals,
+                          numcores=int(pars["nproc"]))
+
+    # Combine into single region file
+    from region import CXCRegion
+    allout = CXCRegion()
+    for myreg in outreg:
+        if myreg is None:
+            continue
+
+        parsed_reg = CXCRegion(myreg)
+        allout += parsed_reg
+        os.unlink(myreg)  # Delete along the way
+
+    # Write output
+    from ciao_contrib.runtool import add_tool_history
+    allout.write(pars["outfile"], fits=True, clobber=True)
+    add_tool_history(pars["outfile"], __toolname__, pars,
+                     toolversion=__revision__)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/map2reg
+++ b/bin/map2reg
@@ -29,10 +29,11 @@ import numpy as np
 
 from ciao_contrib.runtool import make_tool
 import ciao_contrib.logger_wrapper as lw
+from region import CXCRegion
+
 
 __toolname__ = "map2reg"
-__revision__ = "28 August 2023"
-
+__revision__ = "09 September 2023"
 
 __lgr__ = lw.initialize_logger(__toolname__)
 verb0 = __lgr__.verbose0
@@ -51,11 +52,15 @@ def set_nproc(pars):
 
     if "no" == pars["parallel"]:
         pars["nproc"] = 1
+        return
+
+    if pars["nproc"] == "INDEF":
+        # parallel_map doesn't limit to number of CPU's like 
+        # taskRunner does so we have to set the actual number
+        import multiprocessing
+        pars["nproc"] = multiprocessing.cpu_count()
     else:
-        if pars["nproc"] != "INDEF":
-            pars["nproc"] = int(pars["nproc"])
-        else:
-            pars["nproc"] = 999   # Hack, else history gets stuck with a pset
+        pars["nproc"] = int(pars["nproc"])
 
 
 def get_region(n_at):
@@ -77,7 +82,7 @@ def get_region(n_at):
     ypos, xpos = pixels[0] + 1  # Image coords are +1 from array index
 
     tmpfile = NamedTemporaryFile(dir=os.environ["ASCDS_WORK_PATH"],
-                                 suffix="lasso.reg", delete=False)
+                                 suffix="lasso.reg", delete=True)
 
     lasso = make_tool("dmimglasso")
     lasso.infile = infile
@@ -91,7 +96,12 @@ def get_region(n_at):
     lasso.ypos = ypos
     lasso()
 
-    return lasso.outfile
+    lasso_reg = CXCRegion(tmpfile.name)
+
+    # CXCRegion object's can't be pickled so we have to pass back the
+    # string representation.
+
+    return str(lasso_reg)
 
 
 @lw.handle_ciao_errors(__toolname__, __revision__)
@@ -126,20 +136,23 @@ def main():
     outreg = parallel_map(get_region, uniq_vals,
                           numcores=int(pars["nproc"]))
 
-    # Combine into single region file
-    from region import CXCRegion
-    allout = CXCRegion()
-    for myreg in outreg:
-        if myreg is None:
-            continue
+    # Original version adding CXCRegion objects, but it ended up
+    # consuming a huge amount of memory and was slow.  Writing to
+    # an ASCII region file and then reading back in as a single
+    # CXCRegion is much faster
 
-        parsed_reg = CXCRegion(myreg)
-        allout += parsed_reg
-        os.unlink(myreg)  # Delete along the way
+    # Combine into single region file
+    tmpfile = NamedTemporaryFile(dir=os.environ["ASCDS_WORK_PATH"],
+                                 suffix=".reg", delete=True)
+    with open(tmpfile.name, "w") as outfile:
+        for myreg in outreg:
+            outfile.write(myreg+"\n")
 
     # Write output
+    myreg = CXCRegion(tmpfile.name)
+    myreg.write(pars["outfile"], fits=True, clobber=True)
+
     from ciao_contrib.runtool import add_tool_history
-    allout.write(pars["outfile"], fits=True, clobber=True)
     add_tool_history(pars["outfile"], __toolname__, pars,
                      toolversion=__revision__)
 

--- a/bin/merge_too_small
+++ b/bin/merge_too_small
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2014 Smithsonian Astrophysical Observatory
+# Copyright (C) 2014-2023 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -17,106 +17,118 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
+"Combine map regions together based on some metric"
 
 
-toolname = "merge_too_small"
-__revision__ = "31 July 2017"
-
-import os
 import sys
 import numpy as np
 
+
+__toolname__ = "merge_too_small"
+__revision__ = "24 August 2023"
+
 import ciao_contrib.logger_wrapper as lw
-lgr = lw.initialize_logger(toolname)
-verb0 = lgr.verbose0
-verb1 = lgr.verbose1
-verb2 = lgr.verbose2
-verb3 = lgr.verbose3
-verb5 = lgr.verbose5
+verb0 = lw.initialize_logger(__toolname__).verbose0
+verb1 = lw.initialize_logger(__toolname__).verbose1
+verb2 = lw.initialize_logger(__toolname__).verbose2
+verb3 = lw.initialize_logger(__toolname__).verbose3
+verb5 = lw.initialize_logger(__toolname__).verbose5
 
 
+def find_neighbors(mask, maskval):
+    'Identify which map ids neighbor the current mask value'
 
-def find_neighbors( mask, maskval ):
-
-    xxyy = np.where( mask == maskval )
-    xy = zip(xxyy[1],xxyy[0])
+    xxyy = np.where(mask == maskval)
     retvals = []
-    for ee in xy:
 
+    # For each pixel with a given maskval value
+    for ee in zip(xxyy[1], xxyy[0]):
+
+        # Go +/- 1 in Y direction
         for dy in [ee[1]-1, ee[1], ee[1]+1]:
             if dy < 0 or dy >= mask.shape[0]:
                 continue
 
+            # Go +/- 1 in the X direction
             for dx in [ee[0]-1, ee[0], ee[0]+1]:
                 if dx < 0 or dx >= mask.shape[1]:
                     continue
 
                 if mask[dy, dx] != maskval:
-                    retvals.append( int(mask[dy,dx]) )
+                    retvals.append(int(mask[dy, dx]))
 
     retvals = set(retvals)
     return list(retvals)
 
 
-def purge_too_small(mask, minarea, counts):    
+def purge_too_small(mask, minarea, counts):
     """
+    The idea is to check the area or total counts of each
+    mask value.  If it is below the threshold then the map value
+    is reassigned to the neighbor with the smallest area/counts.
     """
     mask_max = int(np.max(mask))
-    skiplist = []
+    skiplist = []   # The list of maskidvals that have been reassigned
 
     while True:
-        hh = np.histogram( mask, bins=mask_max, range=(1,mask_max+1), weights=counts)
+        # make histogram of pixel values.  If counts=None, then
+        # histogram is the area (logical pixels), if counts=value, then
+        # counts=counts (or flux or whatever units the input image is).
+
+        hh = np.histogram(mask, bins=mask_max, range=(1, mask_max+1),
+                          weights=counts)
         area = hh[0]
         maskid = hh[1][:-1]
-        
-        am = list(zip( area, maskid ))
-        am.sort()        
-        am = [ x for x in am if x[0]>0 and x[0] not in skiplist ]
-        
+
+        am = list(zip(area, maskid))
+        am.sort()
+        am = [x for x in am if x[0] > 0 and x[0] not in skiplist]
+
         if am[0][0] > minarea:
+            # When all the mapvals are above the threshold we break out
+            # and return.
             break
 
-        verb1("Working on mask_id {} with value {}".format(int(am[0][1]),am[0][0]))
-        nn = find_neighbors( mask, am[0][1])
+        verb2(f"Working on mask_id {am[0][1]} with value {am[0][0]}")
+        nn = find_neighbors(mask, am[0][1])
+
         if len(nn) == 0:
-            skiplist.append( am[0][1] )
+            # If area is 0, then skip it.
+            skiplist.append(am[0][1])
             continue
-        
-        nn = [i-1 for i in nn]
-        zz = list(zip( area[nn],maskid[nn]))
-        zz.sort()        
-        zz = [x for x in zz if (x[1] != am[0][1]) and (x[0]>0) and (x[1] not in skiplist)]
+
+        nn = [i-1 for i in nn]  # convert mapvalue to histogram index
+        zz = list(zip(area[nn], maskid[nn]))
+        zz.sort()
+
+        zz = [x for x in zz
+              if (x[1] != am[0][1]) and (x[0] > 0) and (x[1] not in skiplist)]
+
         if len(zz) > 0:
             replace_val = int(zz[0][1])
-            mask[ np.where( mask == int(am[0][1]) ) ] = replace_val
+            mask[np.where(mask == int(am[0][1]))] = replace_val
         else:
-            skiplist.append(am[0][0])
-        
+            skiplist.append(am[0][0])  # There are no pixel with this mapval
 
 
-  
-@lw.handle_ciao_errors( toolname, __revision__) 
+@lw.handle_ciao_errors(__toolname__, __revision__)
 def main():
     """
-    
+    Main routine
     """
 
-    from ciao_contrib.param_soaker import get_params
-    from ciao_contrib.runtool import dmmaskbin
-    from ciao_contrib.runtool import add_tool_history
-
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
-        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+    from ciao_contrib.param_soaker import get_params
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
 
     from ciao_contrib._tools.fileio import outfile_clobber_checks
-    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
-    outfile_clobber_checks(pars["clobber"], pars["binimg"] )
+    outfile_clobber_checks(pars["clobber"], pars["outfile"])
+    outfile_clobber_checks(pars["clobber"], pars["binimg"])
 
     import pycrates as pc
     inimg = pc.read_file(pars["infile"])
-    mask = inimg.get_image().values
+    mask = inimg.get_image().values  # mask pointing to data in the crate
 
     if "counts" == pars["method"]:
         counts = pc.read_file(pars["imgfile"]).get_image().values
@@ -125,25 +137,21 @@ def main():
     else:
         raise ValueError("Unknown value for method parameter")
 
-    purge_too_small( mask, int(pars["minvalue"]), counts )
+    purge_too_small(mask, int(pars["minvalue"]), counts)
 
-    pc.write_file( inimg, pars["outfile"], clobber=pars["clobber"] )
-    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+    pc.write_file(inimg, pars["outfile"], clobber=pars["clobber"])
 
-    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
-        dmmaskbin( pars["imgfile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
-        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
+    from ciao_contrib.runtool import add_tool_history
+    add_tool_history(pars["outfile"], __toolname__, pars,
+                     toolversion=__revision__)
 
-    
-
-
+    if len(pars["binimg"]) > 0 and "none" != pars["binimg"].lower():
+        from ciao_contrib.runtool import dmmaskbin
+        dmmaskbin(pars["imgfile"], pars["outfile"]+"[opt type=i4]",
+                  pars["binimg"], clobber=True)
+        add_tool_history(pars["binimg"], __toolname__, pars,
+                         toolversion=__revision__)
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as E:
-        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
-        sys.exit(1)
-    sys.exit(0)
-
+    main()

--- a/bin/merge_too_small
+++ b/bin/merge_too_small
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2014 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from __future__ import print_function
+
+
+toolname = "merge_too_small"
+__revision__ = "31 July 2017"
+
+import os
+import sys
+import numpy as np
+
+import ciao_contrib.logger_wrapper as lw
+lgr = lw.initialize_logger(toolname)
+verb0 = lgr.verbose0
+verb1 = lgr.verbose1
+verb2 = lgr.verbose2
+verb3 = lgr.verbose3
+verb5 = lgr.verbose5
+
+
+
+def find_neighbors( mask, maskval ):
+
+    xxyy = np.where( mask == maskval )
+    xy = zip(xxyy[1],xxyy[0])
+    retvals = []
+    for ee in xy:
+
+        for dy in [ee[1]-1, ee[1], ee[1]+1]:
+            if dy < 0 or dy >= mask.shape[0]:
+                continue
+
+            for dx in [ee[0]-1, ee[0], ee[0]+1]:
+                if dx < 0 or dx >= mask.shape[1]:
+                    continue
+
+                if mask[dy, dx] != maskval:
+                    retvals.append( int(mask[dy,dx]) )
+
+    retvals = set(retvals)
+    return list(retvals)
+
+
+def purge_too_small(mask, minarea, counts):    
+    """
+    """
+    mask_max = int(np.max(mask))
+    skiplist = []
+
+    while True:
+        hh = np.histogram( mask, bins=mask_max, range=(1,mask_max+1), weights=counts)
+        area = hh[0]
+        maskid = hh[1][:-1]
+        
+        am = list(zip( area, maskid ))
+        am.sort()        
+        am = [ x for x in am if x[0]>0 and x[0] not in skiplist ]
+        
+        if am[0][0] > minarea:
+            break
+
+        verb1("Working on mask_id {} with value {}".format(int(am[0][1]),am[0][0]))
+        nn = find_neighbors( mask, am[0][1])
+        if len(nn) == 0:
+            skiplist.append( am[0][1] )
+            continue
+        
+        nn = [i-1 for i in nn]
+        zz = list(zip( area[nn],maskid[nn]))
+        zz.sort()        
+        zz = [x for x in zz if (x[1] != am[0][1]) and (x[0]>0) and (x[1] not in skiplist)]
+        if len(zz) > 0:
+            replace_val = int(zz[0][1])
+            mask[ np.where( mask == int(am[0][1]) ) ] = replace_val
+        else:
+            skiplist.append(am[0][0])
+        
+
+
+  
+@lw.handle_ciao_errors( toolname, __revision__) 
+def main():
+    """
+    
+    """
+
+    from ciao_contrib.param_soaker import get_params
+    from ciao_contrib.runtool import dmmaskbin
+    from ciao_contrib.runtool import add_tool_history
+
+    # Load parameters
+    pars = get_params(toolname, "rw", sys.argv, 
+        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
+    outfile_clobber_checks(pars["clobber"], pars["binimg"] )
+
+    import pycrates as pc
+    inimg = pc.read_file(pars["infile"])
+    mask = inimg.get_image().values
+
+    if "counts" == pars["method"]:
+        counts = pc.read_file(pars["imgfile"]).get_image().values
+    elif "area" == pars["method"]:
+        counts = None
+    else:
+        raise ValueError("Unknown value for method parameter")
+
+    purge_too_small( mask, int(pars["minvalue"]), counts )
+
+    pc.write_file( inimg, pars["outfile"], clobber=pars["clobber"] )
+    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+
+    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
+        dmmaskbin( pars["imgfile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
+        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
+
+    
+
+
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as E:
+        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+

--- a/bin/mkregmap
+++ b/bin/mkregmap
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2014-2015,2020 Smithsonian Astrophysical Observatory
+# Copyright (C) 2014-2015, 2020, 2023
+# Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -18,55 +19,57 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+'Create a map from a stack of regions'
 
-toolname = "mkregmap"
-__revision__ = "29 December 2020"
 
 import sys
-import os
 
 import numpy as np
 from region import CXCRegion
 
-
 import ciao_contrib.logger_wrapper as lw
-lgr = lw.initialize_logger(toolname)
-verb0 = lgr.verbose0
-verb1 = lgr.verbose1
-verb2 = lgr.verbose2
-verb3 = lgr.verbose3
-verb5 = lgr.verbose5
 
 
+__toolname__ = "mkregmap"
+__revision__ = "24 August 2023"
 
-def parse_region( region_string ):
+__lgr__ = lw.initialize_logger(__toolname__)
+verb0 = __lgr__.verbose0
+verb1 = __lgr__.verbose1
+verb2 = __lgr__.verbose2
+verb3 = __lgr__.verbose3
+verb5 = __lgr__.verbose5
+
+
+def parse_region(region_string):
     """
     Parse stack of regions
     """
     # Region not pickle-able, so have to go serial
-    import stk as stk
-    ss = stk.build(region_string)
-    regions = [CXCRegion(s) for s in ss ]
+    import stk
+    mystk = stk.build(region_string)  # pylint: disable=no-member
+    regions = [CXCRegion(s) for s in mystk]
     return regions
-    
+
 
 class Image():
-    
-    def __init__( self, infile, coord="sky" ):
-        # Read the image file
+    'Class to load/save image'
+
+    def __init__(self, infile, coord="sky"):
+        'Read the image file'
         from crates_contrib.masked_image_crate import MaskedIMAGECrate
         img = MaskedIMAGECrate(infile)
 
         # Load the pixel values -- really just need the image size
         img_data = img.get_image().values
 
-        # Get lengths of each axis 
+        # Get lengths of each axis
         xlen = len(img_data[0])
         ylen = len(img_data)
 
-        # Get mapping to physical X,Y
-        if coord.lower() not in [x.lower() for x in img.get_axisnames()] :
-            raise ValueError("Coordinate '{}' is not in file".format(coord))
+        # Get mapping to physical X, Y
+        if coord.lower() not in [x.lower() for x in img.get_axisnames()]:
+            raise ValueError(f"Coordinate '{coord}' is not in file")
 
         self.sky = img.get_transform(coord)
         self.infile = infile
@@ -74,14 +77,21 @@ class Image():
         self.ylen = ylen
         self.img = img
 
-    def map_regions( self, regions ):
+    def save_map(self, outvals, outfile):
+        'Save the output file'
+
+        self.img.get_image().values = outvals
+        self.img.name = "REGMAP"
+        self.img.write(outfile, clobber=True)
+
+    def map_regions(self, regions):
         """
-        Determine which region each pixel belongs to.  
-        If there are multiple regions covering the same 
+        Determine which region each pixel belongs to.
+        If there are multiple regions covering the same
         pixel, then the last one will win.
         """
 
-        od = np.zeros( [self.ylen, self.xlen ] )
+        od = np.zeros([self.ylen, self.xlen])
 
         reg_no = 0
         for rr in regions:
@@ -89,99 +99,82 @@ class Image():
 
             # Compute bounds of region
             bnds = rr.extent()
-            xy = np.array([(bnds['x0'],bnds['y0']),
-                           (bnds['x1'],bnds['y1'])])
+            xy = np.array([(bnds['x0'], bnds['y0']),
+                           (bnds['x1'], bnds['y1'])])
             # Get bounds in image coordinates
             ij = self.sky.invert(xy)
 
             # Clip bounds 1:axis-length
-            i0 = np.floor(np.clip(ij[0][0],1,self.xlen)).astype('i4')
-            j0 = np.floor(np.clip(ij[0][1],1,self.ylen)).astype('i4')
-            i1 = np.ceil(np.clip(ij[1][0],1,self.xlen)).astype('i4')
-            j1 = np.ceil(np.clip(ij[1][1],1,self.ylen)).astype('i4')
+            i0 = np.floor(np.clip(ij[0][0], 1, self.xlen)).astype('i4')
+            j0 = np.floor(np.clip(ij[0][1], 1, self.ylen)).astype('i4')
+            i1 = np.ceil(np.clip(ij[1][0], 1, self.xlen)).astype('i4')
+            j1 = np.ceil(np.clip(ij[1][1], 1, self.ylen)).astype('i4')
 
-            # Number of pixels in x,y
+            # Number of pixels in x, y
             nx = i1-i0+1
             ny = j1-j0+1
-            
+
             # Setup arrays to do conversion from image to sky coords
-            ii = [float(x) for x in list(range( i0,i1+1)) * ny ]
-            jj = [float(x) for x in np.repeat( list(range(j0,j1+1)), nx) ]
+            ii = [float(x) for x in list(range(i0, i1+1)) * ny]
+            jj = [float(x) for x in np.repeat(list(range(j0, j1+1)), nx)]
 
             # Identify valid pixels
-            rirj = [ (i,j) for i,j in zip(ii,jj) if self.img.valid(int(i-1),int(j-1))]
+            rirj = [(i, j) for i, j in zip(ii, jj)
+                    if self.img.valid(int(i-1), int(j-1))]
             if len(rirj) == 0:
                 # no valid pixels, move on
                 continue
 
             # Compute sky coords
-            rxry = self.sky.apply( np.array(rirj))
+            rxry = self.sky.apply(np.array(rirj))
 
             # Now check pixels in bounding box around region
-            for kk in range(len(rxry)):
-                _i,_j = [int(q) for q in rirj[kk]]
+            for kk in range(len(rxry)):   # pylint: disable=consider-using-enumerate
+                _i, _j = [int(q) for q in rirj[kk]]
 
                 # If pixel already assigned, skip it
-                if od[_j-1,_i-1] != 0:
+                if od[_j-1, _i-1] != 0:
                     continue
- 
+
                 # If pixel is inside, tag it with region number.
-                _x,_y = rxry[kk]
-                if rr.is_inside(_x,_y):
-                    od[_j-1,_i-1] = reg_no
-        
+                _x, _y = rxry[kk]
+                if rr.is_inside(_x, _y):
+                    od[_j-1, _i-1] = reg_no
+
         return od
 
 
-def save_output( od, infile, outfile):
-    """
-    Save map, WANT to use same input crate, just replace pixel
-    values, but crates has bug in linear WCS, so go cxcdm
-    """
-
-    from cxcdm import dmImageOpen, dmBlockCreateCopy, dmDatasetCreate, dmImageSetData, dmImageGetDataDescriptor, dmImageClose
-
-    if os.path.exists( outfile ):
-        os.remove(outfile)
-
-    in_img = dmImageOpen(infile)
-    out_img = dmBlockCreateCopy( dmDatasetCreate(outfile), "REGMAP", in_img, copydata=False)
-    dmImageSetData( dmImageGetDataDescriptor( out_img), od )
-    dmImageClose( out_img)
-
-
-@lw.handle_ciao_errors( toolname, __revision__)
+@lw.handle_ciao_errors(__toolname__, __revision__)
 def main():
+    'Main routine'
 
     # get parameters
     from ciao_contrib.param_soaker import get_params
-    from ciao_contrib.runtool import dmmaskbin
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
-        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
 
     from ciao_contrib._tools.fileio import outfile_clobber_checks
-    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
+    outfile_clobber_checks(pars["clobber"], pars["outfile"])
+    outfile_clobber_checks(pars["clobber"], pars["binimg"])
 
-    
-    img = Image( pars["infile"], coord=pars["coord"] )
-    reg = parse_region( pars["regions"]  )
-    out = img.map_regions( reg )
-    save_output( out, pars["infile"], pars["outfile"] )
+    img = Image(pars["infile"], coord=pars["coord"])
+    reg = parse_region(pars["regions"])
+    out = img.map_regions(reg)
 
+    # Save output
+    img.save_map(out, pars["outfile"])
     from ciao_contrib.runtool import add_tool_history
-    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+    add_tool_history(pars["outfile"], __toolname__, pars,
+                     toolversion=__revision__)
 
-    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
-        dmmaskbin( pars["infile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
-        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
-
+    if len(pars["binimg"]) > 0 and "none" != pars["binimg"].lower():
+        from ciao_contrib.runtool import dmmaskbin  # pylint: disable=no-name-in-module
+        dmmaskbin(pars["infile"], pars["outfile"]+"[opt type=i4]",
+                  pars["binimg"], clobber=True)
+        add_tool_history(pars["binimg"], __toolname__, pars,
+                         toolversion=__revision__)
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as E:
-        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
-        sys.exit(1)
-    sys.exit(0)
+    main()

--- a/bin/mkregmap
+++ b/bin/mkregmap
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+
+#
+# Copyright (C) 2014-2015,2020 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+toolname = "mkregmap"
+__revision__ = "29 December 2020"
+
+import sys
+import os
+
+import numpy as np
+from region import CXCRegion
+
+
+import ciao_contrib.logger_wrapper as lw
+lgr = lw.initialize_logger(toolname)
+verb0 = lgr.verbose0
+verb1 = lgr.verbose1
+verb2 = lgr.verbose2
+verb3 = lgr.verbose3
+verb5 = lgr.verbose5
+
+
+
+def parse_region( region_string ):
+    """
+    Parse stack of regions
+    """
+    # Region not pickle-able, so have to go serial
+    import stk as stk
+    ss = stk.build(region_string)
+    regions = [CXCRegion(s) for s in ss ]
+    return regions
+    
+
+class Image():
+    
+    def __init__( self, infile, coord="sky" ):
+        # Read the image file
+        from crates_contrib.masked_image_crate import MaskedIMAGECrate
+        img = MaskedIMAGECrate(infile)
+
+        # Load the pixel values -- really just need the image size
+        img_data = img.get_image().values
+
+        # Get lengths of each axis 
+        xlen = len(img_data[0])
+        ylen = len(img_data)
+
+        # Get mapping to physical X,Y
+        if coord.lower() not in [x.lower() for x in img.get_axisnames()] :
+            raise ValueError("Coordinate '{}' is not in file".format(coord))
+
+        self.sky = img.get_transform(coord)
+        self.infile = infile
+        self.xlen = xlen
+        self.ylen = ylen
+        self.img = img
+
+    def map_regions( self, regions ):
+        """
+        Determine which region each pixel belongs to.  
+        If there are multiple regions covering the same 
+        pixel, then the last one will win.
+        """
+
+        od = np.zeros( [self.ylen, self.xlen ] )
+
+        reg_no = 0
+        for rr in regions:
+            reg_no = reg_no+1
+
+            # Compute bounds of region
+            bnds = rr.extent()
+            xy = np.array([(bnds['x0'],bnds['y0']),
+                           (bnds['x1'],bnds['y1'])])
+            # Get bounds in image coordinates
+            ij = self.sky.invert(xy)
+
+            # Clip bounds 1:axis-length
+            i0 = np.floor(np.clip(ij[0][0],1,self.xlen)).astype('i4')
+            j0 = np.floor(np.clip(ij[0][1],1,self.ylen)).astype('i4')
+            i1 = np.ceil(np.clip(ij[1][0],1,self.xlen)).astype('i4')
+            j1 = np.ceil(np.clip(ij[1][1],1,self.ylen)).astype('i4')
+
+            # Number of pixels in x,y
+            nx = i1-i0+1
+            ny = j1-j0+1
+            
+            # Setup arrays to do conversion from image to sky coords
+            ii = [float(x) for x in list(range( i0,i1+1)) * ny ]
+            jj = [float(x) for x in np.repeat( list(range(j0,j1+1)), nx) ]
+
+            # Identify valid pixels
+            rirj = [ (i,j) for i,j in zip(ii,jj) if self.img.valid(int(i-1),int(j-1))]
+            if len(rirj) == 0:
+                # no valid pixels, move on
+                continue
+
+            # Compute sky coords
+            rxry = self.sky.apply( np.array(rirj))
+
+            # Now check pixels in bounding box around region
+            for kk in range(len(rxry)):
+                _i,_j = [int(q) for q in rirj[kk]]
+
+                # If pixel already assigned, skip it
+                if od[_j-1,_i-1] != 0:
+                    continue
+ 
+                # If pixel is inside, tag it with region number.
+                _x,_y = rxry[kk]
+                if rr.is_inside(_x,_y):
+                    od[_j-1,_i-1] = reg_no
+        
+        return od
+
+
+def save_output( od, infile, outfile):
+    """
+    Save map, WANT to use same input crate, just replace pixel
+    values, but crates has bug in linear WCS, so go cxcdm
+    """
+
+    from cxcdm import dmImageOpen, dmBlockCreateCopy, dmDatasetCreate, dmImageSetData, dmImageGetDataDescriptor, dmImageClose
+
+    if os.path.exists( outfile ):
+        os.remove(outfile)
+
+    in_img = dmImageOpen(infile)
+    out_img = dmBlockCreateCopy( dmDatasetCreate(outfile), "REGMAP", in_img, copydata=False)
+    dmImageSetData( dmImageGetDataDescriptor( out_img), od )
+    dmImageClose( out_img)
+
+
+@lw.handle_ciao_errors( toolname, __revision__)
+def main():
+
+    # get parameters
+    from ciao_contrib.param_soaker import get_params
+    from ciao_contrib.runtool import dmmaskbin
+    # Load parameters
+    pars = get_params(toolname, "rw", sys.argv, 
+        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
+
+    
+    img = Image( pars["infile"], coord=pars["coord"] )
+    reg = parse_region( pars["regions"]  )
+    out = img.map_regions( reg )
+    save_output( out, pars["infile"], pars["outfile"] )
+
+    from ciao_contrib.runtool import add_tool_history
+    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+
+    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
+        dmmaskbin( pars["infile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
+        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
+
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as E:
+        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)

--- a/bin/pathfinder
+++ b/bin/pathfinder
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2017 Smithsonian Astrophysical Observatory
+# Copyright (C) 2017, 2023 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
@@ -17,41 +17,43 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-import os
+'Group pixels together based on steepest assent'
+
+
 import sys
 
-
-
-toolname = "pathfinder"
-__revision__ = "27 June 2017"
-
-
 import ciao_contrib.logger_wrapper as lw
-lgr = lw.initialize_logger(toolname)
-verb0 = lgr.verbose0
-verb1 = lgr.verbose1
-verb2 = lgr.verbose2
-verb3 = lgr.verbose3
-verb5 = lgr.verbose5
 
+__toolname__ = "pathfinder"
+__revision__ = "24 August 2023"
+
+__lgr__ = lw.initialize_logger(__toolname__)
+verb0 = __lgr__.verbose0
+verb1 = __lgr__.verbose1
+verb2 = __lgr__.verbose2
+verb3 = __lgr__.verbose3
+verb5 = __lgr__.verbose5
 
 
 class PathFinderBase():
-    
-    def __init__(self, infile, debugfile ):
+    'Base class for pathfinder objects'
+
+    neighborhood = None
+
+    def __init__(self, infile, debugfile):
         """
-        
+        load data and do setup
         """
 
         # Load the input image file
-        from pycrates import read_file
-        self.crate = read_file(infile)
-        self.img = self.crate.get_image().values        
+        from crates_contrib.masked_image_crate import MaskedIMAGECrate
+
+        self.crate = MaskedIMAGECrate(infile)
+        self.img = self.crate.get_image().values
         self.xlen = self.img.shape[1]
         self.ylen = self.img.shape[0]
 
-        # Create the 
+        # Create the
         self.maxid = 0
         self.cell_list = {}
 
@@ -61,20 +63,19 @@ class PathFinderBase():
         # Init the debugregion file, if any
         self.init_debugfile(debugfile)
 
-
     def init_debugfile(self, debugfile):
         """Setup the debug region file file"""
 
-        if debugfile.lower().strip() in ["","none"]:
+        if debugfile.lower().strip() in ["", "none"]:
             self.fp = None
             return
 
-        self.fp = open(debugfile,"w") #NB:  Clobber is done in the main routine 
+        # NB:  Clobber is done in the main routine
+        self.fp = open(debugfile, "w")
 
         self.fp.write('# Region file format: DS9 version 4.1\n')
         self.fp.write('global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n')
         self.fp.write('image\n')  # Yes, image coordinates -- just easier!
-
 
     def __del__(self):
         """
@@ -83,180 +84,159 @@ class PathFinderBase():
         if self.fp is not None:
             self.fp.close()
 
-        
-
-    def find_peak( self, xx, yy ):
+    def find_peak(self, xx, yy):
         """
         From the starting location we follow the gradient up to the
         local maximum.
-        
+
         Since we know all these pixels will follow the same gradient, we
-        return the entire path to the max so that we can set all the 
+        return the entire path to the max so that we can set all the
         pixels along the way to the same cell.
         """
 
         # Starting location
-        xmax = xx  
-        ymax = yy  
+        xmax = xx
+        ymax = yy
         maxval = self.img[ymax][xmax]
 
-        _path = [ (xmax,ymax) ]
-            
+        _path = [(xmax, ymax)]
+
         while True:
             imax = None
             jmax = None
 
-            for ii,jj in self.neighborhood:
+            for ii, jj in self.neighborhood:
                 yat = ymax+jj
-                if (yat < 0) or (yat >= self.ylen):  continue
-                
+                if (yat < 0) or (yat >= self.ylen):
+                    continue
+
                 xat = xmax+ii
-                if (xat < 0) or (xat >= self.xlen):  continue
+                if (xat < 0) or (xat >= self.xlen):
+                    continue
 
                 if self.img[yat][xat] > maxval:
                     imax = ii
                     jmax = jj
                     maxval = self.img[yat][xat]
-                        
+
             if imax is None:
                 # max didn't move, we're done
                 return _path
-            else:
-                xmax = xmax + imax
-                ymax = ymax + jmax
-                _path.append( (xmax,ymax) )
 
+            xmax = xmax + imax
+            ymax = ymax + jmax
+            _path.append((xmax, ymax))
 
-    def get_cellid( self, max_loc ):
-        """ 
+    def get_cellid(self, max_loc):
+        """
         Get the cellid for the current local maximum location.  If it
         doesn't already exist, then add it to the list and increment
         counter.
         """
-        if ( max_loc not in self.cell_list ):
-            self.maxid = self.maxid +1
+        if max_loc not in self.cell_list:
+            self.maxid = self.maxid + 1
             self.cell_list[max_loc] = self.maxid
-        
+
         return self.cell_list[max_loc]
 
-
-    def paint( self, minval ):
+    def paint(self, minval):
         """
-        
+        Loop over pixels and assign to group based on steepest assent.
         """
-        import numpy as np
 
         for yy in range(self.ylen):
-            for xx in range(self.xlen):                
+            for xx in range(self.xlen):
                 # check threshold value
-                if (self.img[yy][xx] <= minval): 
+                if self.img[yy][xx] <= minval:
                     self.out[yy][xx] = 0
                     continue
-                if np.isnan( self.img[yy][xx] ): 
+
+                if not self.crate.valid(xx, yy):
                     self.out[yy][xx] = 0
                     continue
 
                 # check, if point already processed
-                if (self.out[yy][xx] > 0 ) : continue
-   
-                path = self.find_peak( xx, yy )
+                if self.out[yy][xx] > 0:
+                    continue
+
+                path = self.find_peak(xx, yy)
 
                 self._debug(path)
 
-                # Set all pixels along the path to the 
+                # Set all pixels along the path to the
                 # cellid associated with the max (the max is the
                 # last point in the path.
-                for px,py in path:
-                    if (self.out[py][px] > 0) : break
-                    self.out[py][px] = self.get_cellid( path[-1] )
+                for px, py in path:
+                    if self.out[py][px] > 0:
+                        break
+                    self.out[py][px] = self.get_cellid(path[-1])
 
-
-    def write( self, outfile, clobber=True ):
+    def write(self, outfile, clobber=True):
         """
         Write output. Uses the input crate and just replaces the
         pixel values.
-
-        TODO: creator keyword(?)
-        """        
+        """
         self.crate.get_image().values = self.out.astype("i4")
-        self.crate.write(outfile, clobber=clobber )
+        self.crate.name = "PATHMAP"
+        self.crate.write(outfile, clobber=clobber)
 
-
-    def _debug(self,path):
+    def _debug(self, path):
         """
         Write out a ds9 region file
         """
         if self.fp is None:
             return
 
-        if len(path)>1:
-            pts = ""
-            for x,y in path:
-                pts = pts + "{},{},".format(x+1,y+1)
-            self.fp.write( "# segment({})\n".format(pts[:-1]))
+        if len(path) > 1:
+            pts = [f"{x+1}, {y+1}" for x, y in path]
+            pts = ",".join(pts)
+            self.fp.write(f"# segment({pts})\n")
         else:
-            self.fp.write("point({},{}) # point=circle\n".format(path[0][0]+1,path[0][1]+1))\
+            self.fp.write(f"point({path[0][0]+1}, {path[0][1]+1}) # point=circle\n")
 
-        
 
 class PathFinderPerpendicular(PathFinderBase):
     """
     Only allow the gradient search to occur in perpendicular directions.
     """
-    neighborhood = [[-1,0],[0,1],[1,0],[0,-1]]
+    neighborhood = [[-1, 0], [0, 1], [1, 0], [0, -1]]
+
 
 class PathFinderDiagonal(PathFinderBase):
     """
     Allow the gradient search in perpendicular or diagonal directions.
     """
-    neighborhood = [[-1,-1],[-1,0],[-1,1],[0,-1],[0,1],[1,-1],[1,0],[1,1]]
+    neighborhood = [[-1, -1], [-1, 0], [-1, 1], [0, -1],
+                    [0, 1], [1, -1], [1, 0], [1, 1]]
 
 
-@lw.handle_ciao_errors( toolname, __revision__)
+@lw.handle_ciao_errors(__toolname__, __revision__)
 def main():
+    """Main routine
     """
-    """
-    # get parameters
-    from ciao_contrib.param_soaker import get_params
-    from ciao_contrib.runtool import add_tool_history
 
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
-        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+    from ciao_contrib.param_soaker import get_params
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
 
     from ciao_contrib._tools.fileio import outfile_clobber_checks
-    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
-    outfile_clobber_checks(pars["clobber"], pars["debugreg"] )
+    outfile_clobber_checks(pars["clobber"], pars["outfile"])
+    outfile_clobber_checks(pars["clobber"], pars["debugreg"])
 
     if "diagonal" == pars["direction"].strip().lower():
-        img = PathFinderDiagonal( pars["infile"], pars["debugreg"] )
+        img = PathFinderDiagonal(pars["infile"], pars["debugreg"])
     elif "perpendicular" == pars["direction"].strip().lower():
-        img = PathFinderPerpendicular( pars["infile"], pars["debugreg"] )
+        img = PathFinderPerpendicular(pars["infile"], pars["debugreg"])
     else:
-        raise ValueError("Unknown value for direction '{}'".format(pars["direction"]))
-    
-    img.paint( float( pars["minval"]))
-    img.write( pars["outfile"] )
-    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
-    
- 
-   
+        raise ValueError("Unknown value for direction '{pars['direction']}'")
+
+    img.paint(float(pars["minval"]))
+    img.write(pars["outfile"])
+    from ciao_contrib.runtool import add_tool_history
+    add_tool_history(pars["outfile"], __toolname__, pars,
+                     toolversion=__revision__)
+
+
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as E:
-        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
-        sys.exit(1)
-    sys.exit(0)
-
-
-
-
-
-
-
-
-
-
-
-
+    main()

--- a/bin/pathfinder
+++ b/bin/pathfinder
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2017 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from __future__ import print_function
+import os
+import sys
+
+
+
+toolname = "pathfinder"
+__revision__ = "27 June 2017"
+
+
+import ciao_contrib.logger_wrapper as lw
+lgr = lw.initialize_logger(toolname)
+verb0 = lgr.verbose0
+verb1 = lgr.verbose1
+verb2 = lgr.verbose2
+verb3 = lgr.verbose3
+verb5 = lgr.verbose5
+
+
+
+class PathFinderBase():
+    
+    def __init__(self, infile, debugfile ):
+        """
+        
+        """
+
+        # Load the input image file
+        from pycrates import read_file
+        self.crate = read_file(infile)
+        self.img = self.crate.get_image().values        
+        self.xlen = self.img.shape[1]
+        self.ylen = self.img.shape[0]
+
+        # Create the 
+        self.maxid = 0
+        self.cell_list = {}
+
+        # Create the output image array
+        self.out = 0*self.img
+
+        # Init the debugregion file, if any
+        self.init_debugfile(debugfile)
+
+
+    def init_debugfile(self, debugfile):
+        """Setup the debug region file file"""
+
+        if debugfile.lower().strip() in ["","none"]:
+            self.fp = None
+            return
+
+        self.fp = open(debugfile,"w") #NB:  Clobber is done in the main routine 
+
+        self.fp.write('# Region file format: DS9 version 4.1\n')
+        self.fp.write('global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1\n')
+        self.fp.write('image\n')  # Yes, image coordinates -- just easier!
+
+
+    def __del__(self):
+        """
+        make sure debug file gets closed.
+        """
+        if self.fp is not None:
+            self.fp.close()
+
+        
+
+    def find_peak( self, xx, yy ):
+        """
+        From the starting location we follow the gradient up to the
+        local maximum.
+        
+        Since we know all these pixels will follow the same gradient, we
+        return the entire path to the max so that we can set all the 
+        pixels along the way to the same cell.
+        """
+
+        # Starting location
+        xmax = xx  
+        ymax = yy  
+        maxval = self.img[ymax][xmax]
+
+        _path = [ (xmax,ymax) ]
+            
+        while True:
+            imax = None
+            jmax = None
+
+            for ii,jj in self.neighborhood:
+                yat = ymax+jj
+                if (yat < 0) or (yat >= self.ylen):  continue
+                
+                xat = xmax+ii
+                if (xat < 0) or (xat >= self.xlen):  continue
+
+                if self.img[yat][xat] > maxval:
+                    imax = ii
+                    jmax = jj
+                    maxval = self.img[yat][xat]
+                        
+            if imax is None:
+                # max didn't move, we're done
+                return _path
+            else:
+                xmax = xmax + imax
+                ymax = ymax + jmax
+                _path.append( (xmax,ymax) )
+
+
+    def get_cellid( self, max_loc ):
+        """ 
+        Get the cellid for the current local maximum location.  If it
+        doesn't already exist, then add it to the list and increment
+        counter.
+        """
+        if ( max_loc not in self.cell_list ):
+            self.maxid = self.maxid +1
+            self.cell_list[max_loc] = self.maxid
+        
+        return self.cell_list[max_loc]
+
+
+    def paint( self, minval ):
+        """
+        
+        """
+        import numpy as np
+
+        for yy in range(self.ylen):
+            for xx in range(self.xlen):                
+                # check threshold value
+                if (self.img[yy][xx] <= minval): 
+                    self.out[yy][xx] = 0
+                    continue
+                if np.isnan( self.img[yy][xx] ): 
+                    self.out[yy][xx] = 0
+                    continue
+
+                # check, if point already processed
+                if (self.out[yy][xx] > 0 ) : continue
+   
+                path = self.find_peak( xx, yy )
+
+                self._debug(path)
+
+                # Set all pixels along the path to the 
+                # cellid associated with the max (the max is the
+                # last point in the path.
+                for px,py in path:
+                    if (self.out[py][px] > 0) : break
+                    self.out[py][px] = self.get_cellid( path[-1] )
+
+
+    def write( self, outfile, clobber=True ):
+        """
+        Write output. Uses the input crate and just replaces the
+        pixel values.
+
+        TODO: creator keyword(?)
+        """        
+        self.crate.get_image().values = self.out.astype("i4")
+        self.crate.write(outfile, clobber=clobber )
+
+
+    def _debug(self,path):
+        """
+        Write out a ds9 region file
+        """
+        if self.fp is None:
+            return
+
+        if len(path)>1:
+            pts = ""
+            for x,y in path:
+                pts = pts + "{},{},".format(x+1,y+1)
+            self.fp.write( "# segment({})\n".format(pts[:-1]))
+        else:
+            self.fp.write("point({},{}) # point=circle\n".format(path[0][0]+1,path[0][1]+1))\
+
+        
+
+class PathFinderPerpendicular(PathFinderBase):
+    """
+    Only allow the gradient search to occur in perpendicular directions.
+    """
+    neighborhood = [[-1,0],[0,1],[1,0],[0,-1]]
+
+class PathFinderDiagonal(PathFinderBase):
+    """
+    Allow the gradient search in perpendicular or diagonal directions.
+    """
+    neighborhood = [[-1,-1],[-1,0],[-1,1],[0,-1],[0,1],[1,-1],[1,0],[1,1]]
+
+
+@lw.handle_ciao_errors( toolname, __revision__)
+def main():
+    """
+    """
+    # get parameters
+    from ciao_contrib.param_soaker import get_params
+    from ciao_contrib.runtool import add_tool_history
+
+    # Load parameters
+    pars = get_params(toolname, "rw", sys.argv, 
+        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
+    outfile_clobber_checks(pars["clobber"], pars["debugreg"] )
+
+    if "diagonal" == pars["direction"].strip().lower():
+        img = PathFinderDiagonal( pars["infile"], pars["debugreg"] )
+    elif "perpendicular" == pars["direction"].strip().lower():
+        img = PathFinderPerpendicular( pars["infile"], pars["debugreg"] )
+    else:
+        raise ValueError("Unknown value for direction '{}'".format(pars["direction"]))
+    
+    img.paint( float( pars["minval"]))
+    img.write( pars["outfile"] )
+    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+    
+ 
+   
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as E:
+        print("\n# "+toolname+" ("+__revision__+"): ERROR "+str(E)+"\n", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+
+
+
+
+
+
+
+
+
+
+
+

--- a/bin/vtbin
+++ b/bin/vtbin
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2014-2020 Smithsonian Astrophysical Observatory
+# Copyright (C) 2014-2020, 2023
+# Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,22 +18,24 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from __future__ import print_function
-
-toolname = "vtbin"
-__revision__ = "24 December 2020"
+'Create bins based on voroni tesselation'
 
 
 import os
 import sys
 
 import ciao_contrib.logger_wrapper as lw
-lgr = lw.initialize_logger(toolname)
-verb0 = lgr.verbose0
-verb1 = lgr.verbose1
-verb2 = lgr.verbose2
-verb3 = lgr.verbose3
-verb5 = lgr.verbose5
+
+
+__toolname__ = "vtbin"
+__revision__ = "24 August 2023"
+
+__lgr__ = lw.initialize_logger(__toolname__)
+verb0 = __lgr__.verbose0
+verb1 = __lgr__.verbose1
+verb2 = __lgr__.verbose2
+verb3 = __lgr__.verbose3
+verb5 = __lgr__.verbose5
 
 
 class CIAOTemporaryFile():
@@ -40,18 +43,19 @@ class CIAOTemporaryFile():
     A little class to make sure that tmpfiles are forcefully removed at end.
     """
 
-    def __init__( self, *args, **kwargs ):
-        from tempfile import NamedTemporaryFile    
-        self.tmpfile = NamedTemporaryFile( dir=os.environ["ASCDS_WORK_PATH"], delete=False, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        from tempfile import NamedTemporaryFile
+        self.tmpfile = NamedTemporaryFile(dir=os.environ["ASCDS_WORK_PATH"],
+                                          delete=False, *args, **kwargs)
         self.name = self.tmpfile.name
 
     def __del__(self):
         self.tmpfile.close()
-        if os.path.exists( self.name ):
-            os.remove( self.name )
+        if os.path.exists(self.name):
+            os.remove(self.name)
 
 
-def find_local_max( infile, mask="box(0,0,5,5)"):
+def find_local_max(infile, mask="box(0, 0, 5, 5)"):
     """
     Identify the local peaks in the data.  Value must be the max() valein the
     mask region around the pixel (must be strictly > all surrounding pixels)
@@ -64,91 +68,96 @@ def find_local_max( infile, mask="box(0,0,5,5)"):
     t1 = CIAOTemporaryFile()
     t2 = CIAOTemporaryFile()
     nn = t2.name
-    
-    dmimgfilt( infile, t1.name, function="peak", mask=mask, clobber=True)
-    dmimgblob( t1.name, nn, thresh=0, src=True, clobber=True )
+
+    dmimgfilt(infile, t1.name, function="peak", mask=mask, clobber=True)
+    dmimgblob(t1.name, nn, thresh=0, src=True, clobber=True)
     return t2
 
 
-def make_mask( shape, radius ):
+def make_mask(shape, radius):
     """
-    This is the mask used to determine local max    
+    This is the mask used to determine local max
     """
-    
-    if "circle" == shape:
-        return "circle(0,0,{})".format(radius)
-    elif "box" == shape:
-        r = float(radius)*2.0
-        return "box(0,0,{},{})".format(r,r)
-    else:
-        raise RuntimeError("Unknown shape '{}'".format(shape))
 
+    if "circle" == shape:
+        return f"circle(0, 0, {radius})"
+
+    if "box" == shape:
+        r = float(radius)*2.0
+        return f"box(0, 0, {r}, {r})"
+
+    raise RuntimeError(f"Unknown shape '{shape}'")
 
 
 def cercle_circonscrit(T):
     """Find the center of a circle that circumscribes 3 points (triangle)
-    
+
     The 3 points cannot be colinear or this blows up.
-        
-    https://stackoverflow.com/questions/44231281/circumscribed-circle-of-a-triangle-in-2d
+
+    https: //stackoverflow.com/questions/44231281/circumscribed-circle-of-a-triangle-in-2d
     """
     import numpy as np
-    from math import sqrt
     (x1, y1), (x2, y2), (x3, y3) = T
-    A = np.array([[x3-x1,y3-y1],[x3-x2,y3-y2]])
-    Y = np.array([(x3**2 + y3**2 - x1**2 - y1**2),(x3**2+y3**2 - x2**2-y2**2)])
+    A = np.array([[x3-x1, y3-y1], [x3-x2, y3-y2]])
+    Y = np.array([(x3**2 + y3**2 - x1**2 - y1**2),
+                  (x3**2+y3**2 - x2**2-y2**2)])
     if np.linalg.det(A) == 0:
         return False
     Ainv = np.linalg.inv(A)
-    X = 0.5*np.dot(Ainv,Y)
-    x,y = X[0],X[1]
-    #r = sqrt((x-x1)**2+(y-y1)**2)
-    return (x,y) #,r
+    X = 0.5*np.dot(Ainv, Y)
+    x, y = X[0], X[1]
+    # r = sqrt((x-x1)**2+(y-y1)**2)
+    return (x, y)   # , r
 
 
 class Cell():
     """Class to hold Voronoi cells"""
-    
-    def __init__(self,x,y):
+
+    def __init__(self, x, y):
+        'Hold info about cells'
         self.x = x
         self.y = y
         self.neighbors = []
-        
+
     def calc_midpts(self):
+        'Convert center of triangles into voronoi cells'
         from math import atan2
         self.midpts = []
         for n in self.neighbors:
-            (midx,midy) = n
-            ang = atan2(midy-self.y,midx-self.x)
-            self.midpts.append( (ang,(midx,midy)))
-        
+            (midx, midy) = n
+            ang = atan2(midy-self.y, midx-self.x)
+
+            # Do not add duplicate points
+            to_add = (ang, (midx, midy))
+            if to_add not in self.midpts:
+                self.midpts.append(to_add)
+
         self.midpts.sort()
-        self.cellx=[]
-        self.celly=[]
+        self.cellx = []
+        self.celly = []
         for p in self.midpts:
             self.cellx.append(p[1][0])
             self.celly.append(p[1][1])
-                    
-    
 
-def make_vcells( x, y ):
+
+def make_vcells(x, y):
     """
     Use matplotlib's Traiangulation to create Delauny triangulation,
     then find centers of triangles to create Voronoi cells.
     """
 
     import matplotlib.tri as mtri
-    tri = mtri.Triangulation(x,y)
+    tri = mtri.Triangulation(x, y)
 
-    pts = [Cell(_x,_y) for _x,_y in zip(x,y)]
+    pts = [Cell(_x, _y) for _x, _y in zip(x, y)]
 
     for t in tri.get_masked_triangles():
-        # Find center of triangle; add center to list of 
+        # Find center of triangle; add center to list of
         # neighbors at each vertex of the triangle
-        midx,midy=cercle_circonscrit(list(zip(x[t],y[t])))        
-        pts[t[0]].neighbors.append((midx,midy))
-        pts[t[1]].neighbors.append((midx,midy))
-        pts[t[2]].neighbors.append((midx,midy))
+        midx, midy = cercle_circonscrit(list(zip(x[t], y[t])))
+        pts[t[0]].neighbors.append((midx, midy))
+        pts[t[1]].neighbors.append((midx, midy))
+        pts[t[2]].neighbors.append((midx, midy))
 
     for p in pts:
         p.calc_midpts()
@@ -160,23 +169,31 @@ def make_polygon(cell, img_shape):
     "Create polygon and compute extent bounded by image"
     import numpy as np
     from region import polygon
-    
-    p = polygon( cell.cellx, cell.celly)
+
+    try:
+        p = polygon(cell.cellx, cell.celly)
+
+        if len(p) == 0:
+            raise RuntimeError("Bad polygon")
+    except Exception as bad:
+        print(f"Cellx: {cell.cellx}")
+        print(f"Celly: {cell.celly}")
+        raise bad
 
     # Loop over pixels just inside extent of polygon
-    ext=p.extent()
-    xl = max([0,int(ext['x0'])])
+    ext = p.extent()
+    xl = max([0, int(ext['x0'])])
     xh = min([img_shape[1], int(ext['x1']+1)])
-    yl = max([0,int(ext['y0'])])
+    yl = max([0, int(ext['y0'])])
     yh = min([img_shape[0], int(ext['y1']+1)])
 
-    _yrange = np.arange(yl,yh)
-    _xrange = np.arange(xl,xh)
-    
+    _yrange = np.arange(yl, yh)
+    _xrange = np.arange(xl, xh)
+
     return p, _xrange, _yrange
 
 
-def compute_vcells( infile, sitesfile, outfile, clobber ):
+def compute_vcells(infile, sitesfile, outfile, clobber):
     """
     Given a set of local max, grow the regions until they touch and
     cover the image
@@ -187,93 +204,90 @@ def compute_vcells( infile, sitesfile, outfile, clobber ):
     verb1("Assigning pixels to maxima")
 
     # Load data
-    img = MaskedIMAGECrate(sitesfile,mode="r")
+    img = MaskedIMAGECrate(sitesfile, mode="r")
     imgd = img.get_image()
     vv = imgd.values
 
     # Open infile to get subspace
-    dss_img = MaskedIMAGECrate(infile,mode="r")
+    dss_img = MaskedIMAGECrate(infile, mode="r")
 
     # get non-zero pixels
-    sites = np.argwhere(vv>0)
+    sites = np.argwhere(vv > 0)
 
     # get pixel value at all non-zero pixels
-    sitesv = [vv[y,x] for y,x in sites]
+    sitesv = [vv[y, x] for y, x in sites]
 
-    # get x,y coords of non-zero pixels
-    xx = sites[:,1]
-    yy = sites[:,0]
+    # get x, y coords of non-zero pixels
+    xx = sites[:, 1]
+    yy = sites[:, 0]
 
     # Compute V. cells.
-    cells = make_vcells( xx, yy)
+    cells = make_vcells(xx, yy)
 
-    # Now fill in the V. cells with the pixel value    
+    # Now fill in the V. cells with the pixel value
     outvv = np.zeros_like(vv)
-    for c,v in zip(cells,sitesv):
+    for c, v in zip(cells, sitesv):
 
         try:
             p, _xrange, _yrange = make_polygon(c, vv.shape)
-        except:
+        except Exception:
             continue
-        
+
         for _y in _yrange:
             for _x in _xrange:
                 # Pixel already assigned, skip it
-                if outvv[_y,_x] != 0:
+                if outvv[_y, _x] != 0:
                     continue
 
                 # Pixel not in subspace, skip it
-                if not dss_img.valid(_x,_y):
+                if not dss_img.valid(_x, _y):
                     continue
-                
-                # Do the hard work
-                if p.is_inside(_x,_y):
-                    outvv[_y,_x] = v
 
-    # Save the values 
+                # Do the hard work
+                if p.is_inside(_x, _y):
+                    outvv[_y, _x] = v
+
+    # Save the values
     imgd.values = outvv
     img.name = "tess"
-    img.write( outfile, clobber=clobber )
+    img.write(outfile, clobber=clobber)
 
 
-@lw.handle_ciao_errors( toolname, __revision__)
+@lw.handle_ciao_errors(__toolname__, __revision__)
 def main():
     """
-    
+    main routine
     """
-    # get parameters
-    from ciao_contrib.param_soaker import get_params
-    from ciao_contrib.runtool import dmmaskbin
-    from ciao_contrib.runtool import add_tool_history
-
     # Load parameters
-    pars = get_params(toolname, "rw", sys.argv, 
-        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+    from ciao_contrib.param_soaker import get_params
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": verb1})
 
     from ciao_contrib._tools.fileio import outfile_clobber_checks
-    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
-    outfile_clobber_checks(pars["clobber"], pars["binimg"] )
+    outfile_clobber_checks(pars["clobber"], pars["outfile"])
+    outfile_clobber_checks(pars["clobber"], pars["binimg"])
 
-    mask = make_mask( pars["shape"], pars["radius"] )
-    
-    if (len(pars["sitefile"]) == 0) or ("none" == pars["sitefile"].lower()):
-        tmpsitefile = find_local_max( pars["infile"], mask=mask )
+    mask = make_mask(pars["shape"], pars["radius"])
+
+    if len(pars["sitefile"]) == 0 or "none" == pars["sitefile"].lower():
+        tmpsitefile = find_local_max(pars["infile"], mask=mask)
         sitefile = tmpsitefile.name
     else:
         sitefile = pars["sitefile"]
 
-    compute_vcells( pars["infile"], sitefile, pars["outfile"], pars["clobber"] )
-    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
-    
-    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
-        dmmaskbin( pars["infile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
-        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
+    compute_vcells(pars["infile"], sitefile, pars["outfile"], pars["clobber"])
 
+    from ciao_contrib.runtool import add_tool_history
+    add_tool_history(pars["outfile"], __toolname__, pars,
+                     toolversion=__revision__)
+
+    if len(pars["binimg"]) > 0 and "none" != pars["binimg"].lower():
+        from ciao_contrib.runtool import dmmaskbin
+        dmmaskbin(pars["infile"], pars["outfile"]+"[opt type=i4]",
+                  pars["binimg"], clobber=True)
+        add_tool_history(pars["binimg"], __toolname__, pars,
+                         toolversion=__revision__)
 
 
 if __name__ == "__main__":
     main()
-
-
-
-

--- a/bin/vtbin
+++ b/bin/vtbin
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2014-2020 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+from __future__ import print_function
+
+toolname = "vtbin"
+__revision__ = "24 December 2020"
+
+
+import os
+import sys
+
+import ciao_contrib.logger_wrapper as lw
+lgr = lw.initialize_logger(toolname)
+verb0 = lgr.verbose0
+verb1 = lgr.verbose1
+verb2 = lgr.verbose2
+verb3 = lgr.verbose3
+verb5 = lgr.verbose5
+
+
+class CIAOTemporaryFile():
+    """
+    A little class to make sure that tmpfiles are forcefully removed at end.
+    """
+
+    def __init__( self, *args, **kwargs ):
+        from tempfile import NamedTemporaryFile    
+        self.tmpfile = NamedTemporaryFile( dir=os.environ["ASCDS_WORK_PATH"], delete=False, *args, **kwargs)
+        self.name = self.tmpfile.name
+
+    def __del__(self):
+        self.tmpfile.close()
+        if os.path.exists( self.name ):
+            os.remove( self.name )
+
+
+def find_local_max( infile, mask="box(0,0,5,5)"):
+    """
+    Identify the local peaks in the data.  Value must be the max() valein the
+    mask region around the pixel (must be strictly > all surrounding pixels)
+    """
+    from ciao_contrib.runtool import dmimgfilt
+    from ciao_contrib.runtool import dmimgblob
+
+    verb1("Finding local maxima")
+
+    t1 = CIAOTemporaryFile()
+    t2 = CIAOTemporaryFile()
+    nn = t2.name
+    
+    dmimgfilt( infile, t1.name, function="peak", mask=mask, clobber=True)
+    dmimgblob( t1.name, nn, thresh=0, src=True, clobber=True )
+    return t2
+
+
+def make_mask( shape, radius ):
+    """
+    This is the mask used to determine local max    
+    """
+    
+    if "circle" == shape:
+        return "circle(0,0,{})".format(radius)
+    elif "box" == shape:
+        r = float(radius)*2.0
+        return "box(0,0,{},{})".format(r,r)
+    else:
+        raise RuntimeError("Unknown shape '{}'".format(shape))
+
+
+
+def cercle_circonscrit(T):
+    """Find the center of a circle that circumscribes 3 points (triangle)
+    
+    The 3 points cannot be colinear or this blows up.
+        
+    https://stackoverflow.com/questions/44231281/circumscribed-circle-of-a-triangle-in-2d
+    """
+    import numpy as np
+    from math import sqrt
+    (x1, y1), (x2, y2), (x3, y3) = T
+    A = np.array([[x3-x1,y3-y1],[x3-x2,y3-y2]])
+    Y = np.array([(x3**2 + y3**2 - x1**2 - y1**2),(x3**2+y3**2 - x2**2-y2**2)])
+    if np.linalg.det(A) == 0:
+        return False
+    Ainv = np.linalg.inv(A)
+    X = 0.5*np.dot(Ainv,Y)
+    x,y = X[0],X[1]
+    #r = sqrt((x-x1)**2+(y-y1)**2)
+    return (x,y) #,r
+
+
+class Cell():
+    """Class to hold Voronoi cells"""
+    
+    def __init__(self,x,y):
+        self.x = x
+        self.y = y
+        self.neighbors = []
+        
+    def calc_midpts(self):
+        from math import atan2
+        self.midpts = []
+        for n in self.neighbors:
+            (midx,midy) = n
+            ang = atan2(midy-self.y,midx-self.x)
+            self.midpts.append( (ang,(midx,midy)))
+        
+        self.midpts.sort()
+        self.cellx=[]
+        self.celly=[]
+        for p in self.midpts:
+            self.cellx.append(p[1][0])
+            self.celly.append(p[1][1])
+                    
+    
+
+def make_vcells( x, y ):
+    """
+    Use matplotlib's Traiangulation to create Delauny triangulation,
+    then find centers of triangles to create Voronoi cells.
+    """
+
+    import matplotlib.tri as mtri
+    tri = mtri.Triangulation(x,y)
+
+    pts = [Cell(_x,_y) for _x,_y in zip(x,y)]
+
+    for t in tri.get_masked_triangles():
+        # Find center of triangle; add center to list of 
+        # neighbors at each vertex of the triangle
+        midx,midy=cercle_circonscrit(list(zip(x[t],y[t])))        
+        pts[t[0]].neighbors.append((midx,midy))
+        pts[t[1]].neighbors.append((midx,midy))
+        pts[t[2]].neighbors.append((midx,midy))
+
+    for p in pts:
+        p.calc_midpts()
+
+    return pts
+
+
+def make_polygon(cell, img_shape):
+    "Create polygon and compute extent bounded by image"
+    import numpy as np
+    from region import polygon
+    
+    p = polygon( cell.cellx, cell.celly)
+
+    # Loop over pixels just inside extent of polygon
+    ext=p.extent()
+    xl = max([0,int(ext['x0'])])
+    xh = min([img_shape[1], int(ext['x1']+1)])
+    yl = max([0,int(ext['y0'])])
+    yh = min([img_shape[0], int(ext['y1']+1)])
+
+    _yrange = np.arange(yl,yh)
+    _xrange = np.arange(xl,xh)
+    
+    return p, _xrange, _yrange
+
+
+def compute_vcells( infile, sitesfile, outfile, clobber ):
+    """
+    Given a set of local max, grow the regions until they touch and
+    cover the image
+    """
+    from crates_contrib.masked_image_crate import MaskedIMAGECrate
+    import numpy as np
+
+    verb1("Assigning pixels to maxima")
+
+    # Load data
+    img = MaskedIMAGECrate(sitesfile,mode="r")
+    imgd = img.get_image()
+    vv = imgd.values
+
+    # Open infile to get subspace
+    dss_img = MaskedIMAGECrate(infile,mode="r")
+
+    # get non-zero pixels
+    sites = np.argwhere(vv>0)
+
+    # get pixel value at all non-zero pixels
+    sitesv = [vv[y,x] for y,x in sites]
+
+    # get x,y coords of non-zero pixels
+    xx = sites[:,1]
+    yy = sites[:,0]
+
+    # Compute V. cells.
+    cells = make_vcells( xx, yy)
+
+    # Now fill in the V. cells with the pixel value    
+    outvv = np.zeros_like(vv)
+    for c,v in zip(cells,sitesv):
+
+        try:
+            p, _xrange, _yrange = make_polygon(c, vv.shape)
+        except:
+            continue
+        
+        for _y in _yrange:
+            for _x in _xrange:
+                # Pixel already assigned, skip it
+                if outvv[_y,_x] != 0:
+                    continue
+
+                # Pixel not in subspace, skip it
+                if not dss_img.valid(_x,_y):
+                    continue
+                
+                # Do the hard work
+                if p.is_inside(_x,_y):
+                    outvv[_y,_x] = v
+
+    # Save the values 
+    imgd.values = outvv
+    img.name = "tess"
+    img.write( outfile, clobber=clobber )
+
+
+@lw.handle_ciao_errors( toolname, __revision__)
+def main():
+    """
+    
+    """
+    # get parameters
+    from ciao_contrib.param_soaker import get_params
+    from ciao_contrib.runtool import dmmaskbin
+    from ciao_contrib.runtool import add_tool_history
+
+    # Load parameters
+    pars = get_params(toolname, "rw", sys.argv, 
+        verbose={"set":lw.set_verbosity, "cmd":verb1} )
+
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    outfile_clobber_checks(pars["clobber"], pars["outfile"] )
+    outfile_clobber_checks(pars["clobber"], pars["binimg"] )
+
+    mask = make_mask( pars["shape"], pars["radius"] )
+    
+    if (len(pars["sitefile"]) == 0) or ("none" == pars["sitefile"].lower()):
+        tmpsitefile = find_local_max( pars["infile"], mask=mask )
+        sitefile = tmpsitefile.name
+    else:
+        sitefile = pars["sitefile"]
+
+    compute_vcells( pars["infile"], sitefile, pars["outfile"], pars["clobber"] )
+    add_tool_history( pars["outfile"], toolname, pars, toolversion=__revision__)
+    
+    if len(pars["binimg"])>0 and "none" != pars["binimg"].lower():
+        dmmaskbin( pars["infile"], pars["outfile"]+"[opt type=i4]", pars["binimg"], clobber=True)
+        add_tool_history( pars["binimg"], toolname, pars, toolversion=__revision__)
+
+
+
+if __name__ == "__main__":
+    main()
+
+
+
+

--- a/ciao_contrib/runtool.py
+++ b/ciao_contrib/runtool.py
@@ -2695,6 +2695,13 @@ parinfo['celldetect'] = {
     }
 
 
+parinfo['centroid_map'] = {
+    'istool': True,
+    'req': [ParValue("infile","f","Input counts image",None),ParValue("outfile","f","Output map file",None)],
+    'opt': [ParRange("numiter","i","Number of centroid iterations",1,1,None),ParValue("sitefile","f","Input initial site locations",None),ParSet("scale","s","Scaling applied to pixel values when computing centroid",'linear',["linear","sqrt","squared","asinh"]),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove outfile if it already exists?",True)],
+    }
+
+
 parinfo['chandra_repro'] = {
     'istool': True,
     'req': [ParValue("indir","f","Input directory",'./'),ParValue("outdir","f","Output directory (default = $indir/repro)",None)],
@@ -3241,6 +3248,13 @@ parinfo['gti_align'] = {
     }
 
 
+parinfo['hexgrid'] = {
+    'istool': True,
+    'req': [ParValue("infile","f","Input image",None),ParValue("outfile","f","Output hexagon grid image",None),ParRange("sidelen","r","Side length of hexagons",10,3,None)],
+    'opt': [ParValue("binimg","f","Output image file",None),ParValue("xref","r","X coordinate of reference point (image coordinates)",0),ParValue("yref","r","Y coordinate of reference point (image coordinates)",0),ParRange("verbose","i","Tool chatter level",0,0,5),ParValue("clobber","b","Remove outfile if it already exists?",False)],
+    }
+
+
 parinfo['hrc_bkgrnd_lookup'] = {
     'istool': True,
     'req': [ParValue("infile","f","The file for which you want a background file",None),ParSet("caltype","s","What type of background file?",'event',["event","spectrum"])],
@@ -3325,6 +3339,13 @@ parinfo['merge_obs'] = {
     }
 
 
+parinfo['merge_too_small'] = {
+    'istool': True,
+    'req': [ParValue("infile","f","Input map",None),ParValue("outfile","f","Output map",None)],
+    'opt': [ParSet("method","s","Apply minval threshold to area of region or counts in region?",'counts',["counts","area"]),ParValue("imgfile","f","Input counts image file, required for method=counts",None),ParValue("binimg","f","Optional output image file",None),ParRange("minvalue","i","Minimum counts or area (logical pixels)",0,0,None),ParRange("verbose","i","Tool chatter level",0,0,5),ParValue("clobber","b","Remove outfile if it already exists?",False)],
+    }
+
+
 parinfo['mkacisrmf'] = {
     'istool': True,
     'req': [ParValue("infile","f","scatter/rsp matrix file",' '),ParValue("outfile","f","RMF output file",' '),ParValue("wmap","f","WMAP file",' '),ParValue("energy","s","energy grid in keV (lo:hi:bin)",' '),ParValue("channel","s","channel grids in pixel (min:max:bin)",' '),ParSet("chantype","s","channel type",'PI',["PI","PHA"]),ParRange("ccd_id","i","filter CCD-ID",None,0,9),ParValue("chipx","i","filter chipx in pixel",None),ParValue("chipy","i","filter chipy in pixel",None),ParValue("gain","f","gain file",'CALDB')],
@@ -3371,6 +3392,13 @@ parinfo['mkpsfmap'] = {
     'istool': True,
     'req': [ParValue("infile","f","Input image file name",None),ParValue("outfile","f","Output image file name",None),ParValue("energy","r","Energy of PSF to lookup [keV]",None),ParValue("spectrum","f","Spectrum file [keV vs weight] if energy=None",None),ParRange("ecf","r","ECF of PSF to lookup",None,0,1)],
     'opt': [ParValue("psffile","f","PSF Calibration file",'CALDB'),ParSet("units","s","Units of output image",'arcsec',["arcsec","logical","physical"]),ParValue("geompar","f","Pixlib geometry file",'geom.par'),ParValue("clobber","b","Clobber files?",False)],
+    }
+
+
+parinfo['mkregmap'] = {
+    'istool': True,
+    'req': [ParValue("infile","f","Input image file",None),ParValue("regions","f","Input stack of regions",None),ParValue("outfile","f","Output map file",None)],
+    'opt': [ParValue("binimg","f","Output binned image",None),ParValue("coord","s","Image coodinate name",'sky'),ParValue("clobber","b","Remove outfile if it already exists?",False),ParRange("verbose","i","Tool chatter level",1,0,5)],
     }
 
 
@@ -3427,6 +3455,13 @@ parinfo['obsid_search_csc'] = {
     'istool': True,
     'req': [ParValue("obsid","s","Chandra Observation ID",None),ParValue("outfile","f","Name of output table (TSV format)",None)],
     'opt': [ParValue("columns","s","List of columns to include",'INDEF'),ParSet("download","s","Download data products for which sources?",'none',["none","ask","all"]),ParValue("root","f","Output root for data products",'./'),ParValue("bands","s","Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all",'broad,wide'),ParValue("filetypes","s","Comma separated list of CSC filetypes.  Blank retrieves all",'regevt,pha,arf,rmf,lc,psf,regexp'),ParSet("catalog","s","Version of catalog",'csc2',["csc2","csc1","current"]),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove existing outfile if it exists?",False)],
+    }
+
+
+parinfo['pathfinder'] = {
+    'istool': True,
+    'req': [ParValue("infile","f","Input image",None),ParValue("outfile","f","Output map image",None)],
+    'opt': [ParValue("minval","r","Minimum pixel value to consider in input image.",0),ParSet("direction","s","Directions to follow gradient",'diagonal',["diagonal","perpendicular"]),ParValue("debugreg","f","Diagnostic region file",None),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove output file if it already exists?",False)],
     }
 
 
@@ -3749,6 +3784,13 @@ parinfo['update_column_range'] = {
     'istool': True,
     'req': [ParValue("infile","f","File to edit",None)],
     'opt': [ParValue("columns","s","Column names (includes vector columns)",'sky'),ParValue("round","b","Should data ranges be rounded to nearest mid-integer?",True),ParRange("verbose","i","Debug Level (0-5)",1,0,5)],
+    }
+
+
+parinfo['vtbin'] = {
+    'istool': True,
+    'req': [ParValue("infile","f","Input image",None),ParValue("outfile","f","Output map",None)],
+    'opt': [ParValue("binimg","f","Output image file",None),ParSet("shape","s","Shape of local max mask",'box',["box","circle"]),ParRange("radius","r","Radius of local max mask",2.5,0,None),ParValue("sitefile","f","Input site file",None),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove outfile if it already exists?",False)],
     }
 
 

--- a/crates_contrib/masked_image_crate.py
+++ b/crates_contrib/masked_image_crate.py
@@ -1,0 +1,116 @@
+
+#
+# Copyright (C) 2018,2020 Smithsonian Astrophysical Observatory
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+
+from pycrates import IMAGECrate
+import numpy as np
+
+class MaskedIMAGECrate( IMAGECrate ):
+    """
+    This class extends the basic IMAGECrate by adding a 'valid' 
+    method.  
+    
+    The valid method takes the 0-based image index and sees if 
+    the pixel is valid, where valid means:
+    
+     - pixel is not a special IEEE value, eg NaN or +/- INF
+     - pixel is not an integer NULL value, eg -999 (if set)
+     - pixel is inside the data subspace, ie region filter
+    """
+
+    def __init__(self, filename, mode="r"):
+        super(MaskedIMAGECrate, self).__init__( filename, mode)
+        
+        if ( 2 != len(self.get_image().values.shape)):
+            raise NotImplementedError("Only 2D images are supported")
+    
+        self._pix = self.get_image().values
+        self.__make_valid_mask()
+
+
+    def __check_finite(self):
+        """Check for NaN|Inf
+        
+        """
+        badidx = np.where( ~(np.isfinite(self._pix)))
+        self._mask[badidx[0]] = 0
+
+
+    def __check_null(self):
+        """Check for integer NULL values """
+        nullval = self.get_image().get_nullval()
+        if nullval is None:  # is None, not == None (nor 0)
+            return
+        nullidx = np.where( self._pix == nullval )
+        self._mask[nullidx[0]] = 0
+        
+        
+    def __check_subspace(self):
+        """Check to see if pixels are in subspace        
+        """
+        _a = [x.lower() for x in self.get_axisnames()]
+        if 'sky' in _a:
+            sky = 'sky'
+        elif 'pos' in _a:
+            sky = 'pos'
+        else:
+            #warning()
+            return
+                
+        try:
+            xform = self.get_axis(sky).get_transform()
+            subspace = self.get_subspace_data(1, sky)
+            assert subspace.region is not None, "No region in subpsace"
+        except Exception as ee:
+            #warnings
+            return
+
+        # We need to check regInside using physical coords. Compute 'em all.
+        ylen,xlen = self._pix.shape        
+        ivals = [x+1.0 for x in range(xlen)] # +1 -> image coords
+        jvals = [y+1.0 for y in range(ylen)]
+        ivals = np.array( ivals*ylen) # this is why using lists instead of np.arrays
+        jvals = np.repeat( jvals,xlen)
+        ijvals = list(zip(ivals,jvals))
+        xyvals = xform.apply( ijvals ) # Due to memory leaks/etc, best to send all i,j in at once.
+        
+        import region as old        
+        for ij,xy in zip( ijvals, xyvals):
+            i=int(ij[0])-1
+            j=int(ij[1])-1
+            x=xy[0]
+            y=xy[1]
+            self._mask[j][i] = 1 if old.regInsideRegion( subspace.region, x,y) else 0
+
+
+    def __make_valid_mask( self ):
+        """
+        Apply all the filters to create the mask array
+        """
+        self._mask = np.ones_like( self._pix ) # Assume everything is good
+        self.__check_finite()
+        self.__check_null()
+        self.__check_subspace()
+
+
+    def valid( self, i, j ):
+        """
+        Is pixel at 0-based indices i,j valid?  
+        """
+        return self._mask[j][i] == 1

--- a/crates_contrib/masked_image_crate.py
+++ b/crates_contrib/masked_image_crate.py
@@ -1,6 +1,6 @@
-
 #
-# Copyright (C) 2018,2020 Smithsonian Astrophysical Observatory
+# Copyright (C) 2018, 2020, 2023
+# Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,52 +17,51 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+'An IMAGECrate that knows which pixels are valid'
 
 from pycrates import IMAGECrate
 import numpy as np
 
-class MaskedIMAGECrate( IMAGECrate ):
+
+class MaskedIMAGECrate(IMAGECrate):
     """
-    This class extends the basic IMAGECrate by adding a 'valid' 
-    method.  
-    
-    The valid method takes the 0-based image index and sees if 
+    This class extends the basic IMAGECrate by adding a 'valid'
+    method.
+
+    The valid method takes the 0-based image index and sees if
     the pixel is valid, where valid means:
-    
+
      - pixel is not a special IEEE value, eg NaN or +/- INF
      - pixel is not an integer NULL value, eg -999 (if set)
      - pixel is inside the data subspace, ie region filter
     """
 
     def __init__(self, filename, mode="r"):
-        super(MaskedIMAGECrate, self).__init__( filename, mode)
-        
-        if ( 2 != len(self.get_image().values.shape)):
+        super().__init__(filename, mode)
+
+        if 2 != len(self.get_image().values.shape):
             raise NotImplementedError("Only 2D images are supported")
-    
+
         self._pix = self.get_image().values
         self.__make_valid_mask()
 
-
     def __check_finite(self):
         """Check for NaN|Inf
-        
-        """
-        badidx = np.where( ~(np.isfinite(self._pix)))
-        self._mask[badidx[0]] = 0
 
+        """
+        badidx = np.where(~(np.isfinite(self._pix)))
+        self._mask[badidx[0]] = 0
 
     def __check_null(self):
         """Check for integer NULL values """
         nullval = self.get_image().get_nullval()
         if nullval is None:  # is None, not == None (nor 0)
             return
-        nullidx = np.where( self._pix == nullval )
+        nullidx = np.where(self._pix == nullval)
         self._mask[nullidx[0]] = 0
-        
-        
+
     def __check_subspace(self):
-        """Check to see if pixels are in subspace        
+        """Check to see if pixels are in subspace
         """
         _a = [x.lower() for x in self.get_axisnames()]
         if 'sky' in _a:
@@ -70,47 +69,49 @@ class MaskedIMAGECrate( IMAGECrate ):
         elif 'pos' in _a:
             sky = 'pos'
         else:
-            #warning()
+            #  warning()
             return
-                
+
         try:
             xform = self.get_axis(sky).get_transform()
             subspace = self.get_subspace_data(1, sky)
             assert subspace.region is not None, "No region in subpsace"
-        except Exception as ee:
-            #warnings
+        except Exception as bad:
+            #  warnings
             return
 
         # We need to check regInside using physical coords. Compute 'em all.
-        ylen,xlen = self._pix.shape        
-        ivals = [x+1.0 for x in range(xlen)] # +1 -> image coords
+        ylen, xlen = self._pix.shape
+
+        # TODO: is there is numpy meshgrid or somesort to do this
+        ivals = [x+1.0 for x in range(xlen)]   # +1 -> image coords
         jvals = [y+1.0 for y in range(ylen)]
-        ivals = np.array( ivals*ylen) # this is why using lists instead of np.arrays
-        jvals = np.repeat( jvals,xlen)
-        ijvals = list(zip(ivals,jvals))
-        xyvals = xform.apply( ijvals ) # Due to memory leaks/etc, best to send all i,j in at once.
-        
-        import region as old        
-        for ij,xy in zip( ijvals, xyvals):
-            i=int(ij[0])-1
-            j=int(ij[1])-1
-            x=xy[0]
-            y=xy[1]
-            self._mask[j][i] = 1 if old.regInsideRegion( subspace.region, x,y) else 0
+        ivals = np.array(ivals*ylen)  # why using lists instead of np.arrays
+        jvals = np.repeat(jvals, xlen)
+        ijvals = list(zip(ivals, jvals))
+        # Due to memory leaks/etc, best to send all i, j in at once.
+        xyvals = xform.apply(ijvals)
 
+        # Crates still uses the old region module :(
+        import region as old
+        for ij, xy in zip(ijvals, xyvals):
+            i = int(ij[0])-1
+            j = int(ij[1])-1
+            x = xy[0]
+            y = xy[1]
+            self._mask[j][i] = 1 if old.regInsideRegion(subspace.region, x, y) else 0
 
-    def __make_valid_mask( self ):
+    def __make_valid_mask(self):
         """
         Apply all the filters to create the mask array
         """
-        self._mask = np.ones_like( self._pix ) # Assume everything is good
+        self._mask = np.ones_like(self._pix)  # Assume everything is good
         self.__check_finite()
         self.__check_null()
         self.__check_subspace()
 
-
-    def valid( self, i, j ):
+    def valid(self, i, j):
         """
-        Is pixel at 0-based indices i,j valid?  
+        Is pixel at 0-based indices i, j valid?
         """
         return self._mask[j][i] == 1

--- a/param/centroid_map.par
+++ b/param/centroid_map.par
@@ -1,0 +1,8 @@
+infile,f,a,"",,,"Input counts image"
+outfile,f,a,"",,,"Output map file"
+numiter,i,h,1,1,,"Number of centroid iterations"
+sitefile,f,h,"",,,"Input initial site locations"
+scale,s,h,linear,linear|sqrt|squared|asinh,,"Scaling applied to pixel values when computing centroid"
+verbose,i,h,1,0,5,"Tool chatter level"
+clobber,b,h,yes,,,"Remove outfile if it already exists?"
+mode,s,h,"ql",,,

--- a/param/hexgrid.par
+++ b/param/hexgrid.par
@@ -1,0 +1,9 @@
+infile,f,a,"",,,"Input image"
+outfile,f,a,"",,,"Output hexagon grid image"
+sidelen,r,a,10,3,,"Side length of hexagons"
+binimg,f,h,"",,,"Output image file"
+xref,r,h,0,,,"X coordinate of reference point (image coordinates)"
+yref,r,h,0,,,"Y coordinate of reference point (image coordinates)"
+verbose,i,h,0,0,5,"Tool chatter level"
+clobber,b,h,no,,,"Remove outfile if it already exists?"
+mode,s,h,"ql",,,

--- a/param/map2reg.par
+++ b/param/map2reg.par
@@ -1,0 +1,7 @@
+infile,f,a,"",,,"Input map image"
+outfile,f,a,"",,,"Output region file"
+parallel,b,h,yes,,,"Run processes in parallel?"
+nproc,i,h,INDEF,,,"Number of processors to use (INDEF:use all available)"
+verbose,i,h,1,0,5,"Tool chatter level"
+clobber,b,h,no,,,"Remove output file if it already exists?"
+mode,s,h,ql,,,

--- a/param/merge_too_small.par
+++ b/param/merge_too_small.par
@@ -1,0 +1,9 @@
+infile,f,a,"",,,"Input map"
+outfile,f,a,"",,,"Output map"
+method,s,h,"counts","counts|area",,"Apply minval threshold to area of region or counts in region?"
+imgfile,f,h,"",,,"Input counts image file, required for method=counts"
+binimg,f,h,"",,,"Optional output image file"
+minvalue,i,h,0,0,,"Minimum counts or area (logical pixels)"
+verbose,i,h,0,0,5,"Tool chatter level"
+clobber,b,h,no,,,"Remove outfile if it already exists?"
+mode,s,h,"ql",,,

--- a/param/mkregmap.par
+++ b/param/mkregmap.par
@@ -1,0 +1,8 @@
+infile,f,a,"",,,"Input image file"
+regions,f,a,"",,,"Input stack of regions"
+outfile,f,a,"",,,"Output map file"
+binimg,f,h,"",,,"Output binned image"
+coord,s,h,"sky",,,"Image coodinate name"
+clobber,b,h,"no",,,"Remove outfile if it already exists?"
+verbose,i,h,1,0,5,"Tool chatter level"
+mode,s,h,ql,,,

--- a/param/pathfinder.par
+++ b/param/pathfinder.par
@@ -1,0 +1,8 @@
+infile,f,a,"",,,"Input image"
+outfile,f,a,"",,,"Output map image"
+minval,r,h,0,,,"Minimum pixel value to consider in input image."
+direction,s,h,diagonal,diagonal|perpendicular,,"Directions to follow gradient"
+debugreg,f,h,"",,,"Diagnostic region file"
+verbose,i,h,1,0,5,"Tool chatter level"
+clobber,b,h,no,,,"Remove output file if it already exists?"
+mode,s,h,ql,,,

--- a/param/vtbin.par
+++ b/param/vtbin.par
@@ -1,0 +1,9 @@
+infile,f,a,"",,,"Input image"
+outfile,f,a,"",,,"Output map"
+binimg,f,h,"",,,"Output image file"
+shape,s,h,"box",box|circle,,"Shape of local max mask"
+radius,r,h,2.5,0,,"Radius of local max mask"
+sitefile,f,h,"",,,"Input site file"
+verbose,i,h,1,0,5,"Tool chatter level"
+clobber,b,h,no,,,"Remove outfile if it already exists?"
+mode,s,h,"ql",,,

--- a/share/doc/xml/centroid_map.xml
+++ b/share/doc/xml/centroid_map.xml
@@ -19,7 +19,7 @@
         to determine the convex hull polygons around each initial site.
         This is done using the vtbin tool.
         Next it computes the centroid of the pixel values enclosed in each
-        polygon. Theses centroid are then used as the sites for the next
+        polygon. Theses centroids are then used as the sites for the next
         iteration.  The tessellation and centroid process is repeated
         the user-specified number of iterations.
         </PARA>
@@ -48,10 +48,6 @@
         whose pixel values indicate which pixels are grouped together.
         Users can use the dmmaskbin tool to create a binned imaged.
         </PARA>
-
-
-        <PARA>REF: There is a paper on this algorithm in IEEE ,
-        need to locate it.</PARA>
     </DESC>
 
 
@@ -208,13 +204,11 @@
           <SYNOPSIS>Scaling applied to pixel values when computing centroid</SYNOPSIS>
           <DESC>
             <PARA>
-              In [Ref, integral , adaptive bin], they discuss 
-              how simply using the pixel values can lead to biases
-              in the centroid map (smaller cells around brighter pixels).
-              There is reference to additional work that advocates 
-              for scaling the pixel values can yeild more uniform 
-              cells (uniform in the sense of containing similar cell sizes
-              with similar counts, ie surface brightness).            
+                In images with a large dynamic range of pixel values,
+                very bright pixels can lead to very small groups.
+                By applying a scaling function to the pixel values
+                before computing the centroid it can help the algorithm
+                produce groups with more uniform areas.
             </PARA>
             <PARA>
             The following scaling functions are available
@@ -243,6 +237,14 @@
         </PARAM>
     </PARAMLIST>
 
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
 
     <BUGS>
         <PARA>
@@ -251,6 +253,6 @@
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>December 2020</LASTMODIFIED>
+    <LASTMODIFIED>August 2023</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/centroid_map.xml
+++ b/share/doc/xml/centroid_map.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+<ENTRY 
+        context="tools" 
+        key="centroid_map" 
+        refkeywords="centroid map mask adaptive bin group grow max tessellation" 
+        seealsogroups="dmimgtools"
+    >
+    <SYNOPSIS>
+       Adaptively bin an image using centroid map algorithm
+    </SYNOPSIS>
+    <DESC>
+        <PARA>
+        The centroid_map tool implements an iterative adaptive binning 
+        routine.  First, the tool determines the location of the local
+        maxima in the input image.  The location of these maxima are called
+        'sites'.  It then performs a Voronoi Tessellation
+        to determine the convex hull polygons around each initial site.
+        This is done using the vtbin tool.
+        Next it computes the centroid of the pixel values enclosed in each
+        polygon. Theses centroid are then used as the sites for the next
+        iteration.  The tessellation and centroid process is repeated
+        the user-specified number of iterations.
+        </PARA>
+        <PARA>
+        It can be shown that this algorithm will eventually converge
+        (ie the sites do not change between iterations).  However, it
+        may converge slowly where most of the sites remain fixed and only
+        a few sites take many iterations to converge.  This is why the
+        number of iterations is left as a user parameter.  Typical values
+        will be in the 30-150 range.  
+        </PARA>
+        <PARA>
+        Users can also supply their own initial site file (rather than
+        use the location of the local maxima).  This allows the user 
+        to control the initial location of the site and to control the total
+        number of site locations.  The number of sites is fixed; 
+        neighboring sites cannot 'merge' together.
+        </PARA>
+        <PARA>
+        The input image should be smoothed.  Since the tool 
+        determines the location of local maxima in a 5x5 pixel neighborhood, 
+        the input should be smoothed at least on that scale.
+        </PARA>
+        <PARA>
+        The output from the centroid_map tool is the map file: an image
+        whose pixel values indicate which pixels are grouped together.
+        Users can use the dmmaskbin tool to create a binned imaged.
+        </PARA>
+
+
+        <PARA>REF: There is a paper on this algorithm in IEEE ,
+        need to locate it.</PARA>
+    </DESC>
+
+
+     <QEXAMPLELIST>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>% aconvolve img.fits sm_img.fits "lib:gaus(2,5,1,3,3)"</LINE>
+            <LINE>% centroid_map sm_img.fits sm_img.map numiter=30</LINE>
+            <LINE>% dmmaskbin sm_img.fits sm_img.map sm_img.img</LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            First the input image is smoothed with a 3-pixel sigma Gaussian.
+            Then we compute the centroid_map using this smoothed image, using
+            30 iterations.
+            </PARA>
+            <PARA>
+            The dmmaskbin tool is then used to apply the map to the
+            input image to create the rebinned image: sm_img.img.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>% dmimgadapt img.fits smoothed.fits function=cone counts=50 min=1 max=20 num=20 radscale=linear</LINE>
+            <LINE>% dmimgfilt smoothed.fits local_max function=peak mask="box(0,0,7,7)"</LINE>
+            <LINE>% dmimgblob local_max sites.fits threshold=0.5 srconly=yes</LINE>
+            <LINE>% centroid_map img.fits img.map numiter=50 sitefile=sites.fits</LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            In this example we start by adaptively smoothing the 
+            input image.  We then locate the local maximum in a larger
+            7x7 pixel region, and then use dmimgblob to label local max 
+            with a unique value to create the sites.fits files.
+            </PARA>
+            <PARA>
+            The sites.fits file is then used to seed the centroid_map
+            algorithm.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>% python -c 'import sherpa.astro.ui as ui;ui.load_data("img.fits");ui.set_model("const2d.flat");flat.c0=0.005;ui.fake();ui.save_image("fake.img",ascii=False,clobber=True)'</LINE>
+            <LINE>% dmimgthresh fake.img fake_thresh.img exp=smimg.fits cut=0.5 value=0</LINE>
+            <LINE>% dmimgblob fake_thresh.img sites.fits thresh=1 srconly=yes</LINE>
+            <LINE>% centroid_map img.fits random.map numiter=30 site=sites.fits</LINE>
+            <LINE>% dmmaskbin img.fits random.map random.img</LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            In this example we want to use a random starting location for
+            the sites.  To do this, we use the sherpa fake() command
+            with a flat, 2D constant model with a Poisson rate of 0.005 
+            counts per pixel.  We then use the dmimgthresh command to 
+            remove sites that are off the detector (in parts of the smoothed
+            image which are zero). Then we use dmimgblob as before to
+            assign a unique label to each site.             
+            </PARA>
+            <PARA>
+            The random sites.fits file is then used to 
+            initialize the centroid_map algorithm.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+     </QEXAMPLELIST>
+
+
+
+     <PARAMLIST>
+        <PARAM name="infile" type="file" filetype="input" reqd="yes">
+            <SYNOPSIS>
+            Input image.
+            </SYNOPSIS>
+            <DESC>
+                <PARA>
+            If the sitefile parameter is not 
+            specified, then this image should be smoothed so that
+            the algorithm locate statistically significant local maxima
+            (ie not just single isolated events).  If the sites file
+            is supplied then this image does not need to be smoothed.
+                </PARA>
+                <PARA>
+            If the input image contains a large number of pixels 
+            outside the detector's field-of-view, users should 
+            filter the image first to encode the boundary in the
+            file's data-subspace                
+                </PARA>
+<VERBATIM>% dmcopy "img.fits[sky=region(fov.fits)]" img.dss.fits</VERBATIM>
+            <PARA>
+            The centroid_map script will use the information in
+            the file's subspace; making it run faster by avoiding
+            processing the off-detector pixels.            
+            </PARA>
+            </DESC>
+        </PARAM>
+
+        <PARAM name="outfile" type="file" filetype="output" reqd="yes">
+          <SYNOPSIS>
+            Output map file
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+              The outfile is a map file containing integer pixel values.
+              The pixel values indicate which pixels are grouped
+              together by the algorithm.  A pixel value of 0 are pixels
+              which are ungrouped (ie outside the image subspace).            
+            </PARA>
+            <PARA>
+              Users can use the dmmaskbin tool to apply this map file
+              to a counts image to obtain an adaptively binned counts
+              image.
+            </PARA>
+          </DESC>
+        </PARAM>
+
+        <PARAM name="numiter" type="integer" min="1" def="1">
+          <SYNOPSIS>Number of iterations</SYNOPSIS>
+          <DESC>
+            <PARA>
+            The centroid_map will eventually converge to a state
+            where the sites no longer move.  However, it can
+            converge very slowly, where only a few sites at the
+            end take a large number of iterations to become fixed.
+            Rather than try to guess when the algorithm has converged 
+            "enough", the script uses the numiter parameter to
+            control the number of iterations.  Typical values will 
+            be on the order of 30 to 150 iterations. 
+            </PARA>          
+          </DESC>
+        </PARAM>
+        <PARAM name="sitefile" type="file" filetype="input">
+          <SYNOPSIS>Optional input site file</SYNOPSIS>
+          <DESC>
+            <PARA>
+                If not specified, the centroid_map begins by
+                determining the intial site locations by finding 
+                all the local maxima in 5x5 regions.  This fixes
+                the number of sites, and thus the number of 
+                bins in the final output.            
+            </PARA>
+            <PARA>
+                Instead, users can supply their own sitefile, based
+                on whatever criteria they wish. This allows the  user
+                to control the number of sites and thus the number of
+                bin in the final output. 
+            </PARA>
+          </DESC>
+        </PARAM>
+        <PARAM name="scale" type="string" def="linear">
+          <SYNOPSIS>Scaling applied to pixel values when computing centroid</SYNOPSIS>
+          <DESC>
+            <PARA>
+              In [Ref, integral , adaptive bin], they discuss 
+              how simply using the pixel values can lead to biases
+              in the centroid map (smaller cells around brighter pixels).
+              There is reference to additional work that advocates 
+              for scaling the pixel values can yeild more uniform 
+              cells (uniform in the sense of containing similar cell sizes
+              with similar counts, ie surface brightness).            
+            </PARA>
+            <PARA>
+            The following scaling functions are available
+            </PARA>
+            <LIST>
+                <ITEM>linear</ITEM>
+                <ITEM>sqrt</ITEM>
+                <ITEM>squared</ITEM>
+                <ITEM>asinh</ITEM>            
+            </LIST>
+          
+          </DESC>
+        
+        </PARAM>
+
+
+        <PARAM name="verbose" type="integer" def="1" min="0" max="5">
+            <SYNOPSIS>
+            Amount of chatter from the tool.
+            </SYNOPSIS>
+        </PARAM>
+        <PARAM name="clobber" type="boolean" def="no">
+            <SYNOPSIS>
+            Delete outfile if it already exists?
+            </SYNOPSIS>
+        </PARAM>
+    </PARAMLIST>
+
+
+    <BUGS>
+        <PARA>
+            See the
+            <HREF link="http://cxc.harvard.edu/ciao/bugs/index.html">CIAO
+            website</HREF> for an up-to-date listing of known bugs.
+        </PARA>
+    </BUGS>
+    <LASTMODIFIED>December 2020</LASTMODIFIED>
+</ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/hexgrid.xml
+++ b/share/doc/xml/hexgrid.xml
@@ -196,6 +196,15 @@
         </PARAM>
     </PARAMLIST>
 
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+
 
     <BUGS>
         <PARA>
@@ -204,6 +213,6 @@
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>January 2019</LASTMODIFIED>
+    <LASTMODIFIED>August 2023</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/hexgrid.xml
+++ b/share/doc/xml/hexgrid.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+<ENTRY 
+        context="tools" 
+        key="hexgrid" 
+        refkeywords="hex hexagonal map mask adaptive bin grid regular circular approximation" 
+        seealsogroups="dmimgtools"
+    >
+    <SYNOPSIS>
+       Create a regular hexagonal grid and apply to input image
+    </SYNOPSIS>
+    <DESC>
+        <PARA>
+        hexgrid creates a uniform grid of hexagonal shaped regions.
+        Hexagons are highest order polygon which can be used to 
+        uniformly tile a plane; thus they are are the closest approximation
+        to a circular grid.
+        All hexagons have the same size and orientation.  Users can
+        specify a center location which centers one of the hexagons;
+        the rest of the field then is shifted to accommodate this 
+        constraint.
+        </PARA>
+
+        <PARA>
+        The output from hexgrid is a map file, where the pixel values
+        indicate to which group each pixel belongs.
+        If a binimg is supplied, hexgrid will apply the 
+        grouping to the infile and the result saved in the binimg file.
+        </PARA>
+
+    </DESC>
+
+     <QEXAMPLELIST>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+  % hexgrid img.fits hex.map sidelen=10 
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+    This example creates an output map file, hex.map, the same size and 
+    dimensions as the input file, img.fits.  Each hexagon 
+    will have a side length=10 pixels (in image or logical pixel).
+    Note: due to quantization, the side length may vary +/-1.
+            </PARA>
+           <PARA>
+    If the input image contains any pixel values that have a value of NaN,
+    or are outside the image's data subspace, then those pixels will
+    be left ungrouped (map values equal to zero).           
+           </PARA>
+            <PARA>
+     The output image contains integer values, where pixels with the same
+     value belong to the same hexagon.  Note that the pixel values
+     do not always start at one (1), nor are they guaranteed to be
+     consecutive.  A pixel value equal to zero (0) means that the
+     pixel is ungrouped.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+  % hexgrid img.fits hex.map sidelen=10 xref=512 yref=512
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>  
+        Same as the previous example; however, a reference location
+        has been specified.  The reference location is specified
+        in logical (image) coordinates.  When these parameters are
+        set, the tool will adjust the starting location of the
+        hexagonal grid such that the reference position is
+        in the center of a hexagon.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+  % hexgrid img.fits hex.map sidelen=10 binimg=hex.img 
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+        Same as first example, except with the binimg parameter
+        specified, the script will apply the grouping scheme
+        in the hex.map output file to the img.fits infile, and
+        output the binned image, hex.img.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+
+     </QEXAMPLELIST>
+
+     <PARAMLIST>
+        <PARAM name="infile" type="file" filetype="input" reqd="yes">
+            <SYNOPSIS>
+            Input image.
+            </SYNOPSIS>
+            <DESC>
+           <PARA>
+            Null  and NaN pixels, as well as those pixels outside the
+            image subspace will not be grouped.
+            </PARA>
+
+          </DESC>
+        </PARAM>
+
+        <PARAM name="outfile" type="file" filetype="output" reqd="yes">
+          <SYNOPSIS>
+            Output map file
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+              The outfile is a map file containing integer pixel values.
+              The pixel values indicate which pixels are grouped
+              together by the algorithm.  A pixel value of 0 are pixels
+              which are ungrouped (ie outside the image subspace).            
+            </PARA>
+          </DESC>
+        </PARAM>
+
+        <PARAM name="sideline" type="real" def="10" min="3" reqd="yes">
+          <SYNOPSIS>The side length of each hexagon</SYNOPSIS>
+          
+          <DESC>
+            <PARA>
+                The side length is expressed in logical (ie image) pixels.
+                The true side lengths may vary by +/- 1 pixel
+                due to quantization effect.  Also due to quantization,
+                the tool has lower limit of 3 image pixels; smaller
+                than that and the hexagons become squares.
+            </PARA>
+          </DESC>
+        
+        </PARAM>
+
+        <PARAM name="binimg" type="file" filetype="output">
+          <SYNOPSIS>Optional, output binned image</SYNOPSIS>
+          <DESC>
+            <PARA>
+                If the binimg file is specified, the script
+                will use the input image and the output map file to
+                create a binned version of the input image.
+            </PARA>          
+          </DESC>
+        </PARAM>
+
+        <PARAM name="xref" type="real" def="0">
+          <SYNOPSIS>X coordinate of the reference location in image coordinates</SYNOPSIS>
+          <DESC>
+            <PARA>
+        The reference location is specified
+        in logical (image) coordinates.  When these parameters are
+        set, the tool will adjust the starting location of the
+        hexagonal grid such that the reference position is
+        in the center of a hexagon.  The exact group 
+        (map ID) where the reference location is located is
+        undetermined.
+            </PARA>
+          
+          </DESC>
+        </PARAM>
+
+        <PARAM name="yref" type="real" def="0">
+          <SYNOPSIS>Y coordinate of the reference location in image coordinates</SYNOPSIS>
+          <DESC>
+            <PARA>
+        The reference location is specified
+        in logical (image) coordinates.  When these parameters are
+        set, the tool will adjust the starting location of the
+        hexagonal grid such that the reference position is
+        in the center of a hexagon.  The exact group 
+        (map ID) where the reference location is located is
+        undetermined.
+            </PARA>
+          
+          </DESC>
+        </PARAM>
+
+
+        <PARAM name="verbose" type="integer" def="1" min="0" max="5">
+            <SYNOPSIS>
+            Amount of chatter from the tool.
+            </SYNOPSIS>
+        </PARAM>
+        <PARAM name="clobber" type="boolean" def="no">
+            <SYNOPSIS>
+            Delete outfile if it already exists?
+            </SYNOPSIS>
+        </PARAM>
+    </PARAMLIST>
+
+
+    <BUGS>
+        <PARA>
+            See the
+            <HREF link="http://cxc.harvard.edu/ciao/bugs/index.html">CIAO
+            website</HREF> for an up-to-date listing of known bugs.
+        </PARA>
+    </BUGS>
+    <LASTMODIFIED>January 2019</LASTMODIFIED>
+</ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/map2reg.xml
+++ b/share/doc/xml/map2reg.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+<ENTRY 
+        context="tools" 
+        key="map2reg" 
+        refkeywords="map mask bin group region convert display" 
+        seealsogroups="dmimgtools"
+        displayseealsogroups="regiontools"
+    >
+    <SYNOPSIS>
+        Convert a map file into a region file.
+    </SYNOPSIS>
+    <DESC>
+        <PARA>
+        This script creates a polygon region around each 
+        unique set of pixel values in the input map file.
+        The `dmimglasso' tool is used to identify the 
+        polygons.  The polgyons may contain multiple components
+        if there is a hole in the interior (eg a separate
+        group completely surrounded by another group).
+        </PARA>
+        <PARA>
+        This script assumes that all groups are contiguous.  If 
+        a group is split into multiple disjoint sections then
+        only 1 of those sub-groups will be processed.        
+        </PARA>
+        
+        <PARA>
+        Only pixel values greater than zero (&gt;0) are considered.
+        Pixel values equal to zero are considered as being ungrouped.            
+        </PARA>
+        <PARA>
+        This script runs in parallel; though for a large number of unique
+        map IDs it can still be slow.
+        </PARA>
+
+        <PARA>
+        The map values in the infile are not the same as the
+        COMPONENT values in the output region file.
+        </PARA>
+    </DESC>
+     <QEXAMPLELIST>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+            % map2reg hex.map hex.reg 
+            % ds9 hex.map -region hex.reg
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            Convert the map file,  hex.map, into an ASC-FITS format
+            region file, hex.reg.  We then use ds9 to display
+            the results.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+     </QEXAMPLELIST>
+
+     <PARAMLIST>
+        <PARAM name="infile" type="file" filetype="input" reqd="yes">
+            <SYNOPSIS>
+            Input map file.
+            </SYNOPSIS>
+            <DESC>
+            <PARA>
+                The map file should contain integer pixel values which
+                represent which pixels are grouped together.
+                Pixel values equal to 0 are ignored (treated as being
+                ungrouped).  
+            </PARA>
+          </DESC>
+        </PARAM>
+        <PARAM name="outfile" type="file" filetype="output" reqd="yes">
+          <SYNOPSIS>Output region file</SYNOPSIS>
+          <DESC>
+            <PARA>
+                The output is stored as an ASC-FITS format region
+                file.  Each map ID in the input image will be output
+                as one or more polygons.  The map ID is 
+                not stored (it is not guaranteed to be the COMPONENT 
+                value).  Each component may have interior polygons
+                excluded if they completely surround another 
+                group (or an ungrouped area).
+            </PARA>
+          </DESC>
+        </PARAM>
+
+      <PARAM name="parallel" type="boolean" def="yes" reqd="no">
+        <SYNOPSIS>Run code in parallel using multiple processors?</SYNOPSIS>
+        <DESC>
+          <PARA>
+            If multiple processors are available, then 
+            this parameter controls whether the tool should 
+            run various underlying tools in parallel.
+          </PARA>
+        </DESC>        
+      </PARAM>
+      
+      <PARAM name="nproc" type="integer" def="INDEF" min="1" reqd="no">
+        <SYNOPSIS>Number of processors to use</SYNOPSIS>
+        <DESC>
+          <PARA>
+            If parallel=yes, then this controls the number of
+            processes to run at once.  The default, INDEF,
+            will use all available processors.  The value
+            cannot be larger than the number of processors.
+          </PARA>
+        </DESC>        
+      </PARAM>
+
+        <PARAM name="verbose" type="integer" def="1" min="0" max="5">
+            <SYNOPSIS>
+            Amount of chatter from the tool.
+            </SYNOPSIS>
+        </PARAM>
+        <PARAM name="clobber" type="boolean" def="no">
+            <SYNOPSIS>
+            Delete outfile if it already exists?
+            </SYNOPSIS>
+        </PARAM>
+    </PARAMLIST>
+
+
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+
+
+    <BUGS>
+        <PARA>
+            See the
+            <HREF link="http://cxc.harvard.edu/ciao/bugs/index.html">CIAO
+            website</HREF> for an up-to-date listing of known bugs.
+        </PARA>
+    </BUGS>
+    <LASTMODIFIED>August 2023</LASTMODIFIED>
+</ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/merge_too_small.xml
+++ b/share/doc/xml/merge_too_small.xml
@@ -187,6 +187,14 @@
         </PARAM>
     </PARAMLIST>
 
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
 
     <BUGS>
         <PARA>
@@ -195,6 +203,6 @@
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>January 2019</LASTMODIFIED>
+    <LASTMODIFIED>August 2023</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/merge_too_small.xml
+++ b/share/doc/xml/merge_too_small.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+<ENTRY 
+        context="tools" 
+        key="merge_too_small" 
+        refkeywords="merge map mask adaptive bin group small area counts" 
+        seealsogroups="dmimgtools"
+    >
+    <SYNOPSIS>
+       Adjust input map file to meet some minimum criteria
+    </SYNOPSIS>
+    <DESC>
+        <PARA>
+        The output maps from various adaptive binning routines
+        may contain small, insignificant groups which were 
+        the result of filling in the gaps between neighboring 
+        groups.  The merge_too_small script reassigns these
+        small regions to the largest neighbor.  The 
+        script will identify groups with a small geometric
+        area (ie few pixels), or with low number of counts 
+        (requires imgfile be supplied).
+        </PARA>
+        <PARA>
+        The deficient groups are always merged in to the 
+        largest neighboring group; where largest is the 
+        same metric (largest area or largest counts).
+        </PARA>
+        <PARA>
+        The output is a new map file with the deficient 
+        regions pixel values replaced with the largest neighbor.
+        </PARA>
+        <PARA>
+        With method=area, the minvalue is the minimum number of image 
+        (ie logical) pixels a group can contain.  With method=counts,
+        the minvalue is the minimum sum of pixel values obtained
+        from imgfile.  The imgfile typically will be a counts image; 
+        however, it could also be exposure corrected and|or background
+        subtracted.        
+        </PARA>
+        <PARA>
+        This script does not preserve any morphology imposed by the
+        tool which created the input map.  For example, if the
+        input map was created by following some contours, the
+        output map will not adhere to that constraint.  Similarly, if
+        the input has some geometric shape (circle, square, hexagon,etc)
+        the output will not preserve that geometry.
+        </PARA>
+
+    </DESC>
+
+
+     <QEXAMPLELIST>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+            % merge_too_small scales.map scales_min10px.map method=area minvalue=10
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+                Takes the input map file, scales.map, and identifies 
+                all the groups with 10 or fewer image pixels (ie logical
+                pixels).  Those groups are merged into their neighboring
+                groups with the largest area.  The updated map
+                file is written to the outfile, scales_min10px.map.                
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+            % merge_too_small scales_min10px.map scales_min10px+100cts.map method=counts minvalue=100 imgfile=img.fits
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            Taking the output from the previous example, we now
+            identify any groups which contain fewer than 100
+            counts and merge them into their neighbor with the 
+            most counts.
+            The imgfile, img.fits, must be supplied so
+            we can obtain the counts.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+     </QEXAMPLELIST>
+
+     <PARAMLIST>
+        <PARAM name="infile" type="file" filetype="input" reqd="yes">
+            <SYNOPSIS>
+            Input map file.
+            </SYNOPSIS>
+            <DESC>
+             <PARA>
+            The input map file should have integer pixel values.
+              The pixel values indicate which pixels are grouped      
+              together by some algorithm.  A pixel value of 0 are pixels
+              which are ungrouped (ie outside the image subspace).                 
+            </PARA>
+            <PARA>
+            The script will identify groups where the area is too
+            small, or the number of counts is too few and will merge
+            those groups into their neighbor with the largest
+            area or counts.
+            </PARA>
+          </DESC>
+        </PARAM>
+
+
+        <PARAM name="outfile" type="file" filetype="output" reqd="yes">
+          <SYNOPSIS>
+            Output map file
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+              The outfile is a map file containing integer pixel values.
+              The pixel values indicate which pixels are grouped
+              together by the algorithm.  A pixel value of 0 are pixels
+              which are ungrouped (ie outside the image subspace).            
+            </PARA>
+          </DESC>
+        </PARAM>
+        
+        
+        <PARAM name="method" type="string" def="counts">
+          <SYNOPSIS>Metric used for minimum calculation: counts or area</SYNOPSIS>
+          <DESC>
+              <PARA>
+         With method=area, the minvalue is the minimum number of image 
+        (ie logical) pixels a group can contain.  With method=counts,
+        the minvalue is the minimum sum of pixel values obtained
+        from imgfile.  The imgfile typically will be a counts image; 
+        however, it could also be exposure corrected and|or background
+        subtracted.        
+        </PARA>
+          </DESC>
+        </PARAM>
+        
+        
+        <PARAM name="imgfile" type="file" filetype="input">
+          <SYNOPSIS>Optional, input counts image</SYNOPSIS>
+          <DESC>
+            <PARA>
+            The imgfile is used if method=counts to determine 
+            the sum of the pixel values (counts) in each group.
+            The imgfile is also used if binimg is set in 
+            which case the script will apply the new map values,
+            outfile, to the imgfile and produce a binned image.            
+            </PARA>
+          </DESC>
+        </PARAM>
+        
+
+       <PARAM name="binimg" type="file" filetype="output">
+          <SYNOPSIS>Optional, output binned image</SYNOPSIS>
+          <DESC>
+            <PARA>
+                If the binimg file is specified, the script
+                will use the input image and the output map file to
+                create a binned version of the input image.
+            </PARA>          
+          </DESC>
+        </PARAM>
+
+        <PARAM name="minvalue" type="integer" min="0">
+            <SYNOPSIS>The lower limit on counts or area</SYNOPSIS>
+            <DESC>
+                <PARA>
+         With method=area, the minvalue is the minimum number of image 
+        (ie logical) pixels a group can contain.  With method=counts,
+        the minvalue is the minimum sum of pixel values obtained
+        from imgfile.      
+                </PARA>            
+            </DESC>
+        </PARAM>
+
+        <PARAM name="verbose" type="integer" def="1" min="0" max="5">
+            <SYNOPSIS>
+            Amount of chatter from the tool.
+            </SYNOPSIS>
+        </PARAM>
+        <PARAM name="clobber" type="boolean" def="no">
+            <SYNOPSIS>
+            Delete outfile if it already exists?
+            </SYNOPSIS>
+        </PARAM>
+    </PARAMLIST>
+
+
+    <BUGS>
+        <PARA>
+            See the
+            <HREF link="http://cxc.harvard.edu/ciao/bugs/index.html">CIAO
+            website</HREF> for an up-to-date listing of known bugs.
+        </PARA>
+    </BUGS>
+    <LASTMODIFIED>January 2019</LASTMODIFIED>
+</ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/mkregmap.xml
+++ b/share/doc/xml/mkregmap.xml
@@ -14,8 +14,11 @@
     <DESC>
         <PARA>
         The tool take an image and a stack of region descriptions.
-        The regions can multiple files, multiple rows in a single
+        The regions can be multiple files, multiple rows in a single
         file, or a list individual shapes.
+        The output image pixel values indicate which region each pixel is inside.
+        If a pixel is inside more than one region, the last region number is
+        used.        
         </PARA>
     </DESC>
 
@@ -207,6 +210,14 @@ circle(3288,6778,100)
         </PARAM>
     </PARAMLIST>
 
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
 
     <BUGS>
         <PARA>
@@ -215,6 +226,6 @@ circle(3288,6778,100)
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>January 2019</LASTMODIFIED>
+    <LASTMODIFIED>August 2023</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/mkregmap.xml
+++ b/share/doc/xml/mkregmap.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+<ENTRY 
+        context="tools" 
+        key="mkregmap" 
+        refkeywords="region map mask bin group stack" 
+        seealsogroups="dmimgtools"
+        displayseealsogroups="regiontools"
+    >
+    <SYNOPSIS>
+       Create map from stack of input regions.
+    </SYNOPSIS>
+    <DESC>
+        <PARA>
+        The tool take an image and a stack of region descriptions.
+        The regions can multiple files, multiple rows in a single
+        file, or a list individual shapes.
+        </PARA>
+    </DESC>
+
+     <QEXAMPLELIST>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+                % mkregmap img.fits "region1.fits,region2.fits,region3.fits" reg.map                 
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+              Three region files are supplied as input using
+              commas (",") to separate them.  The output
+              map file will contain values 1, 2, or 3 if the pixels
+              in the input image, img.fits, are inside any of those
+              regions.  The outfile, reg.map, stores this information,
+              and will have pixels equal to zero (0) if they are
+              not included in any of the regions, or if the 
+              input pixels were NaN.  We could also use the 
+              "region(filename)" syntax
+            </PARA>
+
+<VERBATIM>
+"region(region1.fits),region(region2.fits),region(region3.fits)"
+</VERBATIM>
+
+<PARA>
+or use the "@stack_filename" syntax
+</PARA>
+
+<VERBATIM>
+% cat my_region.lis
+region1.fits
+region2.fits
+region3.fits
+circle(3288,6778,100)
+% mkregmap region=@my_region.lis
+</VERBATIM>
+
+ <PARA>
+ Note: Users should be careful when using the "@" syntax with
+ list files located in different directories.  The "@-" syntax
+ may be need to suppress appending the directory name to the 
+ stack elements.
+ </PARA>
+
+
+          </DESC>
+        </QEXAMPLE>
+
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+                % mkregmap img.fits "pgrid(4096,4096,0:1000:100,0:360:360)" pgrid.map
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+              Here we use the polar-grid, "pgrid", stack syntax to create
+              a set of 10 annuli, all centered at (4096,4096), with
+              radii that go from 0 to 1000 pixels in 100 pixel steps.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>% dmellipse img.fits out=ellipse.out fraction="lgrid(0.05:1.0:0.025)"</LINE>
+            <LINE>% dmsort ellipse.out ellipse_sort.fits key=-component</LINE>
+            <LINE>% mkregmap img.fits "ellipse_sort.fits[#row=igrid(1:100:1)]" ellipse.map</LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+    Here we start by using dmellipse to generate a set of ellipses which
+    enclose from 5% to 100% of the flux in the input image.  We then
+    reverse sort these based on the COMPONENT column value (ie in 
+    descending order).  These are then fed 
+    into mkregmap to create an elliptical-annulus map.  We sorted
+    the values since the inner most region (5%) is typically fully enclosed
+    by the larger fractions and since mkregmap uses the last region
+    when regions overlap, we need it to be at the end of the stack.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>% mkregmap xmm.fits @region.lis xmm.map coord="pos"</LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            Not all images have a "sky" coordinate system that 
+            the scripts can understand.  Some images likes those from
+            XMM data products contain a "pos" coordinate system.
+            </PARA>
+            <PARA>
+            Users can use dmlist with the "cols" option to see the
+            coordinate axis name needed to use the script.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+
+
+     </QEXAMPLELIST>
+
+     <PARAMLIST>
+        <PARAM name="infile" type="file" filetype="input" reqd="yes">
+            <SYNOPSIS>
+            Input image.
+            </SYNOPSIS>
+            <DESC>
+           <PARA>
+            Null and NaN pixels, as well as those pixels outside the
+            image subspace will not be grouped.  Otherwise the
+            pixel values are ignored, just the size and dimensions 
+            of the image are used.
+            </PARA>
+
+          </DESC>
+        </PARAM>
+
+        <PARAM name="regions" type="string" reqd="yes" stacks="yes">
+          <SYNOPSIS>
+          Stack of regions
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+            Each region in the stack is assigned an ID, from 1 to N.
+            The output image is set to the region ID if the pixel
+            is inside the region.
+            If multiple regions overlap, the last region in the stack
+            will be used to set the group ID (highest region ID).            
+            </PARA>          
+          </DESC>
+
+        </PARAM>
+
+
+        <PARAM name="outfile" type="file" filetype="output" reqd="yes">
+          <SYNOPSIS>
+            Output map file
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+              The outfile is a map file containing integer pixel values.
+              The pixel values indicate which pixels are grouped
+              together by the algorithm.  A pixel value of 0 are pixels
+              which are ungrouped (ie outside the image subspace).            
+            </PARA>
+          </DESC>
+        </PARAM>
+
+
+        <PARAM name="binimg" type="file" filetype="output">
+          <SYNOPSIS>Optional, output binned image</SYNOPSIS>
+          <DESC>
+            <PARA>
+                If the binimg file is specified, the script
+                will use the input image and the output map file to
+                create a binned version of the input image.
+            </PARA>          
+          </DESC>
+        </PARAM>
+        
+        <PARAM name="coord" type="string" def="sky">
+          <SYNOPSIS>Axis name to filter input image</SYNOPSIS>
+            <DESC>
+              <PARA>
+              Not all images have a "sky" coordinate system.  For example
+              XMM images typically have a  "pos" coordinate system.
+              Users can use the dmlist command with the "cols" option
+              to determine the column name to filter on.
+              </PARA>            
+            </DESC>
+        </PARAM>
+
+        <PARAM name="verbose" type="integer" def="1" min="0" max="5">
+            <SYNOPSIS>
+            Amount of chatter from the tool.
+            </SYNOPSIS>
+        </PARAM>
+        <PARAM name="clobber" type="boolean" def="no">
+            <SYNOPSIS>
+            Delete outfile if it already exists?
+            </SYNOPSIS>
+        </PARAM>
+    </PARAMLIST>
+
+
+    <BUGS>
+        <PARA>
+            See the
+            <HREF link="http://cxc.harvard.edu/ciao/bugs/index.html">CIAO
+            website</HREF> for an up-to-date listing of known bugs.
+        </PARA>
+    </BUGS>
+    <LASTMODIFIED>January 2019</LASTMODIFIED>
+</ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/pathfinder.xml
+++ b/share/doc/xml/pathfinder.xml
@@ -145,6 +145,15 @@
         </PARAM>
     </PARAMLIST>
 
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+ 
 
     <BUGS>
         <PARA>
@@ -153,6 +162,6 @@
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>January 2019</LASTMODIFIED>
+    <LASTMODIFIED>August 2023</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/pathfinder.xml
+++ b/share/doc/xml/pathfinder.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+<ENTRY 
+        context="tools" 
+        key="pathfinder" 
+        refkeywords="gradient ascent steep steepest map mask adaptive bin group max tessellation" 
+        seealsogroups="dmimgtools"
+    >
+    <SYNOPSIS>
+       Group pixels by steepest gradient ascent to local maximum
+    </SYNOPSIS>
+    <DESC>
+        <PARA>
+        For each pixel, identify the maximum neighboring pixel.  Those form a group.
+        Continue from that maximum to identify it's maximum neighbor which
+        is then added to the group and so on.    When the algorithm finds a
+        local maximum which already belongs to a group, the new group is
+        abandoned and the pixels are added to the existing group. The process 
+        is repeated until the pixel being processed is the local maximum.
+        </PARA>
+        <PARA>
+        The input image should be modestly smoothed such that the 
+        local maxima are statistically significant.        
+        </PARA>
+        <PARA>
+        This algorithm can be helpful to separate region based on the 
+        "saddle-point" (where the gradient goes to zero).  For example it
+        helps find the natural separation point between point-likes sources
+        with different intensities (or different extent); rather than
+        simply using the mid-point between them, it uses the gradient
+        to assign pixel ownership to one-or-the-other.        
+        </PARA>
+
+    </DESC>
+
+     <QEXAMPLELIST>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+                % pathfinder smoothed.img out.map 
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            The smoothed infile, smoothed.img, is processed through 
+            the path-finding algorithm.  The outfile, out.map, 
+            contains the group ID for each local maxima.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+                % pathfinder smoothed.img out.map direction=perpendicular
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            Same as above; however this time restrict the search for
+            neighboring maxima to only 4 pixels: top, bottom, left, right.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+     </QEXAMPLELIST>
+
+     <PARAMLIST>
+        <PARAM name="infile" type="file" filetype="input" reqd="yes">
+            <SYNOPSIS>
+            Input image.
+            </SYNOPSIS>
+            <DESC>
+            <PARA>The image to be grouped.  Generally this 
+            algorithm works better if it is moderately smoothed.
+            </PARA>
+            <PARA>
+            Null  and NaN pixels, as well as those pixels outside the
+            image subspace will not be grouped.
+            </PARA>
+          </DESC>
+        </PARAM>
+
+        <PARAM name="outfile" type="file" filetype="output" reqd="yes">
+          <SYNOPSIS>
+            Output map file
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+              The outfile is a map file containing integer pixel values.
+              The pixel values indicate which pixels are grouped
+              together by the algorithm.  A pixel value of 0 are pixels
+              which are ungrouped (ie outside the image subspace or below minval).           
+            </PARA>
+          </DESC>
+        </PARAM>
+
+<!--
+        <PARAM name="binimg" type="file" filetype="output">
+          <SYNOPSIS>Optional, output binned image</SYNOPSIS>
+          <DESC>
+            <PARA>
+                If the binimg file is specified, the script
+                will use the input image and the output map file to
+                create a binned version of the input image.
+            </PARA>          
+          </DESC>
+        </PARAM>
+-->
+
+        <PARAM name="minval" type="real" def="0">
+          <SYNOPSIS>
+          Minimum pixel value to group
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+            Pixels values less than minval will be left ungrouped.
+            </PARA>
+          </DESC>
+        </PARAM>
+
+        <PARAM name="direction" type="string" def="diagonal">
+          <SYNOPSIS>Direction to follow gradient: perpendicular or diagonal</SYNOPSIS>
+          <DESC>
+            <PARA>
+            When searching for the neighboring pixel with the maximum 
+            value, the tool will just consider just the 4 perpendicular
+            pixels (top, bottom, left, right) of the current pixel, 
+            or can consider all 8 adjacent pixels including the diagonal
+            pixels.            
+            </PARA>
+          </DESC>
+        </PARAM>
+
+
+        <PARAM name="verbose" type="integer" def="1" min="0" max="5">
+            <SYNOPSIS>
+            Amount of chatter from the tool.
+            </SYNOPSIS>
+        </PARAM>
+        
+        <PARAM name="clobber" type="boolean" def="no">
+            <SYNOPSIS>
+            Delete outfile if it already exists?
+            </SYNOPSIS>
+        </PARAM>
+    </PARAMLIST>
+
+
+    <BUGS>
+        <PARA>
+            See the
+            <HREF link="http://cxc.harvard.edu/ciao/bugs/index.html">CIAO
+            website</HREF> for an up-to-date listing of known bugs.
+        </PARA>
+    </BUGS>
+    <LASTMODIFIED>January 2019</LASTMODIFIED>
+</ENTRY>
+</cxchelptopics>

--- a/share/doc/xml/vtbin.xml
+++ b/share/doc/xml/vtbin.xml
@@ -14,7 +14,7 @@
         <PARA>
             vtbin starts by identifying the local maxima in 
             the input image.  Each local max is assigned a unique
-            group ID. It then computes the Voronoi Tessellation
+            identification number. It then computes the Voronoi Tessellation
             around the location of the local maxima (sites) and 
             assigns all pixels within the Voronoi cells to the group. 
         </PARA>
@@ -113,7 +113,7 @@
               The outfile is a map file containing integer pixel values.
               The pixel values indicate which pixels are grouped
               together by the algorithm.  A pixel value of 0 are pixels
-              which are ungrouped (ie outside the image subspace).            
+              which are ungrouped.
             </PARA>
           </DESC>
         </PARAM>
@@ -183,15 +183,22 @@
 
 
 
-    <ADESC title="Relation to weighted v.t. binning">
+    <ADESC title="Relation to weighted Voronoi Tesselation binning">
       <PARA>Users of this tool should also be 
       familiar with Diehl &amp; Statler's the weighted Voronoi 
-      tessellation binning tool, wvt_bin, https://doi.org/10.1111/j.1365-2966.2006.10125.x .      
-        
+      tessellation binning tool, wvt_bin, https://doi.org/10.1111/j.1365-2966.2006.10125.x .   
       </PARA>    
     </ADESC>
 
-
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+ 
 
     <BUGS>
         <PARA>
@@ -200,6 +207,6 @@
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>February 2020</LASTMODIFIED>
+    <LASTMODIFIED>August 2023</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/vtbin.xml
+++ b/share/doc/xml/vtbin.xml
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+<ENTRY 
+        context="tools" 
+        key="vtbin" 
+        refkeywords="cell voronoi grow localmax max site map mask adaptive bin group grow max tessellation" 
+        seealsogroups="dmimgtools"
+    >
+    <SYNOPSIS>
+       Create adaptive bin image using Voronoi Tessellation
+    </SYNOPSIS>
+    <DESC>
+        <PARA>
+            vtbin starts by identifying the local maxima in 
+            the input image.  Each local max is assigned a unique
+            group ID. It then computes the Voronoi Tessellation
+            around the location of the local maxima (sites) and 
+            assigns all pixels within the Voronoi cells to the group. 
+        </PARA>
+        <PARA>
+            Users can override the initial site location by supplying 
+            their own sitefile.  If not, then the input image should
+            be smoothed on a scale larger than the local-max
+            search size as specified by the shape and radius parameters.
+            (default is a 5x5 box)
+        </PARA>
+
+        <PARA title="See also: centroid_map">
+          Users may also want to consider the centroid_map tool.  It
+          runs vtbin repeatedly adjusting the input sites 
+          to be the centroid of each cell.        
+        </PARA>
+
+    </DESC>
+
+
+     <QEXAMPLELIST>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+            % vtbin sm_img.fits vt.map 
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            Here a smoothed image is input.  With the default 
+            parameters, the tool will then identify all the 
+            local maxima in a 5x5 square neighborhood in the image.
+            The Voronoi tessellation of the location of those maxima 
+            will then computed and the map created.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+            % dmimgfilt sm_img.fits points.img "max" "box(0,0,3,1)+box(0,0,1,3)"
+            % dmimgblob points.img point.map srconly=yes thresh=0.5
+            % vtbin sm_img.fits vt.map sitefile=points.map
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            In this example we show how a user might create an
+            input sitefile.  We use the dmimgfilt too to identify
+            local maxima in a plus (+) shape region (instead of the
+            box or circle available in this tool).  We then label
+            each local maxima using the dmimgblob tool.            
+            With the sitefile specified, the script will use the
+            locations in that file for the tessellation.   
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+            % vtbin sm_img.fits vt.map shape=circle radius=4 binimg=vt.img 
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            In this example the local maximum search is changed to
+            use a circular region with a radius of 4 logical pixels. 
+            In addition we choose to output the binned image by
+            specifying the binimg parameter.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+     </QEXAMPLELIST>
+
+     <PARAMLIST>
+        <PARAM name="infile" type="file" filetype="input" reqd="yes">
+            <SYNOPSIS>
+            Input image.
+            </SYNOPSIS>
+            <DESC>
+            <PARA>The image to be grouped.  Generally this 
+            algorithm works better if it is slightly smoothed.
+            </PARA>
+            <PARA>
+            Null  and NaN pixels, as well as those pixels outside the
+            image subspace will not be grouped.
+            </PARA>
+          </DESC>
+        </PARAM>
+        <PARAM name="outfile" type="file" filetype="output" reqd="yes">
+          <SYNOPSIS>
+            Output map file
+          </SYNOPSIS>
+          <DESC>
+            <PARA>
+              The outfile is a map file containing integer pixel values.
+              The pixel values indicate which pixels are grouped
+              together by the algorithm.  A pixel value of 0 are pixels
+              which are ungrouped (ie outside the image subspace).            
+            </PARA>
+          </DESC>
+        </PARAM>
+
+
+        <PARAM name="binimg" type="file" filetype="output">
+          <SYNOPSIS>Optional, output binned image</SYNOPSIS>
+          <DESC>
+            <PARA>
+                If the binimg file is specified, the script
+                will use the input image and the output map file to
+                create a binned version of the input image.
+            </PARA>          
+          </DESC>
+        </PARAM>
+        
+        
+        <PARAM name="shape" type="string" def="box">
+          <SYNOPSIS>Shape of local max search region.</SYNOPSIS>
+          <DESC>
+            <PARA>The shape and radius parameters specify
+            the region to use when searching for "local" maxima.
+            The radius is expressed in logical (image) pixels.
+            </PARA>
+          </DESC>
+        </PARAM>
+        
+        <PARAM name="radius" type="real" def="2.5">
+          <SYNOPSIS>Shape of local max search region.</SYNOPSIS>
+          <DESC>
+            <PARA>The shape and radius parameters specify
+            the region to use when searching for "local" maxima.
+            The radius is expressed in logical (image) pixels.
+            </PARA>
+          </DESC>
+        </PARAM>
+        
+        <PARAM name="sitefile" type="file" filetype="input">
+          <SYNOPSIS>Input site map file</SYNOPSIS>
+          <DESC>
+            <PARA>
+            If the sitefile is specified, then the local max
+            search specified by the shape and radius parameters
+            is not performed.  The sitefile must have the 
+            same shape/size as the input image.  The pixel values
+            should be integers; values not equal to zero are 
+            used for the tessellation and the values 
+            must be unique.  Typically there should be
+            a few hundred to maybe a few thousand sites (based on
+            the image sizes).             
+            </PARA>
+          </DESC>
+        </PARAM>
+
+        
+        <PARAM name="verbose" type="integer" def="1" min="0" max="5">
+            <SYNOPSIS>
+            Amount of chatter from the tool.
+            </SYNOPSIS>
+        </PARAM>
+        <PARAM name="clobber" type="boolean" def="no">
+            <SYNOPSIS>
+            Delete outfile if it already exists?
+            </SYNOPSIS>
+        </PARAM>
+    </PARAMLIST>
+
+
+
+    <ADESC title="Relation to weighted v.t. binning">
+      <PARA>Users of this tool should also be 
+      familiar with Diehl &amp; Statler's the weighted Voronoi 
+      tessellation binning tool, wvt_bin, https://doi.org/10.1111/j.1365-2966.2006.10125.x .      
+        
+      </PARA>    
+    </ADESC>
+
+
+
+    <BUGS>
+        <PARA>
+            See the
+            <HREF link="http://cxc.harvard.edu/ciao/bugs/index.html">CIAO
+            website</HREF> for an up-to-date listing of known bugs.
+        </PARA>
+    </BUGS>
+    <LASTMODIFIED>February 2020</LASTMODIFIED>
+</ENTRY>
+</cxchelptopics>


### PR DESCRIPTION
This PR brings over all but two of the "adaptive binning" , nay "map making", tools from my old repository.  I used each of these when working with the `energy_hue_map` testing so I think it will be useful for users to have access to these too.

- `pathfinder` : groups pixels together based on the local gradient. it follows the steepest ascent to a local maximum. 
- `vtbin` : groups pixels based the inclusion in the Voronoi Tessellation cells of the local maximum points.
- `centroid_map` : iterates on `vtbin` by computing the centroid of the pixel in each cell and repeating the v.t. 
- `hexgrid` : creates a map whose groups are in the shape of hexagons
- `mkregmap` : creates a map from a stack of input regions
- `merge_too_small` : a helpful utility to tweak map files such that the groups meet a certain criteria (min area or min counts)
- `map2reg` : utlity to convert map files into regions.

Left behind are

- `dragon_scales` :  Repeatedly finding max pixel not already grouped and created group of specified shape (eg circle), includes only ungrouped pixels. Ultimately not too useful.
- `contour_map` : Create map based on contour levels.  Slow, and Sanders tool is better

