### PR TITLE
reproject_obs fails if mask files cannot be found

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -54,6 +54,12 @@ Updated scripts
     The script has been updated to support changes to Sherpa plotting
     in this release.
 
+  reproject_obs
+
+    The script has been updated so that file validation checks at its
+    initialization will not have a dependency on mask files, which are
+    otherwise not used. 
+
   srcflux
   
     Added new option to create "optimized" source and background regions

--- a/bin/reproject_obs
+++ b/bin/reproject_obs
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2019, 2020, 2021
+# Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2019, 2020, 2021, 2023
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -56,7 +56,7 @@ import ciao_contrib._tools.utils as utils
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'reproject_obs'
-__revision__ = '15 November 2021'
+__revision__ = '20 October 2023'
 
 lgr = lw.initialize_logger(toolname)
 v1 = lgr.verbose1
@@ -452,7 +452,10 @@ def link_ancillary_files(taskrunner,
     for obs in obsinfos:
         obsid = obs.obsid
         link_file(obsid, 'bpix', obs.get_ancillary_('bpix'))
-        (mtask, mfile) = link_file(obsid, 'mask', obs.get_ancillary_('mask'))
+        try:
+            (mtask, mfile) = link_file(obsid, 'mask', obs.get_ancillary_('mask'))
+        except TypeError:
+            mfile = None
         if itype is not None:
             link_file_inst(obsid, itype, obs.get_ancillary_(itype))
 
@@ -460,7 +463,11 @@ def link_ancillary_files(taskrunner,
         #
         (key, label) = get_key_label(obsid)
         taskname = labelconv(f"fov-{obsid}")
-        pretasks = [mtask] + asoltasks[label]
+
+        pretasks = asoltasks[label]
+        if mfile is not None:
+            pretasks += [mtask]
+
         fovname = f"{outroot}{obsid}.fov"
         evtfile = f"{outroot}{obsid}_reproj_evt.fits"  # assume this is correct
         taskrunner.add_task(taskname, pretasks, run.make_fov,

--- a/share/doc/xml/reproject_obs.xml
+++ b/share/doc/xml/reproject_obs.xml
@@ -760,6 +760,15 @@
       </LIST>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.16.0 (December 2023) release">
+      <PARA>
+	File validation checks at the initialization of the script had
+	an overlooked dependency on the presence of mask files, which
+	are neither a parameter input nor used by the script.  The
+	script has been updated to break this unnecessary dependency.
+      </PARA>
+    </ADESC>    
+    
     <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
       <PARA>
 	The script now generates the FOV file for each reprojected event file
@@ -892,7 +901,7 @@
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2022</LASTMODIFIED>
+    <LASTMODIFIED>October 2023</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
from a helpdesk ticket, we've found that `reproject_obs` requires the presence of mask files in the working directory by its initial file validation checks even though they are not used by the script.  This update fixes the problem should mask files are unavailable.