### PR TITLE
dax: fix ciao analysis menu 

### DIFF
--- a/config/ciao.ds9
+++ b/config/ciao.ds9
@@ -350,7 +350,7 @@ buttonbar
     Photometry (srcflux)
     *EVT* *evt*
     button
-    $param(srcflux); ds9_aper.sh $xpa "$energy" "$model" "$pmvals" "$absmodel" "$apmvals" "$psfmethod" |& $text
+    $param(srcflux); ds9_imgproc_wrapper $xpa srcflux "$energy" "$model" "$pmvals" "$absmodel" "$apmvals" "$psfmethod" |& $text
 
     Chandra Coordinates
     *


### PR DESCRIPTION
after absorbing ds9_aper.sh into the ds9_imgproc_wrapper script. somehow uncommented and deleted the wrong line in the config file. 
