### PR TITLE
add support for L3 asolfile w/ CONTENT=ASPSOL3 and evt3 w/o TITLE keyword

### DIFF
--- a/bin/srcflux
+++ b/bin/srcflux
@@ -18,7 +18,7 @@
 #
 
 toolname = "srcflux"
-__revision__ = "03 October 2023"
+__revision__ = "02 November 2023"
 
 import os
 
@@ -372,7 +372,8 @@ def choose_skyfov_method( asolfiles ):
     skyfov convex hull algorithm.
     """
 
-    skyfov_choices={ 'ASPSOLOBI' : 'convexhull' , 'ASPSOL' : 'minmax' }
+    skyfov_choices={'ASPSOLOBI' : 'convexhull' , 'ASPSOL' : 'minmax',
+                    'ASPSOL3': 'minmax'}
     if asolfiles is None or 1 != len(asolfiles):
         # New obi based asol, there will be 1 file per obi (by design)
         return skyfov_choices["ASPSOL"]

--- a/ciao_contrib/_tools/fileio.py
+++ b/ciao_contrib/_tools/fileio.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2019, 2020
+#  Copyright (C) 2010-2016, 2019, 2020, 2023
 #            Smithsonian Astrophysical Observatory
 #
 #
@@ -324,7 +324,7 @@ def validate_asol(infile):
     except KeyError:
         raise IOError("The file {} is missing the CONTENT keyword.".format(infile))
 
-    if content not in ['ASPSOL', 'ASPSOLOBI']:
+    if content not in ['ASPSOL', 'ASPSOLOBI', 'ASPSOL3']:
         raise IOError("Aspect solutions have CONTENT=ASPSOL or ASPSOLOBI, but found {} in\n{}".format(content, infile))
 
     req = ['time', 'ra', 'dec', 'roll']
@@ -654,7 +654,7 @@ def find_output_grid(evtfile, asolfile, maskfile,
     content = contents.pop()
     if content == 'ASPSOLOBI':
         method = 'convexhull'
-    elif content == 'ASPSOL':
+    elif content in ['ASPSOL', 'ASPSOL3']:
         method = 'minmax'
     else:
         raise IOError("Invalid CONTENT={} in aspect solution\n{}".format(content,

--- a/ciao_contrib/_tools/run.py
+++ b/ciao_contrib/_tools/run.py
@@ -575,7 +575,7 @@ def make_fov(evtfile, asolfiles, msk, outfile):
     content = contents.pop()
     if content == 'ASPSOLOBI':
         method = 'convexhull'
-    elif content == 'ASPSOL':
+    elif content in ['ASPSOL', 'ASPSOL3']:
         method = 'minmax'
     else:
         raise OSError(f"Invalid CONTENT={content} in aspect solution: {asolfiles}")

--- a/ciao_contrib/_tools/specextract.py
+++ b/ciao_contrib/_tools/specextract.py
@@ -892,25 +892,9 @@ class ParDicts(object):
         """
 
         keys_to_check = ['TITLE', 'OBSERVER', 'OBJECT', 'OBS_ID', 'DS_IDENT']
-        merge_key = []
         for mkey in keys_to_check:
-            if mkey in kwdict:
-                merge_key.append(kwdict[mkey].lower())
-
-        # ~ merge_key = [kwdict["TITLE"].lower(),
-                     # ~ kwdict["OBSERVER"].lower(),
-                     # ~ kwdict["OBJECT"].lower(),
-                     # ~ kwdict["OBS_ID"].lower()]
-
-        # ~ try:
-            # ~ merge_key.append(kwdict["DS_IDENT"].lower())
-        # ~ except KeyError:
-            # ~ pass
-
-        if "merged" in merge_key:
-            raise IOError(f"Merged data sets are unsupported by {toolname}.  Merged events files should not be used for spectral analysis.") # or v1 warning?
-
-        del(merge_key)
+            if mkey in kwdict and kwdict[mkey].lower() == "merged":
+                raise IOError(f"Merged data sets are unsupported by {toolname}.  Merged events files should not be used for spectral analysis.") # or v1 warning?
 
 
     def _check_blanksky(self,headerkeys,srcbkg_kw,bkgresp):

--- a/ciao_contrib/_tools/specextract.py
+++ b/ciao_contrib/_tools/specextract.py
@@ -188,10 +188,10 @@ class ParDicts(object):
         src_cnt = len(src_stk)
         asptype = self._get_keyvals(asp_stk, "CONTENT")
 
-        if all(["ASPHIST" in asptype, "ASPSOL" in asptype or "ASPSOLOBI" in asptype]):
+        if all(["ASPHIST" in asptype, "ASPSOL" in asptype or "ASPSOLOBI" in asptype or "ASPSOL3" in asptype]):
             raise IOError("A mix of aspect solution and histogram files were entered into 'asp'; please enter one or a list of either type, not both.\n")
 
-        if all(["ASPHIST" not in asptype, "ASPSOL" not in asptype, "ASPSOLOBI" not in asptype]):
+        if all(["ASPHIST" not in asptype, "ASPSOL" not in asptype, "ASPSOLOBI" not in asptype, "ASPSOL3" not in asptype]):
             raise IOError("Neither aspect histogram nor aspect solution files were found in the 'asp' input. Either the ASPHIST/asphist or ASPSOL FITS HDU is not in the expected place - which could cause the CIAO tools invoked by this script to fail - or a filename was entered incorrectly or does not exist. Exiting.\n")
 
         if "ASPHIST" in utils.getUniqueSynset(asptype):
@@ -891,15 +891,21 @@ class ParDicts(object):
         check if the input file has been merged using its header keywords
         """
 
-        merge_key = [kwdict["TITLE"].lower(),
-                     kwdict["OBSERVER"].lower(),
-                     kwdict["OBJECT"].lower(),
-                     kwdict["OBS_ID"].lower()]
+        keys_to_check = ['TITLE', 'OBSERVER', 'OBJECT', 'OBS_ID', 'DS_IDENT']
+        merge_key = []
+        for mkey in keys_to_check:
+            if mkey in kwdict:
+                merge_key.append(kwdict[mkey].lower())
 
-        try:
-            merge_key.append(kwdict["DS_IDENT"].lower())
-        except KeyError:
-            pass
+        # ~ merge_key = [kwdict["TITLE"].lower(),
+                     # ~ kwdict["OBSERVER"].lower(),
+                     # ~ kwdict["OBJECT"].lower(),
+                     # ~ kwdict["OBS_ID"].lower()]
+
+        # ~ try:
+            # ~ merge_key.append(kwdict["DS_IDENT"].lower())
+        # ~ except KeyError:
+            # ~ pass
 
         if "merged" in merge_key:
             raise IOError(f"Merged data sets are unsupported by {toolname}.  Merged events files should not be used for spectral analysis.") # or v1 warning?


### PR DESCRIPTION
This updates the low level i/o routines to accept `CONTENT="ASPSOL3"` to be the same as `ASPSOL`.  (upshot: need to run `skyfov method=minmax`) .

It also relaxes `specextract` requirement for keys to check for merged files since `evt3` file omits `TITLE`.  

This will close #769 

