### PR TITLE
increment Python version in mk_script_tarfile

### DIFF
--- a/mk_script_tarfile
+++ b/mk_script_tarfile
@@ -34,7 +34,7 @@ import sys
 import time
 
 
-def build_dist(version, dirname, outdir, python="python3.9"):
+def build_dist(version, dirname, outdir, python="python3.10"):
     """Build contrib scripts package into a separate temp dir"""
 
     outdir = Path(outdir)


### PR DESCRIPTION
Increment the default Python version used to build the tarball to Python 3.10.