### PR TITLE
Dax model editor check

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -2,7 +2,14 @@
 
 TODO: overview of changes.
 
+
 Using CIAO tools from ds9 (dax)
+
+  The model editor now checks that any values that have been modified
+  have been set (by pressing the Return or Enter key) before allowing
+  the user to proceed with certain actions such as Fit or Plot.
+  Modified values that have not been set appear as red text; the text
+  changes to black after the values have been set.
 
   Re-ordered and renamed a number of tasks:
 
@@ -12,6 +19,7 @@ Using CIAO tools from ds9 (dax)
     PHA               Spectrum (PHA)
     TIME              Ligthcurve (Time)
     EXPNO             Lightcurve (Exposure Number)
+
 
 New scripts
 

--- a/dax/dax_model_editor.py
+++ b/dax/dax_model_editor.py
@@ -198,6 +198,10 @@ class DaxModelEditor():
 
     def quit(self):
         'Continue on with rest of script'
+
+        if self.check_modified():
+            return
+
         self.win.quit()
         self.win.destroy()
 

--- a/dax/dax_model_editor.py
+++ b/dax/dax_model_editor.py
@@ -175,10 +175,6 @@ class DaxModelEditor():
         from sherpa.utils.err import EstErr
 
         if self.check_modified():
-            messagebox.showerror("DAX Model Editor",
-                       "Some values have been modified but not set. "+
-                       "Please set the values by pressing Return and the "+
-                       "text will change color from red to black.")
             return
 
         if self.conf_command:
@@ -192,10 +188,6 @@ class DaxModelEditor():
         '''
 
         if self.check_modified():
-            messagebox.showerror("DAX Model Editor",
-                       "Some values have been modified but not set. "+
-                       "Please set the values by pressing Return and the "+
-                       "text will change color from red to black.")
             return
 
         try:
@@ -228,6 +220,12 @@ class DaxModelEditor():
         for modpar in self.model_parameters:
             if modpar.check_modified():
                 is_modified = True
+
+        if is_modified:
+            messagebox.showerror("DAX Model Editor",
+                       "Some values have been modified but not set. "+
+                       "Please set the values by pressing Return and the "+
+                       "text will change color from red to black.")
 
         return is_modified
 
@@ -264,10 +262,6 @@ class DaxModelEditor():
         import sherpa.astro.ui as sherpa
 
         if self.check_modified():
-            messagebox.showerror("DAX Model Editor",
-                       "Some values have been modified but not set. "+
-                       "Please set the values by pressing Return and the "+
-                       "text will change color from red to black.")
             return
 
         if self.xpa is None:
@@ -364,9 +358,10 @@ class DaxModelParameter():
             to_mod.insert(0, self.__format_val(self.initial_value[field]))
             to_mod.configure(foreground="black")
             setattr(self.sherpa_par, field, self.initial_value[field])
+            to_mod.modified = False
 
     def update(self):
-        """Reset values to original"""
+        """Update values after fit"""
         for field in ['max', 'min', 'val']:
             to_mod = getattr(self, field)
             newval = getattr(self.sherpa_par, field)


### PR DESCRIPTION
Adds a property to each entry box widget to identify when the value has been modified but not yet set (press `Return`/`Enter`).

Checks that all entry box widgets have been set before allowing user to `Fit`, `Plot`, run `Conf`, or `Quit` -- `Quit` resumes the sherpa fitting script so we want to be sure that the values set in the GUI are what sherpa is actually using.