### PR TITLE
blanksky* revisions for contrib 4.16.0

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -27,7 +27,66 @@ Using CIAO tools from ds9 (dax)
 
 New scripts
 
-  TODO
+  energy_hue_map
+  
+    A new technique to create true color images from a continuous 
+    energy spectrum rather than traditional tri-color images created
+    using 3 energy bands.  The inputs include a map estimating the
+    median (or mean) energy in each pixel (for example created 
+    using the statmap tool), and an image of the counts or flux.
+
+  The following scripts provide different algorithms to create map
+  files with different morphologies that have been found to be useful
+  when creating the mean|median energy map with a variety of 
+  fields.
+    
+    hexgrid
+
+        Creates a regular grid of hexagonal shaped map regions.
+        Hexagons can best approximate circles as they are the
+        highest order regular polygon that can uniformly tile a plane.
+
+    vtbin
+
+        Creates a map file based on the Voronoi Tessellation of points in
+        the input image.  By default it uses the location of the local maxima
+        or users can supply their own locations (via the sitefile).
+
+    centroid_map
+
+        This script runs vtbin and then computes the centroid of the pixel
+        values in each map region.  It then repeats the Voronoi Tessellation
+        using the centroid values N-many times, where N is the numiter parameter.
+
+    pathfinder
+
+        This script generates map regions based on the local gradient. It
+        follows the steepest ascent to the local maxima.  All pixels that reach
+        the same local maxim are grouped together.  Better for point sources
+        and other "clumpy" emission.
+
+    mkregmap
+
+        Turn a stack of regions into a map file.  Examples include
+        - Stack of region files:  @ciao.lis
+        - Special stack expanders:  pgrid() and rgrid()
+        - Multiple rows in a single region file:  foo.fits[@row=igrid(1:N:1)]
+          "Common" uses would be the output from tools like dmellipse or
+          dmcontour.
+
+    merge_too_small
+
+        Some of these algorithms can create small regions needed to "fill in"
+        the space between other more statistically significant regions.
+        The merge_too_small script will re-assign small groups to the largest
+        neighboring group; where "small" is either area below threshold
+        or counts below threshold.
+
+    map2reg
+
+        A utility tool to take a map file and converts it into a 
+        region file.  This can be useful to overlay the map boundaries
+        on images in ds9.
 
 
 Updated scripts
@@ -39,6 +98,18 @@ Updated scripts
     as the old behavior could lead to data loss. This does increase
     the memory needed to store the images, so the datatype parameter
     can be used to change back to the old behaviour.
+
+  blanksky, blanksky_image, blanksky_sample
+
+    The scripts have been linted and cleaned up.  'blanksky' has been
+    updated to make use of the CHKVFPHA keyword, introduced to
+    acis_process_events in CIAO 4.16, to determine if "status=0" event
+    filtering should be applied to ACIS VFaint observations, but will
+    fall back on the old technique of parsing the input event file
+    header to make the determination if the new keyword is not available.
+    The 'blanksky_sample' will make use of the reference 'infile' keywords
+    for the optional combined infile/sampled background products instead of
+    the 'Merged'-valued keywords as a result of using dmmerge.
 
   convert_xspec_script
 
@@ -53,6 +124,12 @@ Updated scripts
 
     The script has been updated to support changes to Sherpa plotting
     in this release.
+
+  reproject_obs
+
+    The script has been updated so that file validation checks at its
+    initialization will not have a dependency on mask files, which are
+    otherwise not used. 
 
   srcflux
   
@@ -72,7 +149,13 @@ Updated scripts
 
 New Python modules
 
-  TODO (if any)
+  crates_contrib/masked_image_crate
+  
+    This new module introduces the MaskedIMAGECrate class.  It is
+    a subclass of the standard crates IMAGECrate class but extends it
+    to include a `valid` method to check if the pixel location is a
+    valid pixel (inside subspace and not NULL/NaN/Inf).  It only
+    supports 2D images.
 
 
 Updated Python modules

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -101,15 +101,15 @@ Updated scripts
 
   blanksky, blanksky_image, blanksky_sample
 
-    The scripts have been linted and cleaned up.  'blanksky' has been
-    updated to make use of the CHKVFPHA keyword, introduced to
-    acis_process_events in CIAO 4.16, to determine if "status=0" event
-    filtering should be applied to ACIS VFaint observations, but will
-    fall back on the old technique of parsing the input event file
-    header to make the determination if the new keyword is not available.
-    The 'blanksky_sample' will make use of the reference 'infile' keywords
-    for the optional combined infile/sampled background products instead of
-    the 'Merged'-valued keywords as a result of using dmmerge.
+    'blanksky' has been updated to make use of the CHKVFPHA keyword,
+    introduced to acis_process_events in CIAO 4.16, to determine if
+    "status=0" event filtering should be applied to ACIS VFaint
+    observations, but will fall back on the old technique of parsing
+    the input event file header to make the determination if the new
+    keyword is not available. The 'blanksky_sample' will make use of
+    the reference 'infile' keywords for the optional combined
+    infile/sampled background products instead of the 'Merged'-valued
+    keywords as a result of using dmmerge.
 
   convert_xspec_script
 

--- a/bin/blanksky
+++ b/bin/blanksky
@@ -19,7 +19,7 @@
 #
 
 __toolname__ = "blanksky"
-__revision__  = "31 October 2023"
+__revision__  = "07 November 2023"
 
 
 import os
@@ -224,6 +224,15 @@ def check_tool_par(evt,tool,param):
     par_instance = [par.replace("\"","") for par in par_instance]
 
     return f"{param}=yes" in par_instance
+
+
+
+def _chkvfpha(kw,evt):
+    if kw["DATAMODE"] == "VFAINT":
+        if "CHKVFPHA" in kw.keys():
+            return kw["CHKVFPHA"] # kw introduced in 4.16 to replace fragile 'check_tool_par' approach
+        return check_tool_par(evt=evt,tool="acis_process_events", param="check_vf_pha")
+    return False
 
 
 
@@ -816,12 +825,7 @@ is on ACIS-{aimpoint}, due to exceeding of SIM-Z limit.\n")
 
         # if datamode is VFAINT and ran a_p_e with check_vf_pha=yes,
         # remove background events with non-0 status
-        if False not in (keywords["DATAMODE"] == "VFAINT",
-                         check_tool_par(evt=infile,tool="acis_process_events",
-                                        param="check_vf_pha")):
-        # in CIAO 4.16, replace with:
-        # if keywords["DATAMODE"] == "VFAINT" and keyword["CHKVFPHA"]:
-        # and can remove 'check_tool_par' function
+        if keywords["DATAMODE"] == "VFAINT" and _chkvfpha(keywords,infile):
             dmcopy.punlearn()
 
             dmcopy.infile = f"{bkg_calib.name}[status=0]"

--- a/bin/blanksky
+++ b/bin/blanksky
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2018, 2019, 2020, 2022, 2023
+#  Copyright (C) 2016-2023
 #            Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -18,35 +18,38 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-toolname = "blanksky"
-__revision__  = "04 January 2023"
+__toolname__ = "blanksky"
+__revision__  = "31 October 2023"
 
-import os, sys, paramio, tempfile, shutil, stat
 
+import os
+import sys
+import shutil
+import tempfile
+import paramio
 import stk
 import pycrates as pcr
 
-from crates_contrib.utils import *
 from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
 from ciao_contrib.param_wrapper import open_param_file
 
-from ciao_contrib._tools import fluximage, utils, fileio, obsinfo, bands
-
-from ciao_contrib.runtool import hrc_bkgrnd_lookup, dmlist, dmcopy, dmhistory, acis_bkgrnd_lookup, dmcoords, dmmerge, reproject_events, dmkeypar, dmhedit, add_tool_history, dmtcalc, acis_process_events
+from ciao_contrib._tools import fluximage, utils, fileio, obsinfo #, bands
+from ciao_contrib.runtool import make_tool, add_tool_history, new_pfiles_environment
+from ciao_contrib.proptools import dates
 
 #########################################################################################
 #########################################################################################
 
 # Set up the logging/verbose code
-initialize_logger(toolname)
+initialize_logger(__toolname__)
 
 # Use v<n> to display messages at the given verbose level.
-v0 = make_verbose_level(toolname, 0)
-v1 = make_verbose_level(toolname, 1)
-v2 = make_verbose_level(toolname, 2)
-v3 = make_verbose_level(toolname, 3)
-v4 = make_verbose_level(toolname, 4)
-v5 = make_verbose_level(toolname, 5)
+v0 = make_verbose_level(__toolname__, 0)
+v1 = make_verbose_level(__toolname__, 1)
+v2 = make_verbose_level(__toolname__, 2)
+v3 = make_verbose_level(__toolname__, 3)
+v4 = make_verbose_level(__toolname__, 4)
+v5 = make_verbose_level(__toolname__, 5)
 
 
 class ScriptError(RuntimeError):
@@ -73,8 +76,9 @@ class suppress_stdout_stderr(object):
        This will not suppress raised exceptions, since exceptions are printed
     to stderr just before a script exits, and after the context manager has
     exited (at least, I think that is why it lets exceptions through).
-
     '''
+    #import stat
+
     def __init__(self):
         # Open a pair of null files
         self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
@@ -95,9 +99,7 @@ class suppress_stdout_stderr(object):
         os.close(self.null_fds[1])
 
 
-def error_out(msg):
-    "Throw a ScriptError with msg as the message."
-    raise ScriptError(msg)
+###############################################
 
 
 def caldb_blanksky(detector):
@@ -110,17 +112,18 @@ def caldb_blanksky(detector):
         elif detector ==  "ACIS":
             bkg_path = f"{caldb}/data/chandra/acis/bkgrnd"
     else:
-        error_out("Check that CalDB has been installed.")
+        raise ScriptError("Check that CalDB has been installed.")
 
-    if len(os.listdir(bkg_path)) > 2:
-	# the CALDB 'main' tarball only contains a readme and manifest text
-	# file in the 'bkgrnd' sub-directory
-        return True
-    else:
-        return False
+    # the CALDB 'main' tarball only contains a readme and manifest text
+    # file in the 'bkgrnd' sub-directory
+    return len(os.listdir(bkg_path)) > 2
 
 
-def t_norm(evtfile,bkgfile,chip,evt_keywords,bkg_keywords):
+
+def t_norm(chip,evt_keywords,bkg_keywords):
+    """
+    return the scaling factor based on chip exposure time
+    """
     # use pre-filtered evtfile that matches the filtering applied to the bkgfile
 
     det = evt_keywords["INSTRUME"]
@@ -149,10 +152,17 @@ def t_norm(evtfile,bkgfile,chip,evt_keywords,bkg_keywords):
     return obs_time/bkg_time
 
 
+
 def e_norm(evtfile,bkgfile,chip,bkgparams,instrument):
+    """
+    return the high-energy (total) photon count scaling factor
+    """
+
     # use pre-filtered evtfile that matches the filtering applied to the bkgfile
 
     det = instrument
+
+    dmlist = make_tool("dmlist")
 
     if det == "ACIS":
         det = "ccd_id"
@@ -162,13 +172,13 @@ def e_norm(evtfile,bkgfile,chip,bkgparams,instrument):
     ccd = f"[{det}={chip}]"
 
     dmlist.punlearn()
-    dmlist.infile = evtfile+ccd+bkgparams
+    dmlist.infile = f"{evtfile}{ccd}{bkgparams}"
     dmlist.opt = "counts"
 
     obs_counts = float(dmlist())
 
     dmlist.punlearn()
-    dmlist.infile = bkgfile+ccd+bkgparams
+    dmlist.infile = f"{bkgfile}{ccd}{bkgparams}"
     dmlist.opt = "counts"
 
     bkg_counts = float(dmlist())
@@ -176,14 +186,21 @@ def e_norm(evtfile,bkgfile,chip,bkgparams,instrument):
     return obs_counts/bkg_counts
 
 
+
 def he_rate_norm(evtfile,bkgfile,chip,bkgparams,instrument,evt_keywords,bkg_keywords):
+    """
+    return scaling factor based on the the high-energy photon count rate
+    """
+
     he = e_norm(evtfile,bkgfile,chip,bkgparams,instrument)
-    t = t_norm(evtfile,bkgfile,chip,evt_keywords,bkg_keywords)
+    t = t_norm(chip,evt_keywords,bkg_keywords)
 
     return he/t
 
 
+
 def check_tool_par(evt,tool,param):
+    dmhistory = make_tool("dmhistory")
 
     dmhistory.punlearn()
     dmhistory.infile = evt
@@ -192,8 +209,8 @@ def check_tool_par(evt,tool,param):
 
     try:
         hist = dmhistory()
-    except OSError:
-        raise ValueError(f"{tool} was not used to generate {evt}")
+    except OSError as exc:
+        raise ValueError(f"{tool} was not used to generate {evt}") from exc
 
     hist = [t for t in hist.split("\n") if t.startswith(tool)]
 
@@ -206,10 +223,8 @@ def check_tool_par(evt,tool,param):
 
     par_instance = [par.replace("\"","") for par in par_instance]
 
-    if f"{param}=yes" in par_instance:
-        return True
-    else:
-        return False
+    return f"{param}=yes" in par_instance
+
 
 
 def find_acis_stowed_bkg(evtfile,ccd_list):
@@ -282,11 +297,11 @@ def find_acis_stowed_bkg(evtfile,ccd_list):
     # the user wouldn't be using blanksky/particle backgrounds to being with
     try:
         ctiapp = fileio.get_keys_from_file(f"{evtfile}[#row=0]")["CTI_APP"]
-    except KeyError:
-        raise IOError(f"{evtfile} is missing the 'CTI_APP' header keyword!")
+    except KeyError as exc:
+        raise IOError(f"{evtfile} is missing the 'CTI_APP' header keyword!") from exc
 
     if "N" in "".join(set(ctiapp)).upper():
-        raise IOError(f"The '{toolname}' script only supports CTI-corrected event files for ACIS stowed background file selection.")
+        raise IOError(f"The '{__toolname__}' script only supports CTI-corrected event files for ACIS stowed background file selection.")
 
     caldb = os.environ["CALDB"]
 
@@ -319,22 +334,35 @@ def find_acis_stowed_bkg(evtfile,ccd_list):
     return ",".join(stowedfiles)
 
 
+
 def apply_gain(infile,outfile,kw,tmpdir,verbose):
+    """
+    run acis_process_events to update the gain correction, should be done alongside
+    t_gain and CTI correction, which is currently not supported by a_p_e.
+    """
+
     # The two gain files should have the same date and version number in the filename.
     # If they do not match, reprocess the background file with the event file gain file.
 
-    # identify gainfiles
+    # identify gainfiles #
     gainfile = kw["GAINFILE"]
     bkg_gain = fileio.get_keys_from_file(infile)["GAINFILE"]
 
+    a_p_e = make_tool("acis_process_events")
+    dmtcalc = make_tool("dmtcalc")
+
     if gainfile != bkg_gain:
+
+        aciscaldb = f"{os.environ['CALDB']}/data/chandra/acis"
+        ctifile = kw["CTIFILE"]
+        tgainfile = kw["TGAINFIL"]
 
         ## grab eventdef and remove time def
         ## change status bits of background events to match infile w/a_p_e
 
         def _get_edef(evt,removecol=None):
-            cr = pcr.read_file(f"{evt}[#row=1]")
-            colnames = cr.get_colnames(vector=False)
+            cr = pcr.read_file(f"{evt}[#row=0]")
+            colnames = [c[:c.find("(")] if "(" in c else c for c in cr.get_colnames(vectors=True)]
 
             # The data types recognized by acis_process_events include
             # d (double-precision real), f (single-precision real), i (integer),
@@ -347,14 +375,11 @@ def apply_gain(infile,outfile,kw,tmpdir,verbose):
                           "int16" : "s",
                           "uint8" : "x" }
 
-            edef = {}
+            edef = { col : edef_type[cr.get_column(col).values.dtype.name] for col in colnames }
 
-            for col in colnames:
-                edef[col] = edef_type[cr.get_column(col).values.dtype.name]
+            del cr
 
-            cr.__del__()
-
-            if removecol != None:
+            if removecol is not None:
                 try:
                     colnames.remove(removecol)
                 except ValueError:
@@ -362,9 +387,10 @@ def apply_gain(infile,outfile,kw,tmpdir,verbose):
 
             edefstr = [f"{edef[col]}:{col}" for col in colnames]
 
-            return  "{" + ",".join(edefstr) + "}"
+            return  f"{{{','.join(edefstr)}}}"
 
-        eventdef = _get_edef(infile,remove="time")
+
+        eventdef = _get_edef(infile,removecol="time")
 
         ## CTI and TGAIN Calibration Files
         #
@@ -375,53 +401,55 @@ def apply_gain(infile,outfile,kw,tmpdir,verbose):
         # some columns required by acis_process_events.  The error introduced
         # by this mismatched calibration should not be very significant for
         # the faint, extended objects for which people use these backgrounds.
-        acis_process_events.punlearn()
 
-        acis_process_events.outfile = outfile
-        acis_process_events.acaofffile = "NONE"
-        acis_process_events.stop = "none"
-        acis_process_events.doevtgrade = "no"
-        acis_process_events.apply_cti = "yes"
-        acis_process_events.apply_tgain = "no"
-        acis_process_events.calculate_pi = "yes"
-        acis_process_events.pix_adj = "NONE"
-        acis_process_events.gainfile = f"{os.environ['CALDB']}/data/chandra/acis/det_gain/{gainfile}"
-        acis_process_events.eventdef = eventdef
-        acis_process_events.clobber = "yes"
-        acis_process_events.verbose = verbose
+        a_p_e.punlearn()
+
+        a_p_e.outfile = outfile
+        a_p_e.acaofffile = "NONE"
+        a_p_e.stop = "none"
+        a_p_e.doevtgrade = False
+        a_p_e.apply_cti = True
+        a_p_e.apply_tgain = True #False
+        a_p_e.calculate_pi = True
+        a_p_e.pix_adj = "NONE"
+        a_p_e.eventdef = eventdef
+        a_p_e.clobber = True
+        a_p_e.verbose = verbose
+
+        a_p_e.gainfile = f"{aciscaldb}/det_gain/{gainfile}"
+        a_p_e.ctifile = f"{aciscaldb}/t_gain/{tgainfile}"
+        a_p_e.tgainfile = f"{aciscaldb}/cti/{ctifile}"
 
         try:
-            acis_process_events.infile = infile
-            acis_process_events()
+            a_p_e.infile = infile
+            a_p_e()
 
         except OSError:
-
             # add a time and expno column to the blanksky file, so acis_process_events
             # can run on it (change introduced in 4.8)
-            bkg_col = tempfile.NamedTemporaryFile(dir=tmpdir)
+            with tempfile.NamedTemporaryFile(dir=tmpdir) as bkg_col:
 
-            dmtcalc.punlearn()
+                dmtcalc.punlearn()
 
-            dmtcalc.infile = infile
-            dmtcalc.outfile = bkg_col.name
-            dmtcalc.expression = "time=#nan;expno=#nan"
-            dmtcalc.clobber = True
-            dmtcalc.verbose = "0"
+                dmtcalc.infile = infile
+                dmtcalc.outfile = bkg_col.name
+                dmtcalc.expression = "time=#nan;expno=#nan"
+                dmtcalc.clobber = True
+                dmtcalc.verbose = "0"
 
-            dmtcalc()
+                dmtcalc()
 
-            acis_process_events.infile = bkg_col.name
-            acis_process_events()
-
-            bkg_col.close()
+                a_p_e.infile = bkg_col.name
+                a_p_e()
 
     else:
         shutil.copyfile(infile,outfile)
 
 
+
 def get_par(argv):
     """ Get data_products parameters from parameter file """
-    pfile = open_param_file(argv,toolname=toolname)["fp"]
+    pfile = open_param_file(argv,toolname=__toolname__)["fp"]
 
     # Common parameters:
     params = {}
@@ -443,41 +471,41 @@ def get_par(argv):
 
     # print script info
     set_verbosity(pars["verbose"])
-    utils.print_version(toolname, __revision__)
+    utils.print_version(__toolname__, __revision__)
 
     ## check and modify parameters
     ################################
 
     # files with information to reproject
     if params["evtfile"] == "":
-        error_out("Input event file must be specified.")
-    elif params["evtfile"].startswith("@"):
-        error_out("Input event stacks not supported.")
-    else:
-        #params["evtfile"] = stk.build(params["evtfile"])
-        params["infile_filter"] = fileio.get_filter(params["evtfile"])
-        params["evtfile"] = fileio.get_file(params["evtfile"])
+        raise ScriptError("Input event file must be specified.")
+    if params["evtfile"].startswith("@"):
+        raise ScriptError("Input event stacks not supported.")
+
+    #params["evtfile"] = stk.build(params["evtfile"])
+    params["infile_filter"] = fileio.get_filter(params["evtfile"])
+    params["evtfile"] = fileio.get_file(params["evtfile"])
 
     # output file name
     if params["outfile"] == "":
-        error_out("Please specify an output file name.")
+        raise ScriptError("Please specify an output file name.")
+
+    params["outdir"],outfile = utils.split_outroot(params["outfile"])
+
+    if params["outfile"].endswith("_"):
+        params["outfile"] = outfile
     else:
-        params["outdir"],outfile = utils.split_outroot(params["outfile"])
+        params["outfile"] = outfile.rstrip("_")
 
-        if params["outfile"].endswith("_"):
-            params["outfile"] = outfile
-        else:
-            params["outfile"] = outfile.rstrip("_")
-
-        # check if output directory is writable
-        fileio.validate_outdir(params["outdir"])
+    # check if output directory is writable
+    fileio.validate_outdir(params["outdir"])
 
     # aspect solution files, listed in quotes.
     if params["asol"] != "":
         if params["asol"].lower() == "none":
-            error_out(f"Aspect solutions are required to run {toolname}.")
-        else:
-            params["asol"] = ",".join(stk.build(params["asol"]))
+            raise ScriptError(f"Aspect solutions are required to run {__toolname__}.")
+
+        params["asol"] = ",".join(stk.build(params["asol"]))
     else:
         fobs = obsinfo.ObsInfo(params["evtfile"])
 
@@ -542,7 +570,8 @@ def get_par(argv):
     return params,pars
 
 
-def blanksky(infile,filters,asols,tmpdir,keywords,stowedbg,verbose,clobber):
+
+def blanksky(infile,filters,asols,tmpdir,keywords,stowedbg,verbose):
     """This routine will copy and tailor blank-sky maps to observations, but will leave
     reprojection to the observation as a separate step to avoid memory bandwidth limitations
     when trying to copy files in parallel.  Presume that infile has already been cleaned of flares"""
@@ -552,11 +581,10 @@ def blanksky(infile,filters,asols,tmpdir,keywords,stowedbg,verbose,clobber):
 
     ## create binned images from events files, if no image files are provided
     # obtain background for HRC-I observations.
-    if detector == "HRC" and keywords["DETNAM"] == "HRC-S":
-        error_out("There are no HRC-S blank-sky maps available in CalDB to tailor into a background map.")
-
-    elif detector == "HRC" and keywords["DETNAM"] == "HRC-I":
-        from ciao_contrib.proptools import dates
+    if detector == "HRC":
+        if keywords["DETNAM"] == "HRC-S":
+            raise ScriptError("There are no HRC-S blank-sky maps available in \
+CalDB to tailor into a background map.")
 
         v1("Creating HRC-I background files, if available.\n")
 
@@ -567,44 +595,53 @@ def blanksky(infile,filters,asols,tmpdir,keywords,stowedbg,verbose,clobber):
         hrc_earliest = dates("2000-01-01T00:00:00",fromcal="GREG",tocal="CHANDRA")
 
         if not caldb_blanksky("HRC"):
-            error_out("Blank-sky maps not available.  Please make sure that the CalDB blank-sky maps are installed.")
-        elif keywords["TSTART"] < hrc_earliest:
-            error_out(f"ObsID {obsid}: 2000-01-01 is the earliest observation date with valid HRC-I background files.")
-        else:
-            # determine background file to use
-            hrci_bkg = fluximage._find_blanksky_hrci_caldb(infile, verbose=verbose, tmpdir=tmpdir)
+            raise ScriptError("Blank-sky maps not available.  Please make sure that the \
+CalDB blank-sky maps are installed.")
 
-            v1(f"HRC-I background file {hrci_bkg} found.\n")
+        if keywords["TSTART"] < hrc_earliest:
+            raise ScriptError(f"ObsID {obsid}: 2000-01-01 is the earliest observation date \
+with valid HRC-I background files.")
 
-            if hrci_bkg == "":
-                error_out(f"There is no available blank-sky map for {infile}.")
-            else:
-                with suppress_stdout_stderr():
-                    return fluximage.blanksky_hrci(hrci_bkg, infile, tmpdir, obsid, verbose), [0]
+        # determine background file to use
+        hrci_bkg = fluximage._find_blanksky_hrci_caldb(infile, verbose=verbose, tmpdir=tmpdir)
+
+        v1(f"HRC-I background file {hrci_bkg} found.\n")
+
+        if hrci_bkg == "":
+            raise ScriptError(f"There is no available blank-sky map for {infile}.")
+
+        with suppress_stdout_stderr():
+            return fluximage.blanksky_hrci(hrci_bkg, infile, tmpdir, obsid, verbose), [0]
 
     else:
         ## produce ACIS blank-sky background map
+
+        dmcopy = make_tool("dmcopy")
+        dmmerge = make_tool("dmmerge")
+        dmcoords = make_tool("dmcoords")
+        dmhedit = make_tool("dmhedit")
+        dmkeypar = make_tool("dmkeypar")
+        acis_bkgrnd_lookup = make_tool("acis_bkgrnd_lookup")
 
         # grab unique CCDs for each observation, after filtering, if applied.  Otherwise, infile has been
         # stripped of filters earlier to prevent breaking due to tool syntax
         if filters == "":
             ccds = fileio.get_ccds(infile).tolist()
         else:
-            infile_filt = tempfile.NamedTemporaryFile(dir=tmpdir,suffix="_evtfilt")
+            with tempfile.NamedTemporaryFile(dir=tmpdir,suffix="_evtfilt") as infile_filt:
+                dmcopy.punlearn()
 
-            dmcopy.punlearn()
-            dmcopy.infile = infile+filters
-            dmcopy.outfile = infile_filt.name
-            dmcopy.clobber = True
-            dmcopy.verbose = "0"
-            dmcopy()
+                dmcopy.infile = f"{infile}{filters}"
+                dmcopy.outfile = infile_filt.name
+                dmcopy.clobber = True
+                dmcopy.verbose = "0"
+                dmcopy()
 
-            ccds = fileio.get_ccds(infile_filt.name).tolist()
-            infile_filt.close()
+                ccds = fileio.get_ccds(infile_filt.name).tolist()
 
         # check for CTI_APP keyword before running acis_bkgrnd_lookup
         if "CTI_APP" not in keywords.keys():
-            error_out(f"CTI_APP header keyword missing from {infile}. Please reprocess data with chandra_repro.")
+            raise ScriptError(f"CTI_APP header keyword missing from {infile}. Please reprocess data with chandra_repro.")
 
         ## do some case filtering to prevent complete breaking of script
         # There are no background files for:
@@ -613,7 +650,8 @@ def blanksky(infile,filters,asols,tmpdir,keywords,stowedbg,verbose,clobber):
         # *      CTI-corrected data on ACIS-9
         # *      ACIS-0 data, when ACIS-S is in the focal plane (a SIM_Z limit is exceeded)
         if stowedbg and not set([4,8,9]).isdisjoint(set(ccds)):
-            v1("ACIS-S0, -S4, and/or -S5 will be ignored, as no stowed background files are available for these chips.\n")
+            v1("ACIS-S0, -S4, and/or -S5 will be ignored, as no stowed background files are \
+available for these chips.\n")
 
             for ccd in [4,8,9]:
                 try:
@@ -656,7 +694,9 @@ def blanksky(infile,filters,asols,tmpdir,keywords,stowedbg,verbose,clobber):
 
             # check if aimpoints fall on ACIS-S chips
             if aimpoint not in [0,1,2,3]:
-                v1(f"Ignoring ACIS-I0, as no blank-sky map is available for this chips when aimpoint is on ACIS-{aimpoint}, due to exceeding of SIM-Z limit.\n")
+                v1(f"Ignoring ACIS-I0, as no blank-sky map is available for this chips when aimpoint \
+is on ACIS-{aimpoint}, due to exceeding of SIM-Z limit.\n")
+
                 ccds.remove(0)
 
         if stowedbg:
@@ -672,129 +712,135 @@ def blanksky(infile,filters,asols,tmpdir,keywords,stowedbg,verbose,clobber):
             acis_bkg = acis_bkgrnd_lookup.outfile
 
         if acis_bkg == "":
-            error_out(f"There is no available blank-sky map for {infile}.")
+            raise ScriptError(f"There is no available blank-sky map for {infile}.")
+
+        # and hunt down duplicate identifications, since
+        # there are also a few cases that result in identical lookup results:
+        #
+        # *     For the front-illuminated (FI) chips, there is no difference between:
+        #       o CTI_APP = PPPPPNPNPP
+        #       o CTI_APP = PPPPPBPBPP
+        #
+        # since the parallel CTI-correction is applied to all FI chips either way.
+        # *     For the back-illuminated (BI) chips, there is no difference between any of these:
+        #       o CTI_APP = NNNNNNNNNN
+        #       o CTI_APP = PPPPPNPNPP
+        #       o CTI_CORR = YES
+        #       o CTI_CORR = NO
+        #
+        # since no CTI correction is applied to BI chips for any of those configurations.
+
+        acis_bkg = utils.getUniqueSynset(acis_bkg.split(","))
+
+        # print list of blanksky files to be used
+        if len(acis_bkg) == 1:
+            suffix = ''
+        else:
+            suffix = 's'
+
+        v1(f"ACIS background file{suffix} {','.join(acis_bkg)} found.\n")
+
+        # make copy of background file to tailor
+        bkg_calib = tempfile.NamedTemporaryFile(dir=tmpdir)
+
+        if len(ccds) == 1:
+            shutil.copyfile(acis_bkg[0],bkg_calib.name)
 
         else:
-            # and hunt down duplicate identifications, since
-            # there are also a few cases that result in identical lookup results:
-            #
-            # *     For the front-illuminated (FI) chips, there is no difference between:
-            #       o CTI_APP = PPPPPNPNPP
-            #       o CTI_APP = PPPPPBPBPP
-            #
-            # since the parallel CTI-correction is applied to all FI chips either way.
-            # *     For the back-illuminated (BI) chips, there is no difference between any of these:
-            #       o CTI_APP = NNNNNNNNNN
-            #       o CTI_APP = PPPPPNPNPP
-            #       o CTI_CORR = YES
-            #       o CTI_CORR = NO
-            #
-            # since no CTI correction is applied to BI chips for any of those configurations.
+            # combine files
+            dmmerge.punlearn()
 
-            acis_bkg = utils.getUniqueSynset(acis_bkg.split(","))
+            dmmerge.infile = acis_bkg
+            dmmerge.outfile = bkg_calib.name
+            dmmerge.clobber = True
+            dmmerge.verbose = "0"
 
-            # print list of blanksky files to be used
-            if len(acis_bkg) == 1:
-                suffix = ''
-            else:
-                suffix = 's'
+            dmmerge()
 
-            v1(f"ACIS background file{suffix} {','.join(acis_bkg)} found.\n")
+        # spatially handle sub-array observations
+        if keywords["NROWS"] != 1024:
+            nrows = keywords["NROWS"]
+            firstrow = keywords["FIRSTROW"]
 
-            # make copy of background file to tailor
-            if len(ccds) == 1:
-                bkg_calib = tempfile.NamedTemporaryFile(dir=tmpdir)
-                shutil.copyfile(acis_bkg[0],bkg_calib.name)
+            bkg_subarray = tempfile.NamedTemporaryFile(suffix=".bkg",dir=tmpdir)
 
-            else:
-                bkg_calib = tempfile.NamedTemporaryFile(dir=tmpdir)
+            dmcopy.punlearn()
 
-                # combine files
-                dmmerge.punlearn()
+            dmcopy.infile = f"{bkg_calib.name}[chipy={firstrow}:{firstrow+nrows-1}]"
+            dmcopy.outfile = bkg_subarray.name
+            dmcopy.verbose = "0"
+            dmcopy.clobber = True
 
-                dmmerge.infile = acis_bkg
-                dmmerge.outfile = bkg_calib.name
-                dmmerge.clobber = True
-                dmmerge.verbose = "0"
+            dmcopy()
 
-                dmmerge()
+            bkg_calib.close()
 
-            # spatially handle sub-array observations
-            if keywords["NROWS"] != 1024:
-                nrows = keywords["NROWS"]
-                firstrow = keywords["FIRSTROW"]
-
-                bkg_subarray = tempfile.NamedTemporaryFile(suffix=".bkg",dir=tmpdir)
-
-                dmcopy.punlearn()
-
-                dmcopy.infile = f"{bkg_calib.name}[chipy={firstrow}:{firstrow+nrows-1}]"
-                dmcopy.outfile = bkg_subarray.name
-                dmcopy.verbose = "0"
-                dmcopy.clobber = True
-
-                dmcopy()
-
-                bkg_calib.close()
-
-                bkg_calib = bkg_subarray
-
-            # # apply new gain file, if necessary
-            # bkg_repro = tempfile.NamedTemporaryFile(dir=tmpdir)
-            # apply_gain(infile=bkg_calib.name,outfile=bkg_repro.name,kw=keywords,tmpdir=tmpdir,verbose=verbose)
-            # bkg_calib.close()
-
-            bkg_repro = bkg_calib # delete if apply_gain is implemented, uncomment above block
-
-            # add keywords as needed; as of CIAO 4.11, reproject_events
-            # handles teh _PNT and _AVG keywords.
-            for key in ["FIRSTROW", "NROWS"]:
-                dmkeypar.punlearn()
-                dmhedit.punlearn()
-
-                try:
-                    dmkeypar.infile = infile
-                    dmkeypar.keyword = key
-                    dmkeypar()
-
-                except IOError:
-                    raise IOError(f"{infile} missing the {key} header keyword.")
-
-                finally:
-                    dmhedit.infile = bkg_repro.name+"[EVENTS]"
-                    dmhedit.filelist = ""
-                    dmhedit.operation = "add"
-                    dmhedit.key = key
-                    dmhedit.value = dmkeypar.value
-
-                    dmhedit()
-
-            bkg = tempfile.NamedTemporaryFile(suffix=".bkg",dir=tmpdir)
-
-            # if datamode is VFAINT and ran a_p_e with check_vf_pha=yes,
-            # remove background events with non-0 status
-            if False not in (keywords["DATAMODE"] == "VFAINT",
-                             check_tool_par(evt=infile,tool="acis_process_events",
-                                            param="check_vf_pha")):
-
-                dmcopy.punlearn()
-
-                dmcopy.infile = f"{bkg_repro.name}[status=0]"
-                dmcopy.outfile = bkg.name
-                dmcopy.verbose = "0"
-                dmcopy.clobber = True
-
-                dmcopy()
-
-            else:
-                shutil.copyfile(bkg_repro.name,bkg.name)
-
-            bkg_repro.close()
-
-            return bkg,ccds
+            bkg_calib = bkg_subarray
 
 
-@handle_ciao_errors(toolname,__revision__)
+        # ### apply new gain file, if necessary ###
+        #
+        # bkg_repro = tempfile.NamedTemporaryFile(dir=tmpdir)
+        #
+        # apply_gain(infile=bkg_calib.name,outfile=bkg_repro.name,
+        #            kw=keywords,tmpdir=tmpdir,verbose=verbose)
+        #
+        # bkg_calib.close()
+        # bkg_calib = bkg_repro
+
+
+        # add keywords as needed; as of CIAO 4.11, reproject_events
+        # handles the _PNT and _AVG keywords.
+        for key in ["FIRSTROW", "NROWS"]:
+            dmkeypar.punlearn()
+            dmhedit.punlearn()
+
+            try:
+                dmkeypar.infile = infile
+                dmkeypar.keyword = key
+                dmkeypar()
+
+            except IOError as exc:
+                raise IOError(f"{infile} missing the {key} header keyword.") from exc
+
+            finally:
+                dmhedit.infile = f"{bkg_calib.name}[EVENTS]"
+                dmhedit.filelist = ""
+                dmhedit.operation = "add"
+                dmhedit.key = key
+                dmhedit.value = dmkeypar.value
+
+                dmhedit()
+
+        bkg = tempfile.NamedTemporaryFile(suffix=".bkg",dir=tmpdir)
+
+        # if datamode is VFAINT and ran a_p_e with check_vf_pha=yes,
+        # remove background events with non-0 status
+        if False not in (keywords["DATAMODE"] == "VFAINT",
+                         check_tool_par(evt=infile,tool="acis_process_events",
+                                        param="check_vf_pha")):
+        # in CIAO 4.16, replace with:
+        # if keywords["DATAMODE"] == "VFAINT" and keyword["CHKVFPHA"]:
+        # and can remove 'check_tool_par' function
+            dmcopy.punlearn()
+
+            dmcopy.infile = f"{bkg_calib.name}[status=0]"
+            dmcopy.outfile = bkg.name
+            dmcopy.verbose = "0"
+            dmcopy.clobber = True
+
+            dmcopy()
+
+        else:
+            shutil.copyfile(bkg_calib.name,bkg.name)
+
+        bkg_calib.close()
+
+        return bkg,ccds
+
+
+
+@handle_ciao_errors(__toolname__,__revision__)
 def doit():
 
     params,pars = get_par(sys.argv)
@@ -813,8 +859,11 @@ def doit():
     clobber = params["clobber"]
     verbose = params["verbose"]
 
-    kw = fileio.get_keys_from_file(evtfile)
+    kw = fileio.get_keys_from_file(f"{evtfile}[#row=0]")
     instrument = kw["INSTRUME"]
+
+    if clobber.lower() == "no" and os.path.isfile(f"{outdir}/{outfile}"):
+        raise IOError(f"clobber='no' and the file, {outdir}/{outfile}, already exists.")
 
     # # validate enband, but also modify the energy range if specified, since the validate_bands
     # # function requires a format of "elo:ehi:eff", even though effective energy is irrelevant
@@ -827,106 +876,117 @@ def doit():
 
     # check that there are high-energy counts in the input event file (w/filter),
     # will also use the filtered event file downstream to calculate scale factors for each chip
-    check_evt = tempfile.NamedTemporaryFile(dir=tmpdir)
 
-    dmcopy.punlearn()
-    dmcopy.infile = evtfile+filters
-    dmcopy.outfile = check_evt.name
-    dmcopy.clobber = True
-    dmcopy.verbose = "0"
-    dmcopy()
+    reproject_events = make_tool("reproject_events")
+    dmlist = make_tool("dmlist")
+    dmcopy = make_tool("dmcopy")
+    dmhedit = make_tool("dmhedit")
 
-    if method != "time":
-        if instrument == "ACIS":
-            if bkgparams.lower() == "default":
-                e_particle = "[energy=9000:12000]"
+    with new_pfiles_environment(ardlib=False), tempfile.NamedTemporaryFile(dir=tmpdir) as check_evt:
+
+        dmcopy.punlearn()
+        dmcopy.infile = f"{evtfile}{filters}"
+        dmcopy.outfile = check_evt.name
+        dmcopy.clobber = True
+        dmcopy.verbose = "0"
+        dmcopy()
+
+        if method != "time":
+            if instrument == "ACIS":
+                if bkgparams.lower() == "default":
+                    e_particle = "[energy=9000:12000]"
+                else:
+                    e_particle = bkgparams
             else:
-                e_particle = bkgparams
-        else:
-            if bkgparams.lower() == "default":
-                e_particle = "[pi=300:500]"
-            else:
-                e_particle = bkgparams
+                if bkgparams.lower() == "default":
+                    e_particle = "[pi=300:500]"
+                else:
+                    e_particle = bkgparams
 
-        dmlist.punlearn()
-        dmlist.infile = check_evt.name+e_particle
-        dmlist.opt = "counts"
+            dmlist.punlearn()
+            dmlist.infile = f"{check_evt.name}{e_particle}"
+            dmlist.opt = "counts"
 
-        check_counts = int(dmlist())
+            check_counts = int(dmlist())
 
-        if check_counts == 0:
-            raise IOError("The input event file has zero high-energy counts defined by the 'bkgparams' parameter to scale the particle background.")
+            if check_counts == 0:
+                raise IOError("The input event file has zero high-energy \
+counts defined by the 'bkgparams' parameter to scale the \
+particle background.")
 
-    # check that blanksky files are in CalDB
-    if not caldb_blanksky(instrument):
-        if instrument == "ACIS":
-            error_out("ACIS blanksky background files are not installed in the CalDB")
-        else:
-            error_out("HRC blanksky background files are not installed in the CalDB")
+        # check that blanksky files are in CalDB
+        if not caldb_blanksky(instrument):
+            if instrument == "ACIS":
+                raise ScriptError("ACIS blanksky background files are not installed in the CalDB")
 
-    # tailor raw CalDB blanksky files to match observation
-    bsky,ccds = blanksky(evtfile,filters,asol,tmpdir,kw,stowedbg,verbose,clobber)
+            raise ScriptError("HRC blanksky background files are not installed in the CalDB")
 
-    # reproject blank sky file to match observation coordinates
-    reproject_events.punlearn()
+        # tailor raw CalDB blanksky files to match observation
+        bsky,ccds = blanksky(evtfile,filters,asol,tmpdir,kw,stowedbg,verbose)
 
-    reproject_events.infile = bsky.name+filters#+enband
-    reproject_events.outfile = outdir+outfile
-    reproject_events.aspect = asol
-    reproject_events.match = evtfile
-    reproject_events.random = seed
-    reproject_events.verbose = verbose
-    reproject_events.clobber = clobber
+        # reproject blank sky file to match observation coordinates
+        reproject_events.punlearn()
 
-    reproject_events()
-    bsky.close()
+        reproject_events.infile = f"{bsky.name}{filters}" #{enband}"
+        reproject_events.outfile = f"{outdir}{outfile}"
+        reproject_events.aspect = asol
+        reproject_events.match = evtfile
+        reproject_events.random = seed
+        reproject_events.verbose = verbose
+        reproject_events.clobber = clobber
 
-    # calculate and write scale factors to header
-    dmhedit.punlearn()
+        reproject_events()
 
-    dmhedit.infile = outdir+outfile+"[EVENTS]"
-    dmhedit.filelist = ""
-    dmhedit.operation = "add"
+        bsky.close()
 
-    if "e_particle" in locals():
-        dmhedit.key = "BKGPARAM"
-        dmhedit.value = e_particle
+        # calculate and write scale factors to header
+        dmhedit.punlearn()
+
+        dmhedit.infile = f"{outdir}{outfile}[EVENTS]"
+        dmhedit.filelist = ""
+        dmhedit.operation = "add"
+
+        if "e_particle" in locals():
+            dmhedit.key = "BKGPARAM"
+            dmhedit.value = e_particle
+            dmhedit.datatype = "string"
+            dmhedit()
+
+        dmhedit.key = "BKGMETH"
+        dmhedit.value = method
         dmhedit.datatype = "string"
         dmhedit()
 
-    dmhedit.key = "BKGMETH"
-    dmhedit.value = method
-    dmhedit.datatype = "string"
-    dmhedit()
-
-    # calculate scaling factor, add as keyword
-    scale = []
-    for ccd in sorted(ccds):
-        if method == "particle":
-            scalefactor = e_norm(check_evt.name,outdir+outfile,ccd,e_particle,instrument)
-        else:
-            bkg_kw = fileio.get_keys_from_file(outdir+outfile)
-
-            if method == "time":
-                scalefactor = t_norm(check_evt.name,outdir+outfile,ccd,kw,bkg_kw)
+        # calculate scaling factor, add as keyword
+        scale = []
+        for ccd in sorted(ccds):
+            if method == "particle":
+                scalefactor = e_norm(check_evt.name,f"{outdir}{outfile}",
+                                     ccd,e_particle,instrument)
             else:
-                scalefactor = he_rate_norm(check_evt.name,outdir+outfile,ccd,e_particle,instrument,kw,bkg_kw)
+                bkg_kw = fileio.get_keys_from_file(f"{outdir}{outfile}")
 
-        if instrument == "HRC":
-            dmhedit.key = "BKGSCALE"
-        else:
-            dmhedit.key = f"BKGSCAL{ccd}"
+                if method == "time":
+                    scalefactor = t_norm(ccd,kw,bkg_kw)
+                else:
+                    scalefactor = he_rate_norm(check_evt.name,f"{outdir}{outfile}",
+                                               ccd,e_particle,instrument,kw,bkg_kw)
 
-        dmhedit.value = scalefactor
-        dmhedit.datatype = "float"
-        dmhedit()
+            if instrument == "HRC":
+                dmhedit.key = "BKGSCALE"
+            else:
+                dmhedit.key = f"BKGSCAL{ccd}"
 
-        scale.append((ccd,round(scalefactor,8)))
+            dmhedit.value = scalefactor
+            dmhedit.datatype = "float"
+            dmhedit()
 
-    check_evt.close()
+            scale.append((ccd,round(scalefactor,8)))
+
 
     if instrument == "HRC":
-        v1(f"Calculated scale factor for 'weight_method={method}': {scalefactor}, written to the 'BKGSCALE' header keyword.")
+        v1(f"Calculated scale factor for 'weight_method={method}': {scalefactor}, \
+written to the 'BKGSCALE' header keyword.")
 
     else:
         if len(ccds) == 1:
@@ -937,7 +997,8 @@ def doit():
         for n in scale:
             v1(f"    ACIS-{n[0]}: {n[1]} written to the 'BKGSCAL{n[0]}' header keyword.")
 
-    add_tool_history(outdir+outfile,toolname,pars)
+    add_tool_history(f"{outdir}{outfile}",__toolname__,pars)
+
 
 
 if __name__  == "__main__":

--- a/bin/blanksky_image
+++ b/bin/blanksky_image
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-
 #
-# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2017, 2019
+# Copyright (C) 2016-2023
 #           Smithsonian Astrophysical Observatory
 #
 #
@@ -22,36 +21,40 @@
 # 02110-1301 USA.
 #
 
-toolname = "blanksky_image"
-__revision__  = "13 November 2019"
+__toolname__ = "blanksky_image"
+__revision__  = "31 October 2023"
 
 
-import os, sys, paramio, tempfile, numpy
+import os
+import sys
+import tempfile
+import numpy
 
+import paramio
 import pycrates as pcr
 
-from crates_contrib.utils import *
 from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
 from ciao_contrib.param_wrapper import open_param_file
 
 from ciao_contrib._tools import utils, fileio
+from ciao_contrib.runtool import make_tool, add_tool_history, new_pfiles_environment
 
-from ciao_contrib.runtool import dmcopy, dmimgcalc, add_tool_history, get_sky_limits
+from ciao_contrib.parallel_wrapper import parallel_pool_futures
+#from sherpa.utils import parallel_map
 
-from sherpa.utils import parallel_map
-from ciao_contrib.parallel_wrapper import parallel_pool
-from ciao_contrib.runtool import new_pfiles_environment
+#############################################################################
+#############################################################################
 
 # Set up the logging/verbose code
-initialize_logger(toolname)
+initialize_logger(__toolname__)
 
 # Use v<n> to display messages at the given verbose level.
-v0 = make_verbose_level(toolname, 0)
-v1 = make_verbose_level(toolname, 1)
-v2 = make_verbose_level(toolname, 2)
-v3 = make_verbose_level(toolname, 3)
-v4 = make_verbose_level(toolname, 4)
-v5 = make_verbose_level(toolname, 5)
+v0 = make_verbose_level(__toolname__, 0)
+v1 = make_verbose_level(__toolname__, 1)
+v2 = make_verbose_level(__toolname__, 2)
+v3 = make_verbose_level(__toolname__, 3)
+v4 = make_verbose_level(__toolname__, 4)
+v5 = make_verbose_level(__toolname__, 5)
 
 
 class ScriptError(RuntimeError):
@@ -62,88 +65,57 @@ class ScriptError(RuntimeError):
     """
     pass
 
-#########################################################################################
-#
-# suppress warnings printed to screen from fluximage.blanksky_hrci when probing for
-# HRC-I background files
-# http://stackoverflow.com/questions/11130156/suppress-stdout-stderr-print-from-python-functions
-#
-#########################################################################################
-class suppress_stdout_stderr(object):
-    '''
-    A context manager for doing a "deep suppression" of stdout and stderr in
-    Python, i.e. will suppress all print, even if the print originates in a
-    compiled C/Fortran sub-function.
-       This will not suppress raised exceptions, since exceptions are printed
-    to stderr just before a script exits, and after the context manager has
-    exited (at least, I think that is why it lets exceptions through).
-
-    '''
-    def __init__(self):
-        # Open a pair of null files
-        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
-        # Save the actual stdout (1) and stderr (2) file descriptors.
-        self.save_fds = (os.dup(1), os.dup(2))
-
-    def __enter__(self):
-        # Assign the null pointers to stdout and stderr.
-        os.dup2(self.null_fds[0],1)
-        os.dup2(self.null_fds[1],2)
-
-    def __exit__(self, *_):
-        # Re-assign the real stdout/stderr back to (1) and (2)
-        os.dup2(self.save_fds[0],1)
-        os.dup2(self.save_fds[1],2)
-        # Close the null files
-        os.close(self.null_fds[0])
-        os.close(self.null_fds[1])
-
-
-def error_out(msg):
-    "Throw a ScriptError with msg as the message."
-    raise ScriptError(msg)
-
 
 ###############################################
-# def combine_chips((bkgfile,chip,component_info,bkg_kw,bkg,dettype,dmfilter,xylimits,crtype))
-def combine_chips(args): # P3
-    with new_pfiles_environment(ardlib=True):
 
-        (bkgfile,chip,component_info,bkg_kw,bkg,dettype,dmfilter,xylimits,crtype,verbose) = args # P3
 
-        ind = component_info[1].index(chip)
-        elo = component_info[2][ind]
-        ehi = component_info[3][ind]
+def combine_chips(args):
+    """
+    stack the scaled and energy filtered chip images
+    """
 
-        if dettype == "ccd_id":
-            scale = bkg_kw["BKGSCAL{}".format(chip)]
-            energy = "energy={0}:{1}".format(elo,ehi)
-        else:
-            scale = bkg_kw["BKGSCALE"]
-            energy = "pi={0}:{1}".format(elo,ehi)
+    bkgfile,chip,component_info,bkg_kw,bkg,dettype,dmfilter,xylimits,crtype,verbose = args
+
+    ind = component_info[1].index(chip)
+    elo = component_info[2][ind]
+    ehi = component_info[3][ind]
+
+    dmimgcalc = make_tool("dmimgcalc")
+
+    if dettype == "ccd_id":
+        scale = bkg_kw[f"BKGSCAL{chip}"]
+        energy = f"energy={elo}:{ehi}"
+    else:
+        scale = bkg_kw["BKGSCALE"]
+        energy = f"pi={elo}:{ehi}"
+
+    with new_pfiles_environment(ardlib=False,copyuser=False):
 
         dmimgcalc.punlearn()
-        dmimgcalc.infile = "{0}[{1}={2},{3}]{4}[bin {5}][opt type={6}]".format(bkg,dettype,chip,energy,dmfilter,xylimits,crtype)
+        dmimgcalc.infile = f"{bkg}[{dettype}={chip},{energy}]{dmfilter}[bin {xylimits}][opt type={crtype}]"
         dmimgcalc.outfile = bkgfile
-        dmimgcalc.operation = "imgout={}*img1".format(scale)
-        dmimgcalc.clobber = "yes"
+        dmimgcalc.operation = f"imgout={scale}*img1"
+        dmimgcalc.clobber = True
         dmimgcalc.verbose = verbose
 
         dmimgcalc()
 
-# def parallel_map_combine_chips(args):
-#     parallel_map(combine_chips,args)
-###############################################
 
 
 def bkg_img(imgfile,bkg,outfile,dmfilter,dettype,chips,tmpdir,verbose):
+    """
+    return XY-grid; produce scaled image of the background file
+    """
 
-    get_sky_limits.punlearn()
-    get_sky_limits.image = imgfile
-    get_sky_limits.verbose = "0"
-    get_sky_limits()
+    dmimgcalc = make_tool("dmimgcalc")
+    gsl = make_tool("get_sky_limits")
 
-    xylimits = get_sky_limits.dmfilter
+    gsl.punlearn()
+    gsl.image = imgfile
+    gsl.verbose = "0"
+    gsl()
+
+    xylimits = gsl.dmfilter
 
     bkg_kw = fileio.get_keys_from_file(bkg)
     bkgmethod = bkg_kw["BKGMETH"].lower()
@@ -171,7 +143,10 @@ def bkg_img(imgfile,bkg,outfile,dmfilter,dettype,chips,tmpdir,verbose):
 
     for i in range(len(chips)):
         try:
-            component_info.append([i+1,cr.get_subspace_data(i+1,dettype).range_min,cr.get_subspace_data(i+1,subspace_arg).range_min[0],cr.get_subspace_data(i+1,subspace_arg).range_max[0]])
+            component_info.append([i+1,
+                                   cr.get_subspace_data(i+1,dettype).range_min,
+                                   cr.get_subspace_data(i+1,subspace_arg).range_min[0],
+                                   cr.get_subspace_data(i+1,subspace_arg).range_max[0]])
 
         except IndexError:
             break
@@ -179,16 +154,7 @@ def bkg_img(imgfile,bkg,outfile,dmfilter,dettype,chips,tmpdir,verbose):
     # restructure list to remove lists; necessary for subspace components with
     # more than one chip listed
     component_info = [[n[0],chip,n[2],n[3]] for n in component_info for chip in n[1]]
-
-    ### P3
-    try:
-        from importlib import abc
-        component_info = list(zip(*component_info)) # the * in the zip takes the transpose
-
-    except ImportError:
-        #from importlib2 import abc
-        component_info = zip(*component_info) # the * in the zip takes the transpose
-    ### P3
+    component_info = list(zip(*component_info)) # the * in the zip takes the transpose
 
     # get image data type to set appropriate image type
     crtype = cr.get_image()._values.dtype
@@ -209,21 +175,35 @@ def bkg_img(imgfile,bkg,outfile,dmfilter,dettype,chips,tmpdir,verbose):
     # scale each chip before mosaicing them using the BKGSCALn keywords
     # in the background event file
     bkg_scaled = []
-    dmimgcalc_op = "+".join(["img{}".format(n+1) for n in range(len(chips))])
+
+    dmimgcalc_op = "+".join([f"img{n+1}" for n in range(len(chips))])
+
+    outname = f"{outfile}{bkgmethod}_bgnd.img"
 
     try:
-        bkg_scaled = [(tempfile.NamedTemporaryFile(suffix=".bkg{}".format(chip),dir=tmpdir),chip) for chip in chips]
+        bkg_scaled = [(tempfile.NamedTemporaryFile(suffix=f".bkg{chip}",dir=tmpdir),
+                       chip)
+                      for chip in chips]
 
-        args = [(bkg_scaled[i][0].name,bkg_scaled[i][1],component_info,bkg_kw,bkg,dettype,dmfilter,xylimits,crtype,verbose) for i in range(len(bkg_scaled))]
+        args = [(bkg_scaled[i][0].name,
+                 bkg_scaled[i][1],
+                 component_info,
+                 bkg_kw,
+                 bkg,
+                 dettype,
+                 dmfilter,
+                 xylimits,
+                 crtype,
+                 verbose) for i in range(len(bkg_scaled))]
 
-        parallel_map(combine_chips,args)
-        #parallel_pool(combine_chips,args)
+        #parallel_map(combine_chips,args)
+        parallel_pool_futures(combine_chips,args)
 
         dmimgcalc.punlearn()
         dmimgcalc.infile = [bg[0].name for bg in bkg_scaled]
-        dmimgcalc.outfile = "{0}{1}_bgnd.img".format(outfile,bkgmethod)
-        dmimgcalc.operation = "imgout={}".format(dmimgcalc_op)
-        dmimgcalc.clobber = "yes"
+        dmimgcalc.outfile = outname
+        dmimgcalc.operation = f"imgout={dmimgcalc_op}"
+        dmimgcalc.clobber = True
         dmimgcalc.verbose = verbose
 
         dmimgcalc()
@@ -232,13 +212,14 @@ def bkg_img(imgfile,bkg,outfile,dmfilter,dettype,chips,tmpdir,verbose):
         for fn in bkg_scaled:
             fn[0].close()
 
-    return xylimits,"{0}{1}_bgnd.img".format(outfile,bkgmethod),bkgmethod
+    return xylimits,outname,bkgmethod
+
 
 
 def get_par(argv):
     """ Get data_products parameters from parameter file """
 
-    pfile = open_param_file(argv,toolname=toolname)["fp"]
+    pfile = open_param_file(argv,toolname=__toolname__)["fp"]
 
     # Common parameters:
     params = {}
@@ -247,36 +228,36 @@ def get_par(argv):
     # input blanksky background event file
     pars["bkgfile"] = params["bkgfile"] = paramio.pgetstr(pfile,"bkgfile")
     if params["bkgfile"] == "":
-        error_out("Input background event file must be specified.")
-    elif params["bkgfile"].startswith("@"):
-        error_out("Input event stacks not supported.")
-    else:
-        params["infile_filter"] = fileio.get_filter(params["bkgfile"])
-        params["bkgfile"] = fileio.get_file(params["bkgfile"])
+        raise ScriptError("Input background event file must be specified.")
+    if params["bkgfile"].startswith("@"):
+        raise ScriptError("Input event stacks not supported.")
+
+    params["infile_filter"] = fileio.get_filter(params["bkgfile"])
+    params["bkgfile"] = fileio.get_file(params["bkgfile"])
 
     # output file name
     pars["outroot"] = params["outroot"] = paramio.pgetstr(pfile,"outroot")
     if params["outroot"] == "":
-        error_out("Please specify an output file name.")
+        raise ScriptError("Please specify an output file name.")
+
+    params["outdir"],outfile = utils.split_outroot(params["outroot"])
+
+    if outfile.endswith("_"):
+        params["outroot"] = outfile
     else:
-        params["outdir"],outfile = utils.split_outroot(params["outroot"])
+        params["outroot"] = outfile.rstrip("_")
 
-        if outfile.endswith("_"):
-            params["outroot"] = outfile
-        else:
-            params["outroot"] = outfile.rstrip("_")
-
-        # check if output directory is writable
-        fileio.validate_outdir(params["outdir"])
+    # check if output directory is writable
+    fileio.validate_outdir(params["outdir"])
 
     # reference image file to get xygrid and binning
     pars["imgfile"] = params["imgfile"] = paramio.pgetstr(pfile,"imgfile")
     if params["imgfile"] == "":
-        error_out("Reference image file must be specified.")
-    elif params["imgfile"].startswith("@"):
-        error_out("Input image file stacks not supported.")
-    else:
-        params["imgfile"] = fileio.get_file(params["imgfile"])
+        raise ScriptError("Reference image file must be specified.")
+    if params["imgfile"].startswith("@"):
+        raise ScriptError("Input image file stacks not supported.")
+
+    params["imgfile"] = fileio.get_file(params["imgfile"])
 
     # set clobber of files
     pars["tmpdir"] = params["tmpdir"] = paramio.pgetstr(pfile,"tmpdir")
@@ -286,26 +267,31 @@ def get_par(argv):
 
     ## error out if there are spaces in absolute paths of the various parameters
     if " " in os.path.abspath(pars["bkgfile"]):
-        raise IOError("The absolute path for the bkgfile, '{}', cannot contain any spaces".format(os.path.abspath(pars["bkgfile"])))
+        raise IOError(f"The absolute path for the bkgfile, '{os.path.abspath(pars['bkgfile'])}', \
+cannot contain any spaces")
 
     if " " in os.path.abspath(pars["outroot"]):
-        raise IOError("The absolute path for the output file, '{}', cannot contain any spaces".format(os.path.abspath(pars["outroot"])))
+        raise IOError(f"The absolute path for the output file, '{os.path.abspath(pars['outroot'])}', \
+cannot contain any spaces")
 
     if " " in os.path.abspath(params["imgfile"]):
-        raise IOError("The absolute path for the output file, '{}', cannot contain any spaces".format(os.path.abspath(pars["imgfile"])))
+        raise IOError(f"The absolute path for the output file, '{os.path.abspath(pars['imgfile'])}', \
+cannot contain any spaces")
 
     # close parameters block after validation
     paramio.paramclose(pfile)
+
     return params,pars
 
 
-@handle_ciao_errors(toolname,__revision__)
+
+@handle_ciao_errors(__toolname__,__revision__)
 def doit():
 
     params,pars = get_par(sys.argv)
 
     set_verbosity(params["verbose"])
-    utils.print_version(toolname, __revision__)
+    utils.print_version(__toolname__, __revision__)
 
     bkgfile = params["bkgfile"]
     filters = params["infile_filter"]
@@ -333,11 +319,15 @@ def doit():
                                         filters,det,chips,tmpdir,verbose)
 
     # create ACIS background subtracted image
+    outname = f"{outdir}{outroot}{bkgmethod}_bkgsub.img"
+
+    dmimgcalc = make_tool("dmimgcalc")
+
     dmimgcalc.punlearn()
 
     dmimgcalc.infile = imgfile
     dmimgcalc.infile2 = bkgimg
-    dmimgcalc.outfile = "{0}{1}{2}_bkgsub.img".format(outdir,outroot,bkgmethod)
+    dmimgcalc.outfile = outname
     dmimgcalc.operation = "sub"
     dmimgcalc.weight = "1"
     dmimgcalc.weight2 = "1"
@@ -346,8 +336,10 @@ def doit():
 
     dmimgcalc()
 
-    add_tool_history(bkgimg,toolname,pars)
-    add_tool_history("{0}{1}{2}_bkgsub.img".format(outdir,outroot,bkgmethod),toolname,pars)
+    add_tool_history(bkgimg,__toolname__,pars)
+    add_tool_history(outname,__toolname__,pars)
+
+
 
 if __name__  == "__main__":
     doit()

--- a/bin/blanksky_sample
+++ b/bin/blanksky_sample
@@ -23,7 +23,7 @@
 #
 
 __toolname__ = "blanksky_sample"
-__revision__  = "31 October 2023"
+__revision__  = "03 November 2023"
 
 import os
 import sys
@@ -677,7 +677,8 @@ def doit():
 
     dmcopy = make_tool("dmcopy")
     dmmerge = make_tool("dmmerge")
-
+    dmhedit = make_tool("dmhedit")
+    
     ############
     with new_pfiles_environment(ardlib=False), \
          tempfile.NamedTemporaryFile(dir=tmpdir) as tmpin, \
@@ -826,6 +827,25 @@ def doit():
 
                 dmmerge()
 
+                # undo 'merged' keywords in resulting product
+                dmhedit.punlearn()
+                dmhedit.infile = f"{psf_bkg_outdir}{psf_bkg_out}"
+                dmhedit.operation = "add"
+                dmhedit.verbose = 0
+
+                for tkey in ["DATACLAS","OBSERVER","TITLE","OBS_ID",
+                             "SEQ_NUM","DETNAM","OBJECT","DATAMODE",
+                             "RA_TARG","DEC_TARG",
+                             "RA_PNT","DEC_PNT","ROLL_PNT",
+                             "RA_NOM","DEC_NOM","ROLL_NOM"]:
+                    dmhedit.key = tkey
+                    dmhedit.value = kw_psf[tkey]
+                    dmhedit()
+
+                dmhedit.key = "ASPTYPE"
+                dmhedit.op = "delete"
+                dmhedit()
+                    
             try:
                 add_tool_history(f"{psf_bkg_outdir}{psf_bkg_out}", __toolname__, pars)
             except OSError:

--- a/bin/blanksky_sample
+++ b/bin/blanksky_sample
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010-2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021
+# Copyright (C) 2018-2023
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -22,39 +22,41 @@
 # 02110-1301 USA.
 #
 
-toolname = "blanksky_sample"
-__revision__  = "30 July 2021"
+__toolname__ = "blanksky_sample"
+__revision__  = "31 October 2023"
 
-import os, sys, paramio, tempfile, numpy
+import os
+import sys
+import tempfile
 
+import paramio
 import stk
 import pycrates as pcr
+
+from ciao_contrib._tools import fileio, utils
 
 from ciao_contrib.param_wrapper import open_param_file
 from ciao_contrib.logger_wrapper import initialize_logger, make_verbose_level, set_verbosity, handle_ciao_errors
 
-from ciao_contrib._tools import fileio, utils
+from ciao_contrib.runtool import make_tool, new_pfiles_environment, add_tool_history
 
-from ciao_contrib.runtool import dmcopy, dmhedit, dmlist, dmmerge, dmsort, dmtcalc, reproject_events, add_tool_history, dmhistory
-
+from ciao_contrib.parallel_wrapper import parallel_pool_futures
 from sherpa.utils import parallel_map
-from ciao_contrib.parallel_wrapper import parallel_pool
 from multiprocessing import cpu_count
-from ciao_contrib.runtool import new_pfiles_environment
 
 #############################################################################
 #############################################################################
 
 # Set up the logging/verbose code
-initialize_logger(toolname)
+initialize_logger(__toolname__)
 
 # Use v<n> to display messages at the given verbose level.
-v0 = make_verbose_level(toolname, 0)
-v1 = make_verbose_level(toolname, 1)
-v2 = make_verbose_level(toolname, 2)
-v3 = make_verbose_level(toolname, 3)
-v4 = make_verbose_level(toolname, 4)
-v5 = make_verbose_level(toolname, 5)
+v0 = make_verbose_level(__toolname__, 0)
+v1 = make_verbose_level(__toolname__, 1)
+v2 = make_verbose_level(__toolname__, 2)
+v3 = make_verbose_level(__toolname__, 3)
+v4 = make_verbose_level(__toolname__, 4)
+v5 = make_verbose_level(__toolname__, 5)
 
 
 class ScriptError(RuntimeError):
@@ -66,14 +68,12 @@ class ScriptError(RuntimeError):
     pass
 
 
-def error_out(msg):
-    "Throw a ScriptError with msg as the message."
-    raise ScriptError(msg)
+###############################################
 
 
 def get_par(argv):
     """ Get data_products parameters from parameter file """
-    pfile = open_param_file(argv,toolname=toolname)["fp"]
+    pfile = open_param_file(argv,toolname=__toolname__)["fp"]
 
     # Common parameters:
     params = {}
@@ -100,67 +100,74 @@ def get_par(argv):
 
     ## error out if there are spaces in absolute paths of various parameters
     if " " in os.path.abspath(params["infile"]):
-        raise IOError("The absolute path for the source events file, '{}', cannot contain any spaces".format(os.path.abspath(params["infile"])))
+        raise IOError(f"The absolute path for the source events file, \
+'{os.path.abspath(params['infile'])}', cannot contain any spaces")
 
     if " " in os.path.abspath(params["bkgfile"]):
-        raise IOError("The absolute path for the blanksky background file, '{}', cannot contain any spaces".format(os.path.abspath(params["bkgfile"])))
+        raise IOError(f"The absolute path for the blanksky background file, \
+'{os.path.abspath(params['bkgfile'])}', cannot contain any spaces")
 
     if " " in os.path.abspath(params["bkgout"]):
-        raise IOError("The absolute path for the sampled background output file, '{}', cannot contain any spaces".format(os.path.abspath(params["bkgout"])))
+        raise IOError(f"The absolute path for the sampled background output file, \
+'{os.path.abspath(params['bkgout'])}', cannot contain any spaces")
 
     if " " in os.path.abspath(params["psf_bkg_out"]):
-        raise IOError("The absolute path for the PSF+background output file, '{}', cannot contain any spaces".format(os.path.abspath(params["psf_bkg_out"])))
+        raise IOError(f"The absolute path for the PSF+background output file, \
+'{os.path.abspath(params['psf_bkg_out'])}', cannot contain any spaces")
 
     for asol in params["asol"]:
         if " " in os.path.abspath(asol):
-            raise IOError("The absolute path for the asol file, '{}', cannot contain any spaces".format(os.path.abspath(asol)))
+            raise IOError(f"The absolute path for the asol file, '{os.path.abspath(asol)}', \
+cannot contain any spaces")
 
     if " " in os.path.abspath(params["regionfile"]):
-        raise IOError("The absolute path for the region file, '{}', cannot contain any spaces".format(os.path.abspath(params["regionfile"])))
+        raise IOError(f"The absolute path for the region file, \
+'{os.path.abspath(params['regionfile'])}', cannot contain any spaces")
 
     if " " in os.path.abspath(params["fill_out"]):
-        raise IOError("The absolute path for the events substituted output file, '{}', cannot contain any spaces".format(os.path.abspath(params["fill_out"])))
+        raise IOError(f"The absolute path for the events substituted output file, \
+'{os.path.abspath(params['fill_out'])}', cannot contain any spaces")
 
     # check if produced "dmfilth"ed events file will be made
-    if params["regionfile"] != "":
-        if params["fill_out"] == "":
-            error_out("input 'regionfile' specified, an output 'fill_out' file must be specified")
+    if params["regionfile"] != "" and params["fill_out"] == "":
+        raise ScriptError("input 'regionfile' specified, an output 'fill_out' \
+file must be specified")
 
-    else:
-        if params["fill_out"] != "":
-            error_out("'fill_out' output file specified, an input 'regionfile' must also be specified")
+    if params["regionfile"] == "" and params["fill_out"] != "":
+        raise ScriptError("'fill_out' output file specified, an input 'regionfile' \
+must also be specified")
 
     # input PSF file
     if params["infile"] == "":
-        error_out("Input events file must be specified.")
-    elif params["infile"].startswith("@"):
-        error_out("'infile' does not support stacks.")
-    else:
-        params["infile_filter"] = fileio.get_filter(params["infile"])
-        params["infile"] = fileio.get_file(params["infile"])
+        raise ScriptError("Input events file must be specified.")
+    if params["infile"].startswith("@"):
+        raise ScriptError("'infile' does not support stacks.")
+
+    params["infile_filter"] = fileio.get_filter(params["infile"])
+    params["infile"] = fileio.get_file(params["infile"])
 
     # input blanksky background file
     if params["bkgfile"] == "":
-        error_out("Input blanksky background file must be specified.")
-    elif params["bkgfile"].startswith("@"):
-        error_out("Input blanksky background stacks not supported.")
-    else:
-        params["bkgfile_filter"] = fileio.get_filter(params["bkgfile"])
-        params["bkgfile"] = fileio.get_file(params["bkgfile"])
+        raise ScriptError("Input blanksky background file must be specified.")
+    if params["bkgfile"].startswith("@"):
+        raise ScriptError("Input blanksky background stacks not supported.")
+
+    params["bkgfile_filter"] = fileio.get_filter(params["bkgfile"])
+    params["bkgfile"] = fileio.get_file(params["bkgfile"])
 
     # output blanksky sampled file name
     if params["bkgout"] == "":
-        error_out("Please specify an output background file name.")
+        raise ScriptError("Please specify an output background file name.")
+
+    params["bkgoutdir"],bkgoutfile = utils.split_outroot(params["bkgout"])
+
+    if params["bkgout"].endswith("_"):
+        params["bkgout"] = bkgoutfile
     else:
-        params["bkgoutdir"],bkgoutfile = utils.split_outroot(params["bkgout"])
+        params["bkgout"] = bkgoutfile.rstrip("_")
 
-        if params["bkgout"].endswith("_"):
-            params["bkgout"] = bkgoutfile
-        else:
-            params["bkgout"] = bkgoutfile.rstrip("_")
-
-        # check if output directory is writable
-        fileio.validate_outdir(params["bkgoutdir"])
+    # check if output directory is writable
+    fileio.validate_outdir(params["bkgoutdir"])
 
     # output PSF+bkg file name
     if params["psf_bkg_out"] != "":
@@ -199,9 +206,10 @@ def get_par(argv):
     # close parameters block after validation
     paramio.paramclose(pfile)
 
-    v3("  Parameters: {0}".format(params))
+    v3(f"  Parameters: {params}")
 
     return params,pars
+
 
 
 def _get_nevt(fn):
@@ -211,27 +219,28 @@ def _get_nevt(fn):
 
     nevt = cr.get_nrows()
 
-    cr.__del__()
+    del cr
 
     return nevt
+
 
 
 def _cols2int4(fn,tmpdir):
     """Convert the PI and PHA columns in the blanksky file from Int2 to Int4 data types"""
 
+    dmcopy = make_tool("dmcopy")
+    dmtcalc = make_tool("dmtcalc")
+
     # check that column datatype
-    cr = pcr.read_file("{}[cols pi,pha][#row=1]".format(fn))
+    cr = pcr.read_file(f"{fn}[cols pi,pha][#row=0]")
 
     pi_type = cr.get_column("pi").values.dtype.name
     pha_type = cr.get_column("pha").values.dtype.name
 
-    cr.__del__()
+    del cr
 
     if False in [pi_type=="int64",pha_type=="int64"]:
         v2("Converting PI and PHA column integer type for compatibility...")
-
-        tmp1 = tempfile.NamedTemporaryFile(dir=tmpdir)
-        tmp2 = tempfile.NamedTemporaryFile(dir=tmpdir)
 
         if [True,True] == [pi_type!="int64",pha_type!="int64"]:
             convert_col = "tmppha=(long)pha,tmppi=(long)pi"
@@ -250,216 +259,175 @@ def _cols2int4(fn,tmpdir):
                 col_replace = "[cols -pha]"
                 tmpcol_del = "[cols -tmppha]"
 
-        dmtcalc.punlearn()
-        dmtcalc.infile = fn
-        dmtcalc.outfile = tmp1.name
-        dmtcalc.expression = convert_col
-        dmtcalc.verbose = "0"
-        dmtcalc.clobber= "yes"
-        dmtcalc()
+        with tempfile.NamedTemporaryFile(dir=tmpdir) as tmp1, tempfile.NamedTemporaryFile(dir=tmpdir) as tmp2:
+            dmtcalc.punlearn()
+            dmtcalc.infile = fn
+            dmtcalc.outfile = tmp1.name
+            dmtcalc.expression = convert_col
+            dmtcalc.verbose = 0
+            dmtcalc.clobber= True
+            dmtcalc()
 
-        dmtcalc.punlearn()
-        dmtcalc.infile = "{0}{1}".format(tmp1.name,col_replace)
-        dmtcalc.outfile = tmp2.name
-        dmtcalc.expression = tmpcol
-        dmtcalc.verbose = "0"
-        dmtcalc.clobber= "yes"
-        dmtcalc()
+            dmtcalc.punlearn()
+            dmtcalc.infile = f"{tmp1.name}{col_replace}"
+            dmtcalc.outfile = tmp2.name
+            dmtcalc.expression = tmpcol
+            dmtcalc.verbose = 0
+            dmtcalc.clobber= True
+            dmtcalc()
 
-        tmp1.close()
+            dmcopy.punlearn()
+            dmcopy.infile = f"{tmp2.name}{tmpcol_del}"
+            dmcopy.outfile = fn
+            dmcopy.verbose = 0
+            dmcopy.clobber = True
+            dmcopy()
 
-        dmcopy.punlearn()
-        dmcopy.infile = "{0}{1}".format(tmp2.name,tmpcol_del)
-        dmcopy.outfile = fn
-        dmcopy.verbose = "0"
-        dmcopy.clobber = "yes"
-        dmcopy()
-
-        tmp2.close()
 
 
 def _convert_ppr_cols(infile,outfile,instrument,tmpdir):
-    tmp1 = tempfile.NamedTemporaryFile(dir=tmpdir)
-    tmp2 = tempfile.NamedTemporaryFile(dir=tmpdir)
+    dmcopy = make_tool("dmcopy")
+    dmtcalc = make_tool("dmtcalc")
+    dmhedit = make_tool("dmhedit")
 
-    # copy the DETPOS column to a new DET column, for merging purposes
-    dmtcalc.punlearn()
-    dmtcalc.infile = infile
-    dmtcalc.outfile = tmp1.name
-    dmtcalc.expression = "tmpx=(float)x,tmpy=(float)y,tmpdetx=(float)detx,tmpdety=(float)dety,tmpchipx=(short)chipx,tmpchipy=(short)chipy"
-    dmtcalc.verbose = "0"
-    dmtcalc.clobber= "yes"
-    dmtcalc()
+    with tempfile.NamedTemporaryFile(dir=tmpdir) as tmp1, \
+         tempfile.NamedTemporaryFile(dir=tmpdir) as tmp2:
 
-    dmtcalc.punlearn()
-    dmtcalc.infile = "{}[cols -sky,-chip,-detpos]".format(tmp1.name)
-    dmtcalc.outfile = tmp2.name
-    dmtcalc.expression = "x=tmpx,y=tmpy,detx=tmpdetx,dety=tmpdety,chipx=tmpchipx,chipy=tmpchipy"
-    dmtcalc.verbose = "0"
-    dmtcalc.clobber= "yes"
-    dmtcalc()
-
-    dmhedit.punlearn()
-    dmhedit.infile = tmp2.name
-    dmhedit.operation = "add"
-    dmhedit.key = "MTYPE1"
-    dmhedit.value = "chip"
-    dmhedit.verbose = "0"
-    dmhedit()
-
-    dmhedit.punlearn()
-    dmhedit.infile = tmp2.name
-    dmhedit.operation = "add"
-    dmhedit.key = "MFORM1"
-    dmhedit.value = "chipx,chipy"
-    dmhedit.verbose = "0"
-    dmhedit()
-
-    dmhedit.punlearn()
-    dmhedit.infile = tmp2.name
-    dmhedit.operation = "add"
-    dmhedit.key = "MTYPE2"
-    dmhedit.value = "det"
-    dmhedit.verbose = "0"
-    dmhedit()
-
-    dmhedit.punlearn()
-    dmhedit.infile = tmp2.name
-    dmhedit.operation = "add"
-    dmhedit.key = "MFORM2"
-    dmhedit.value = "detx,dety"
-    dmhedit.verbose = "0"
-    dmhedit()
-
-    dmhedit.punlearn()
-    dmhedit.infile = tmp2.name
-    dmhedit.operation = "add"
-    dmhedit.key = "MTYPE3"
-    dmhedit.value = "sky"
-    dmhedit.verbose = "0"
-    dmhedit()
-
-    dmhedit.punlearn()
-    dmhedit.infile = tmp2.name
-    dmhedit.operation = "add"
-    dmhedit.key = "MFORM3"
-    dmhedit.value = "x,y"
-    dmhedit.verbose = "0"
-    dmhedit()
-
-    for key in ["X","Y","DETX","DETY"]:
-        keynum = _structural_kw(tmp2.name,key,tmpdir)
-
-        if keynum != None:
-            dmhedit.punlearn()
-            dmhedit.infile = tmp2.name
-            dmhedit.operation = "add"
-            dmhedit.key = "TLMIN{}".format(keynum)
-            dmhedit.value = "0.5"
-            dmhedit.verbose = "0"
-            dmhedit()
-
-            dmhedit.punlearn()
-            dmhedit.infile = tmp2.name
-            dmhedit.operation = "add"
-            dmhedit.key = "TLMAX{}".format(keynum)
-            dmhedit.value = "8192.5"
-            dmhedit.verbose = "0"
-            dmhedit()
-
-    if instrument == "HRC":
-        # ppr output columns is agnostic on instrument and just uses CCD_ID, which
-        # isn't appropriate for HRC data, which uses CHIP_ID
-
+        # copy the DETPOS column to a new DET column, for merging purposes
         dmtcalc.punlearn()
-        dmtcalc.infile = tmp2.name
+        dmtcalc.infile = infile
         dmtcalc.outfile = tmp1.name
-        dmtcalc.expression = "chip_id=ccd_id"
-        dmtcalc.verbose = "0"
-        dmtcalc.clobber= "yes"
+        dmtcalc.expression = "tmpx=(float)x,tmpy=(float)y,tmpdetx=(float)detx,tmpdety=(float)dety,tmpchipx=(short)chipx,tmpchipy=(short)chipy"
+        dmtcalc.verbose = 0
+        dmtcalc.clobber= True
         dmtcalc()
 
-        dmcopy.punlearn()
-        dmcopy.infile = "{}[cols -ccd_id]".format(tmp1.name)
-        dmcopy.outfile = outfile
-        dmcopy.verbose = "0"
-        dmcopy.clobber = "yes"
-        dmcopy()
+        dmtcalc.punlearn()
+        dmtcalc.infile = f"{tmp1.name}[cols -sky,-chip,-detpos]"
+        dmtcalc.outfile = tmp2.name
+        dmtcalc.expression = "x=tmpx,y=tmpy,detx=tmpdetx,dety=tmpdety,chipx=tmpchipx,chipy=tmpchipy"
+        dmtcalc.verbose = 0
+        dmtcalc.clobber= True
+        dmtcalc()
 
-    else:
-        dmcopy.punlearn()
-        dmcopy.infile = "{}".format(tmp2.name)
-        dmcopy.outfile = outfile
-        dmcopy.verbose = "0"
-        dmcopy.clobber = "yes"
-        dmcopy()
+        dmhedit.punlearn()
+        dmhedit.infile = tmp2.name
+        dmhedit.operation = "add"
+        dmhedit.key = "MTYPE1"
+        dmhedit.value = "chip"
+        dmhedit.verbose = 0
+        dmhedit()
 
-    tmp1.close()
-    tmp2.close()
+        dmhedit.punlearn()
+        dmhedit.infile = tmp2.name
+        dmhedit.operation = "add"
+        dmhedit.key = "MFORM1"
+        dmhedit.value = "chipx,chipy"
+        dmhedit.verbose = 0
+        dmhedit()
+
+        dmhedit.punlearn()
+        dmhedit.infile = tmp2.name
+        dmhedit.operation = "add"
+        dmhedit.key = "MTYPE2"
+        dmhedit.value = "det"
+        dmhedit.verbose = 0
+        dmhedit()
+
+        dmhedit.punlearn()
+        dmhedit.infile = tmp2.name
+        dmhedit.operation = "add"
+        dmhedit.key = "MFORM2"
+        dmhedit.value = "detx,dety"
+        dmhedit.verbose = 0
+        dmhedit()
+
+        dmhedit.punlearn()
+        dmhedit.infile = tmp2.name
+        dmhedit.operation = "add"
+        dmhedit.key = "MTYPE3"
+        dmhedit.value = "sky"
+        dmhedit.verbose = 0
+        dmhedit()
+
+        dmhedit.punlearn()
+        dmhedit.infile = tmp2.name
+        dmhedit.operation = "add"
+        dmhedit.key = "MFORM3"
+        dmhedit.value = "x,y"
+        dmhedit.verbose = 0
+        dmhedit()
+
+        for key in ["X","Y","DETX","DETY"]:
+            keynum = _structural_kw(tmp2.name,key)
+
+            if keynum is not None:
+                dmhedit.punlearn()
+                dmhedit.infile = tmp2.name
+                dmhedit.operation = "add"
+                dmhedit.key = f"TLMIN{keynum}"
+                dmhedit.value = "0.5"
+                dmhedit.verbose = 0
+                dmhedit()
+
+                dmhedit.punlearn()
+                dmhedit.infile = tmp2.name
+                dmhedit.operation = "add"
+                dmhedit.key = f"TLMAX{keynum}"
+                dmhedit.value = "8192.5"
+                dmhedit.verbose = 0
+                dmhedit()
+
+        if instrument == "HRC":
+            # ppr output columns is agnostic on instrument and just uses CCD_ID, which
+            # isn't appropriate for HRC data, which uses CHIP_ID
+
+            dmtcalc.punlearn()
+            dmtcalc.infile = tmp2.name
+            dmtcalc.outfile = tmp1.name
+            dmtcalc.expression = "chip_id=ccd_id"
+            dmtcalc.verbose = 0
+            dmtcalc.clobber= True
+            dmtcalc()
+
+            dmcopy.punlearn()
+            dmcopy.infile = f"{tmp1.name}[cols -ccd_id]"
+            dmcopy.outfile = outfile
+            dmcopy.verbose = 0
+            dmcopy.clobber = True
+            dmcopy()
+
+        else:
+            dmcopy.punlearn()
+            dmcopy.infile = f"{tmp2.name}"
+            dmcopy.outfile = outfile
+            dmcopy.verbose = 0
+            dmcopy.clobber = True
+            dmcopy()
 
 
-def _structural_kw(fn,keyval,tmpdir):
-    # import shutil
 
-    # tmp_dmlist = tempfile.NamedTemporaryFile(dir=tmpdir)
-    # tmp1 = tempfile.NamedTemporaryFile(dir=tmpdir)
-    # tmp2 = tempfile.NamedTemporaryFile(dir=tmpdir)
+def _structural_kw(fn,keyval):
 
-    # with open(tmp1.name, "w") as text_file:
-    #     text_file.write("#")
-
-    # dmlist.punlearn()
-    # dmlist.infile = fn
-    # dmlist.outfile = tmp2.name
-    # dmlist.opt = "header,raw"
-    # dmlist.verbose = "0"
-    # dmlist()
-
-    # # concatentate
-    # with open(tmp_dmlist.name,'wb') as wfd:
-    #     for f in [tmp1.name,tmp2.name]:
-    #         with open(f,'rb') as fd:
-    #             shutil.copyfileobj(fd,wfd)
-
-    # tmp1.close()
-    # tmp2.close()
-
-    # ## strip empty lines
-    # #open(filename_out, "w").write(open(filename_in).read().strip())
-
-    # cr = pcr.read_file("{}[exclude #row=1:3]".format(tmp_dmlist.name))
-    # tmp_dmlist.close()
-
-    # col = cr.get_column("col1").values
+    dmlist = make_tool("dmlist")
 
     dmlist.punlearn()
     dmlist.infile = fn
     dmlist.opt = "keys,raw"
-    dmlist.verbose = "0"
+    dmlist.verbose = 0
 
     col = dmlist()
-    col = col.split("\n")[5:]
-    col = [ln for ln in col if "TTYPE" in ln]
-    col = [j for j in [i.split("=") for i in col]]
+    col = [ln for ln in col.split("\n") if "TTYPE" in ln]
+    col = [i.split("=") for i in col]
 
-    dict = {}
+    col_dict = { d[0].replace(" ","").split("*")[-1] : d[1].replace(" ","").split("/")[0] for d in col }
 
-    for d in col:
-        dict[d[0][d[0].find("*")+1:].replace(" ","")] = d[1][:d[1].find("/")]
+    for k,v in col_dict.items():
+        if v.lower() == keyval.lower():
+            return  int(k.replace("TTYPE",""))
 
-    del(col)
+    return None
 
-    keys = dict.keys()
-
-    for key in keys:
-        if dict[key].strip(" ").lower() == keyval.lower():
-            keynum = key.lstrip("TTYPE")
-
-    try:
-        return keynum.strip(" ")
-
-    except UnboundLocalError:
-        return None
 
 
 def _evt_type(fn):
@@ -489,13 +457,16 @@ def _evt_type(fn):
     return evt_type
 
 
-#def num_pick((bkg,outfile,bkgscale,tmpdir,verbose)):
-def _num_pick(args): # P3
+
+def _num_pick(args):
     """Pick number of photons to add to the simulation"""
 
-    (bkg,outfile,bkgscale,bkgmeth,tobs,tbsky,randomseed,tmpdir,verbose) = args # P3
+    bkg,outfile,bkgscale,bkgmeth,tobs,tbsky,randomseed,tmpdir,verbose = args
 
-    with new_pfiles_environment(ardlib=True,copyuser=False):
+    dmcopy = make_tool("dmcopy")
+    dmtcalc = make_tool("dmtcalc")
+
+    with new_pfiles_environment(ardlib=False,copyuser=False), tempfile.NamedTemporaryFile(dir=tmpdir) as def_rand:
 
         ## get total number of events; the NAXIS2/__NROWS keyword aren't updated if
         ## evt file is filtered
@@ -505,17 +476,15 @@ def _num_pick(args): # P3
 
         # these generate random values between 0 and 1, inclusive
         if randomseed > 0:
-            randseed = "#rand({})".format(randomseed)
+            randseed = f"#rand({randomseed})"
         else:
             randseed = "#trand"
-
-        def_rand = tempfile.NamedTemporaryFile(dir=tmpdir)
 
         dmtcalc.punlearn()
         dmtcalc.infile = bkg
         dmtcalc.outfile = def_rand.name
         dmtcalc.verbose = verbose
-        dmtcalc.clobber = "yes"
+        dmtcalc.clobber = True
 
         if bkgmeth.lower() == "particle-rate":
             # # get HE filter
@@ -536,20 +505,19 @@ def _num_pick(args): # P3
             # ntot = _get_nevt(bkg)
             # nhe = _get_nevt("{0}{1}".format(bkg,efilt))
 
-            dmtcalc.expression = "randnum={0}*({1}/({2}*{3}))".format(randseed,tbsky,tobs,bkgscale)
+            dmtcalc.expression = f"randnum={randseed}*({tbsky}/({tobs}*{bkgscale}))"
         else:
-            dmtcalc.expression = "randnum={0}/{1}".format(randseed,bkgscale)
+            dmtcalc.expression = f"randnum={randseed}/{bkgscale}"
 
         dmtcalc()
 
         dmcopy.punlearn()
-        dmcopy.infile = "{}[randnum=0:1]".format(def_rand.name)
+        dmcopy.infile = f"{def_rand.name}[randnum=0:1]"
         dmcopy.outfile = outfile # sampled event will have RANDNUM value less than 1
-        dmcopy.clobber = "yes"
+        dmcopy.clobber = True
 
         dmcopy()
 
-        def_rand.close()
 
 
 def assign_time(bkg_rand,time_sorted_outfile,kw,randomseed,tmpdir,verbose):
@@ -562,40 +530,41 @@ def assign_time(bkg_rand,time_sorted_outfile,kw,randomseed,tmpdir,verbose):
     t0_corr = t0 + 0.5*(1-dtcor)*(t1-t0)
     t1_corr = t1 - 0.5*(1-dtcor)*(t1-t0)
 
-    time_rand = tempfile.NamedTemporaryFile(dir=tmpdir)
+    dmtcalc = make_tool("dmtcalc")
+    dmsort = make_tool("dmsort")
+    dmhedit = make_tool("dmhedit")
 
-    if randomseed > 0:
-        randseed = "#rand({})".format(randomseed)
-    else:
-        randseed = "#trand"
+    with tempfile.NamedTemporaryFile(dir=tmpdir) as time_rand:
+        if randomseed > 0:
+            randseed = f"#rand({randomseed})"
+        else:
+            randseed = "#trand"
 
-    dmtcalc.punlearn()
+        dmtcalc.punlearn()
 
-    dmtcalc.infile = bkg_rand
-    dmtcalc.outfile = time_rand.name
-    #dmtcalc.expression = "time={0}+({1}-{0})*{2}".format(t0,t1,randseed)
-    dmtcalc.expression = f"time={t0_corr}+({t1_corr}-{t0_corr})*{randseed}"
-    dmtcalc.clobber = "yes"
-    dmtcalc.verbose = verbose
+        dmtcalc.infile = bkg_rand
+        dmtcalc.outfile = time_rand.name
+        #dmtcalc.expression = "time={0}+({1}-{0})*{2}".format(t0,t1,randseed)
+        dmtcalc.expression = f"time={t0_corr}+({t1_corr}-{t0_corr})*{randseed}"
+        dmtcalc.clobber = True
+        dmtcalc.verbose = verbose
 
-    dmtcalc()
+        dmtcalc()
 
-    dmsort.punlearn()
+        dmsort.punlearn()
 
-    dmsort.infile = time_rand.name
-    dmsort.outfile = time_sorted_outfile
-    dmsort.keys = "TIME"
-    dmsort.clobber = "yes"
+        dmsort.infile = time_rand.name
+        dmsort.outfile = time_sorted_outfile
+        dmsort.keys = "TIME"
+        dmsort.clobber = True
 
-    dmsort()
-
-    time_rand.close()
+        dmsort()
 
     # update time-related header keywords of the sampled file
     dmhedit.punlearn()
     dmhedit.infile = time_sorted_outfile
     dmhedit.operation = "add"
-    dmhedit.verbose = "0"
+    dmhedit.verbose = 0
 
     for tkey in ["ONTIME","LIVETIME","EXPOSURE","TSTART","TSTOP","DTCOR"]:
         dmhedit.key = tkey
@@ -606,20 +575,25 @@ def assign_time(bkg_rand,time_sorted_outfile,kw,randomseed,tmpdir,verbose):
         chips = fileio.get_ccds(bkg_rand)
 
         for chip in chips:
-            dmhedit.key = "ONTIME{}".format(chip)
-            dmhedit.value = kw["ONTIME{}".format(chip)]
+            dmhedit.key = f"ONTIME{chip}"
+            dmhedit.value = kw[f"ONTIME{chip}"]
             dmhedit()
 
-            dmhedit.key = "LIVTIME{}".format(chip)
-            dmhedit.value = kw["LIVTIME{}".format(chip)]
+            dmhedit.key = f"LIVTIME{chip}"
+            dmhedit.value = kw[f"LIVTIME{chip}"]
             dmhedit()
 
-            dmhedit.key = "EXPOSUR{}".format(chip)
-            dmhedit.value = kw["EXPOSUR{}".format(chip)]
+            dmhedit.key = f"EXPOSUR{chip}"
+            dmhedit.value = kw[f"EXPOSUR{chip}"]
             dmhedit()
+
 
 
 def sample_chip(bkg,infile,outfile,kw,randomseed,tmpdir,verbose):
+    """
+    randomly sample the number of events for each chip, proportional to 1/BKGSCALn
+    """
+
     instrument = kw["INSTRUME"]
     bkgmeth = kw["BKGMETH"]
 
@@ -638,18 +612,20 @@ def sample_chip(bkg,infile,outfile,kw,randomseed,tmpdir,verbose):
         bkg_sample = []
         bkg_tmp = []
 
+        dmmerge = make_tool("dmmerge")
+
         try:
             for chip in chips:
-                bkgtmp = tempfile.NamedTemporaryFile(suffix=".bkg{}".format(chip),dir=tmpdir)
-                bkgscale = kw["BKGSCAL{}".format(chip)]
-                bkgchipstr = "{0}[ccd_id={1}]".format(bkg,chip)
+                bkgtmp = tempfile.NamedTemporaryFile(suffix=f".bkg{chip}",dir=tmpdir)
+                bkgscale = kw[f"BKGSCAL{chip}"]
+                bkgchipstr = f"{bkg}[ccd_id={chip}]"
 
-                tobs = fileio.get_keys_from_file(infile)["LIVTIME{}".format(chip)]
+                tobs = fileio.get_keys_from_file(infile)[f"LIVTIME{chip}"]
                 try:
-                    tbsky = kw["LIVTIME{}".format(chip)]
+                    tbsky = kw[f"LIVTIME{chip}"]
                 except KeyError:
                     try:
-                        tbsky = kw["LIVETIM{}".format(chip)]
+                        tbsky = kw[f"LIVETIM{chip}"]
                     except KeyError:
                         tbsky = kw["LIVETIME"]
 
@@ -658,7 +634,7 @@ def sample_chip(bkg,infile,outfile,kw,randomseed,tmpdir,verbose):
                 bkg_tmp.append(bkgtmp)
 
             if len(chips) > cpu_count():
-                parallel_pool(_num_pick,bkg_sample)
+                parallel_pool_futures(_num_pick,bkg_sample)
             else:
                 parallel_map(_num_pick,bkg_sample)
 
@@ -667,7 +643,7 @@ def sample_chip(bkg,infile,outfile,kw,randomseed,tmpdir,verbose):
 
             dmmerge.infile = [bg.name for bg in bkg_tmp]
             dmmerge.outfile = outfile
-            dmmerge.clobber = "yes"
+            dmmerge.clobber = True
             dmmerge.verbose = verbose
 
             dmmerge()
@@ -676,13 +652,14 @@ def sample_chip(bkg,infile,outfile,kw,randomseed,tmpdir,verbose):
                 fn.close()
 
 
-@handle_ciao_errors(toolname,__revision__)
+
+@handle_ciao_errors(__toolname__,__revision__)
 def doit():
     params,pars = get_par(sys.argv)
 
     # print script info
     set_verbosity(params["verbose"])
-    utils.print_version(toolname, __revision__)
+    utils.print_version(__toolname__, __revision__)
 
     infile = params["infile"]
     bkgfile = params["bkgfile"]
@@ -698,229 +675,209 @@ def doit():
     clobber = params["clobber"]
     verbose = params["verbose"]
 
+    dmcopy = make_tool("dmcopy")
+    dmmerge = make_tool("dmmerge")
+
     ############
+    with new_pfiles_environment(ardlib=False), \
+         tempfile.NamedTemporaryFile(dir=tmpdir) as tmpin, \
+         tempfile.NamedTemporaryFile(dir=tmpdir) as get_rand, \
+         tempfile.NamedTemporaryFile(dir=tmpdir) as time_sorted:
 
-    get_rand = tempfile.NamedTemporaryFile(dir=tmpdir)
-    time_sorted = tempfile.NamedTemporaryFile(dir=tmpdir)
+        kw_psf = fileio.get_keys_from_file(f"{infile}{params['infile_filter']}")
+        kw_bkg = fileio.get_keys_from_file(bkgfile)
 
-    kw_psf = fileio.get_keys_from_file(infile+params["infile_filter"])
-    kw_bkg = fileio.get_keys_from_file(bkgfile)
+        instrument = kw_bkg["INSTRUME"]
 
-    instrument = kw_bkg["INSTRUME"]
+        etype = _evt_type(infile)
 
-    etype = _evt_type(infile)
+        # filter CCDs if input is a PSF to what's available in the BKG, since PPR contains
+        # all CCD_IDs and MARX is strictly defined between ACIS-I and ACIS-S
+        with tempfile.NamedTemporaryFile(dir=tmpdir) as tmpbkg:
+            if etype != "obs" and instrument == "ACIS":
 
-    # filter CCDs if input is a PSF to what's available in the BKG, since PPR contains
-    # all CCD_IDs and MARX is strictly defined between ACIS-I and ACIS-S
-    if etype != "obs":
-        if instrument == "ACIS":
+                ccd_psf = fileio.get_ccds(infile)
+                ccd_bkg = fileio.get_ccds(bkgfile)
 
-            tmpin = tempfile.NamedTemporaryFile(dir=tmpdir)
-            tmpbkg = tempfile.NamedTemporaryFile(dir=tmpdir)
+                ccd = set(ccd_psf) & set(ccd_bkg)
+                ccd = ",".join([str(i) for i in sorted(ccd)])
 
-            ccd_psf = fileio.get_ccds(infile)
-            ccd_bkg = fileio.get_ccds(bkgfile)
-
-            ccd = set(ccd_psf) & set(ccd_bkg)
-            ccd = ",".join([str(i) for i in sorted(ccd)])
-
-            dmcopy.punlearn()
-            dmcopy.infile = "{0}[ccd_id={1}]".format(infile,ccd)
-            dmcopy.outfile = tmpin.name
-            dmcopy.verbose = "0"
-            dmcopy.clobber = "yes"
-            dmcopy()
-
-            dmcopy.punlearn()
-            dmcopy.infile = "{0}[ccd_id={1}]".format(bkgfile,ccd)
-            dmcopy.outfile = tmpbkg.name
-            dmcopy.verbose = "0"
-            dmcopy.clobber = "yes"
-            dmcopy()
-
-            infile = tmpin.name
-            bkgfile = tmpbkg.name
-
-    # check for background CALDB version; any ACIS background before 4.7.5.1
-    # will need to convert the PHA and PI datatype which were short integers
-    # (Int16/Int2) and match the event files with long integers (Int64/Int4)
-    cr_bkg = pcr.read_file("{}[#row=1]".format(bkgfile))
-
-    if True in [cr_bkg.pi.values.dtype != "int64",cr_bkg.pha.values.dtype != "int64"]:
-        bkg_old = True
-    else:
-        bkg_old = False
-
-    cr_bkg.__del__()
-
-    # sample background file and assign times to each event
-    sample_chip(bkgfile,infile,get_rand.name,kw_bkg,seed,tmpdir,verbose)
-    assign_time(get_rand.name,time_sorted.name,kw_psf,seed,tmpdir,verbose)
-
-    get_rand.close()
-
-    try:
-        tmpbkg.close()
-    except NameError:
-        pass
-
-    if etype != "ppr":
-        if instrument == "ACIS":
-            if bkg_old:
-                _cols2int4(time_sorted.name,tmpdir) # convert PHA and PI columns to Int4 to match observed evt
-
-    if reproject == "yes":
-        # Reproject the blank sky fields to the same position on the sky as the marx simulation.
-        reproject_events.punlearn()
-
-        if instrument == "ACIS":
-            reproject_events.infile = "{}[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]".format(time_sorted.name)
-        else:
-            reproject_events.infile = "{}[cols chip_id,chip,det,sky,pha,pi,status,time]".format(time_sorted.name)
-
-        reproject_events.outfile = bkgoutdir+bkgout
-        reproject_events.aspect = asol
-        reproject_events.match = infile
-        reproject_events.random = seed
-        reproject_events.clobber = "yes"
-        reproject_events.verbose = verbose
-
-        reproject_events()
-
-    else:
-        # if the blank sky file is already reprojected or if the blanksky script was used
-        dmcopy.punlearn()
-
-        if instrument == "ACIS":
-            dmcopy.infile = "{}[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]".format(time_sorted.name)
-        else:
-            dmcopy.infile = "{}[cols chip_id,chip,det,sky,pha,pi,status,time]".format(time_sorted.name)
-
-        dmcopy.outfile = bkgoutdir+bkgout
-        dmcopy.clobber = clobber
-        dmcopy()
-
-    time_sorted.close()
-
-    try:
-        add_tool_history(bkgoutdir+bkgout,toolname,pars)
-    except OSError:
-        pass
-
-    ## Merge marx simulation and blank sky fields into a single fits table.
-    if psf_bkg_out != "":
-
-        psf_bkg_outdir = params["psf_bkg_outdir"]
-
-        dmmerge.punlearn()
-
-        tmppsf = tempfile.NamedTemporaryFile(dir=tmpdir)
-
-        if etype == "ppr":
-            _convert_ppr_cols(infile,tmppsf.name,instrument,tmpdir)
-            dmmerge.infile = "{0},{1}".format(tmppsf.name,bkgoutdir+bkgout)
-
-        elif etype in ["obs","marx"]:
-            if (True,True) == (etype=="obs",instrument=="ACIS"):
-                dmmerge.infile = "{0},{1}".format(infile,bkgoutdir+bkgout)
-
-            else:
-                # first need to convert data type for PI and PHA columns
                 dmcopy.punlearn()
-                dmcopy.infile = infile
-                dmcopy.outfile = tmppsf.name
-                dmcopy.verbose = "0"
-                dmcopy.clobber = "yes"
+                dmcopy.infile = f"{infile}[ccd_id={ccd}]"
+                dmcopy.outfile = tmpin.name
+                dmcopy.verbose = 0
+                dmcopy.clobber = True
                 dmcopy()
 
-                _cols2int4(tmppsf.name,tmpdir)
-                dmmerge.infile = "{0},{1}".format(tmppsf.name,bkgoutdir+bkgout)
+                dmcopy.punlearn()
+                dmcopy.infile = f"{bkgfile}[ccd_id={ccd}]"
+                dmcopy.outfile = tmpbkg.name
+                dmcopy.verbose = 0
+                dmcopy.clobber = True
+                dmcopy()
+
+                infile = tmpin.name
+                bkgfile = tmpbkg.name
+
+            # check for background CALDB version; any ACIS background before 4.7.5.1
+            # will need to convert the PHA and PI datatype which were short integers
+            # (Int16/Int2) and match the event files with long integers (Int64/Int4)
+            cr_bkg = pcr.read_file(f"{bkgfile}[#row=0]")
+
+            bkg_old = (True in (cr_bkg.pi.values.dtype != "int64",
+                                cr_bkg.pha.values.dtype != "int64"))
+
+            del cr_bkg
+
+            # sample background file and assign times to each event
+            sample_chip(bkgfile,infile,get_rand.name,kw_bkg,seed,tmpdir,verbose)
+            assign_time(get_rand.name,time_sorted.name,kw_psf,seed,tmpdir,verbose)
+
+        if etype != "ppr":
+            if instrument == "ACIS":
+                if bkg_old:
+                    _cols2int4(time_sorted.name,tmpdir) # convert PHA and PI columns to Int4 to match observed evt
+
+        if reproject == "yes":
+            reproject_events = make_tool("reproject_events")
+
+            # Reproject the blank sky fields to the same position on the sky as the marx simulation.
+            reproject_events.punlearn()
+
+            if instrument == "ACIS":
+                reproject_events.infile = f"{time_sorted.name}[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]"
+            else:
+                reproject_events.infile = f"{time_sorted.name}[cols chip_id,chip,det,sky,pha,pi,status,time]"
+
+            reproject_events.outfile = f"{bkgoutdir}{bkgout}"
+            reproject_events.aspect = asol
+            reproject_events.match = infile
+            reproject_events.random = seed
+            reproject_events.clobber = True
+            reproject_events.verbose = verbose
+
+            reproject_events()
 
         else:
-            v3("'infile' has unrecognized creator")
+            # if the blank sky file is already reprojected or if the blanksky script was used
+            dmcopy.punlearn()
 
-
-        if etype == "ppr":
             if instrument == "ACIS":
-                dmmerge.columnList = "ccd_id,chip,det,sky,energy"
+                dmcopy.infile = f"{time_sorted.name}[cols ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status,time]"
             else:
-                dmmerge.columnList = "chip_id,chip,det,sky"
+                dmcopy.infile = f"{time_sorted.name}[cols chip_id,chip,det,sky,pha,pi,status,time]"
 
-        else:
-            if instrument == "ACIS":
-                dmmerge.columnList = "time,ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status"
-            else:
-                dmmerge.columnList = "time,chip_id,chip,det,sky,pha,status"
-
-        dmmerge.outfile = psf_bkg_outdir+psf_bkg_out
-        dmmerge.clobber = clobber
-        dmmerge.verbose = verbose
-
-        dmmerge()
+            dmcopy.outfile = bkgoutdir+bkgout
+            dmcopy.clobber = clobber
+            dmcopy()
 
         try:
-            add_tool_history(psf_bkg_outdir+psf_bkg_out,toolname,pars)
+            add_tool_history(bkgoutdir+bkgout,__toolname__,pars)
         except OSError:
             pass
 
-    if fill_out != "":
+        ## Merge MARX simulation and blank sky fields into a single fits table.
+        if psf_bkg_out != "":
 
-        fill_outdir = params["fill_outdir"]
+            psf_bkg_outdir = params["psf_bkg_outdir"]
 
-        dmmerge.punlearn()
+            dmmerge.punlearn()
 
-        dmmerge.outfile = fill_outdir+fill_out
-        dmmerge.clobber = clobber
-        dmmerge.verbose = verbose
+            with tempfile.NamedTemporaryFile(dir=tmpdir) as tmppsf:
+                if etype == "ppr":
+                    _convert_ppr_cols(infile,tmppsf.name,instrument,tmpdir)
+                    dmmerge.infile = f"{tmppsf.name},{bkgoutdir}{bkgout}"
 
-        if etype == "ppr":
-            if psf_bkg_out == "":
-                tmppsf = tempfile.NamedTemporaryFile(dir=tmpdir)
+                elif etype in ["obs","marx"]:
+                    if (True,True) == (etype=="obs",instrument=="ACIS"):
+                        dmmerge.infile = f"{infile},{bkgoutdir}{bkgout}"
 
-                _convert_ppr_cols(infile,tmppsf.name,instrument,tmpdir)
+                    else:
+                        # first need to convert data type for PI and PHA columns
+                        dmcopy.punlearn()
+                        dmcopy.infile = infile
+                        dmcopy.outfile = tmppsf.name
+                        dmcopy.verbose = 0
+                        dmcopy.clobber = True
+                        dmcopy()
 
-                dmmerge.infile = "{0}[exclude sky=region({2})],{1}[sky=region({2})]".format(tmppsf.name+params["infile_filter"],bkgoutdir+bkgout+params["infile_filter"],regionfile)
+                        _cols2int4(tmppsf.name,tmpdir)
+                        dmmerge.infile = f"{tmppsf.name},{bkgoutdir}{bkgout}"
 
-            else:
-                dmmerge.infile = "{0}[exclude sky=region({2})],{1}[sky=region({2})]".format(tmppsf.name+params["infile_filter"],bkgoutdir+bkgout+params["infile_filter"],regionfile)
-
-            if instrument == "ACIS":
-                dmmerge.columnList = "ccd_id,chip,det,sky,energy"
-            else:
-                dmmerge.columnList = "chip_id,chip,det,sky"
-
-        else:
-            dmmerge.infile = "{0}[exclude sky=region({2})],{1}[sky=region({2})]".format(infile+params["infile_filter"],bkgoutdir+bkgout+params["infile_filter"],regionfile)
-
-            if instrument == "ACIS":
-                dmmerge.columnList = "ccd_id,node_id,chip,det,sky,PHA,energy,PI,fltgrade,grade,status,time"
-            else:
-                if etype == "obs":
-                    dmmerge.columnList = "chip_id,chip,det,sky,pha,pi,status,TIME"
-                elif etype == "marx":
-                    dmmerge.columnList = "chip_id,chip,det,sky,pha,status,TIME"
                 else:
                     v3("'infile' has unrecognized creator")
 
-        dmmerge()
 
-        try:
-            add_tool_history(fill_outdir+fill_out,toolname,pars)
-        except OSError:
-            pass
+                if etype == "ppr":
+                    if instrument == "ACIS":
+                        dmmerge.columnList = "ccd_id,chip,det,sky,energy"
+                    else:
+                        dmmerge.columnList = "chip_id,chip,det,sky"
 
-    try:
-        tmppsf.close()
-    except NameError:
-        pass
+                else:
+                    if instrument == "ACIS":
+                        dmmerge.columnList = "time,ccd_id,node_id,chip,det,sky,pha,energy,pi,fltgrade,grade,status"
+                    else:
+                        dmmerge.columnList = "time,chip_id,chip,det,sky,pha,status"
 
-    try:
-        tmpin.close()
-    except NameError:
-        pass
+                dmmerge.outfile = f"{psf_bkg_outdir}{psf_bkg_out}"
+                dmmerge.clobber = clobber
+                dmmerge.verbose = verbose
 
-    # if 'tmppsf' in locals():
-    #     tmppsf.close()
+                dmmerge()
+
+            try:
+                add_tool_history(f"{psf_bkg_outdir}{psf_bkg_out}", __toolname__, pars)
+            except OSError:
+                pass
+
+        if fill_out != "":
+
+            fill_outdir = params["fill_outdir"]
+
+            dmmerge.punlearn()
+
+            dmmerge.outfile = fill_outdir+fill_out
+            dmmerge.clobber = clobber
+            dmmerge.verbose = verbose
+
+            if etype == "ppr":
+                with tempfile.NamedTemporaryFile(dir=tmpdir) as tmppsf:
+                    if psf_bkg_out == "":
+                        _convert_ppr_cols(infile,tmppsf.name,instrument,tmpdir)
+
+                        dmmerge.infile = f"{tmppsf.name}{params['infile_filter']}[exclude sky=region({regionfile})],{bkgoutdir}{bkgout}{params['infile_filter']}[sky=region({regionfile})]"
+
+                    else:
+                        dmmerge.infile = f"{tmppsf.name}{params['infile_filter']}[exclude sky=region({regionfile})],{bkgoutdir}{bkgout}{params['infile_filter']}[sky=region({regionfile})]"
+
+                    if instrument == "ACIS":
+                        dmmerge.columnList = "ccd_id,chip,det,sky,energy"
+                    else:
+                        dmmerge.columnList = "chip_id,chip,det,sky"
+
+                    dmmerge()
+
+            else:
+                dmmerge.infile = f"{infile}{params['infile_filter']}[exclude sky=region({regionfile})],{bkgoutdir}{bkgout}{params['infile_filter']}[sky=region({regionfile})]"
+
+                if instrument == "ACIS":
+                    dmmerge.columnList = "ccd_id,node_id,chip,det,sky,PHA,energy,PI,fltgrade,grade,status,time"
+                else:
+                    if etype == "obs":
+                        dmmerge.columnList = "chip_id,chip,det,sky,pha,pi,status,TIME"
+                    elif etype == "marx":
+                        dmmerge.columnList = "chip_id,chip,det,sky,pha,status,TIME"
+                    else:
+                        v3("'infile' has unrecognized creator")
+
+                dmmerge()
+
+            try:
+                add_tool_history(f"{fill_outdir}{fill_out}", __toolname__, pars)
+            except OSError:
+                pass
+
 
 
 if __name__  == "__main__":

--- a/share/doc/xml/blanksky.xml
+++ b/share/doc/xml/blanksky.xml
@@ -294,25 +294,24 @@
 	background for each chip in the energy band defined by the
 	"bkgparams" parameter.  
       </PARA>
-    </ADESC>
+    </ADESC>    
 
-    <ADESC title="Changes in the scripts 4.15.1 (January 2023) release">
+    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
       <PARA>
-	Corrected the screen output reporting the updated BKGSCAL
-	keywords (the file output was correct).
+        The script no-longer copies over the RA_PNT, DEC_PNT, ROLL_PNT,
+        DY_AVG, DZ_AVG, and DTH_AVG header keywords as they are now
+        provided by reproject_events.
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.15.0 (December 2022) release">
+    <ADESC title="Changes in the scripts 4.11.3 (May 2019) release">
       <PARA>
-	Querying the set of stowed ACIS background files has been
-	added with the "stowedbg" parameter.  The stowed background
-	(NXB) files will be used in lieu of blank sky background
-	(CXB+NXB) files.  This feature only supports CTI-corrected ACIS
-	data sets. 
+        The aimpoint chip is now calculated using the RA_PNT and DEC_PNT
+        keywords, rather than the RA_NOM and DEC_NOM, to better support
+        reprojected datasets.
       </PARA>
     </ADESC>
-    
+
     <!-- I am guessing when this was added -->
     <ADESC title="Changes in the scripts 4.12.0 (December 2019) release">
       <PARA>
@@ -325,22 +324,34 @@
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.11.3 (May 2019) release">
+    <ADESC title="Changes in the scripts 4.15.0 (December 2022) release">
       <PARA>
-        The aimpoint chip is now calculated using the RA_PNT and DEC_PNT
-        keywords, rather than the RA_NOM and DEC_NOM, to better support
-        reprojected datasets.
+	Querying the set of stowed ACIS background files has been
+	added with the "stowedbg" parameter.  The stowed background
+	(NXB) files will be used in lieu of blank sky background
+	(CXB+NXB) files.  This feature only supports CTI-corrected ACIS
+	data sets. 
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.11.2 (April 2019) release">
+    <ADESC title="Changes in the scripts 4.15.1 (January 2023) release">
       <PARA>
-        The script no-longer copies over the RA_PNT, DEC_PNT, ROLL_PNT,
-        DY_AVG, DZ_AVG, and DTH_AVG header keywords as they are now
-        provided by reproject_events.
+	Corrected the screen output reporting the updated BKGSCAL
+	keywords (the file output was correct).
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the November 2023 revision (scripts 4.16.0)">
+      <PARA>
+	Use the <tt>CHKVFPHA</tt> header keyword, introduced via <HREF
+	link="https://cxc.harvard.edu/ciao/ahelp/acis_process_events.html">acis_process_events</HREF>
+	in CIAO 4.16, to determine if VFAINT event status filtering
+	should be applied, if available, but will fall back to the
+	older determination technique if necessary.  Internal code
+	clean up applied. 
+      </PARA>
+    </ADESC>
+    
     <ADESC title="About Contributed Software">
       <PARA>
         This script is not an official part of the CIAO release but is
@@ -361,6 +372,6 @@
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>January 2023</LASTMODIFIED>
+    <LASTMODIFIED>November 2023</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/blanksky.xml
+++ b/share/doc/xml/blanksky.xml
@@ -347,8 +347,7 @@
 	link="https://cxc.harvard.edu/ciao/ahelp/acis_process_events.html">acis_process_events</HREF>
 	in CIAO 4.16, to determine if VFAINT event status filtering
 	should be applied, if available, but will fall back to the
-	older determination technique if necessary.  Internal code
-	clean up applied. 
+	older determination technique if necessary.
       </PARA>
     </ADESC>
     

--- a/share/doc/xml/blanksky.xml
+++ b/share/doc/xml/blanksky.xml
@@ -343,7 +343,7 @@
 
     <ADESC title="Changes in the November 2023 revision (scripts 4.16.0)">
       <PARA>
-	Use the <tt>CHKVFPHA</tt> header keyword, introduced via <HREF
+	Use the CHKVFPHA header keyword, introduced via <HREF
 	link="https://cxc.harvard.edu/ciao/ahelp/acis_process_events.html">acis_process_events</HREF>
 	in CIAO 4.16, to determine if VFAINT event status filtering
 	should be applied, if available, but will fall back to the

--- a/share/doc/xml/blanksky_image.xml
+++ b/share/doc/xml/blanksky_image.xml
@@ -176,13 +176,6 @@
 	has been applied to the input file.
       </PARA>
     </ADESC>
-
-    <ADESC title="Changes in the October 2023 revision (scripts 4.16.0)">
-      <PARA>
-	The script has been completely linted and cleaned up; no
-	change to the UX.
-      </PARA>
-    </ADESC>
     
     <ADESC title="About Contributed Software">
       <PARA>

--- a/share/doc/xml/blanksky_image.xml
+++ b/share/doc/xml/blanksky_image.xml
@@ -177,6 +177,13 @@
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the October 2023 revision (scripts 4.16.0)">
+      <PARA>
+	The script has been completely linted and cleaned up; no
+	change to the UX.
+      </PARA>
+    </ADESC>
+    
     <ADESC title="About Contributed Software">
       <PARA>
         This script is not an official part of the CIAO release but is
@@ -196,6 +203,6 @@
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>December 2022</LASTMODIFIED>
+    <LASTMODIFIED>November 2023</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/blanksky_sample.xml
+++ b/share/doc/xml/blanksky_sample.xml
@@ -339,10 +339,9 @@ ute
 
     <ADESC title="Changes in the November 2023 revision (scripts 4.16.0)">
       <PARA>
-	The script has been linted and cleaned up; replaced
-	"Merged"-valued keywords with the input keyword values from
-	source/PSF event files when combining these results to provide
-	more useful information. 
+	Replaced "Merged"-valued keywords with the input keyword
+	values from source/PSF event files when combining these 
+	results to provide more useful information. 
       </PARA>
     </ADESC>
 

--- a/share/doc/xml/blanksky_sample.xml
+++ b/share/doc/xml/blanksky_sample.xml
@@ -329,6 +329,23 @@ ute
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scipts 4.14.0 (December 2021) release">
+      <PARA>
+	Incorporated deadtime correction from reference observation to
+	better bound the time range the randomly sampled time values
+	assigned to the blanksky events. 
+      </PARA>
+    </ADESC>
+
+    <ADESC title="Changes in the November 2023 revision (scripts 4.16.0)">
+      <PARA>
+	The script has been linted and cleaned up; replaced
+	"Merged"-valued keywords with the input keyword values from
+	source/PSF event files when combining these results to provide
+	more useful information. 
+      </PARA>
+    </ADESC>
+
     <ADESC title="About Contributed Software">
       <PARA>
         This script is not an official part of the CIAO release but is
@@ -338,15 +355,6 @@ ute
         ensure that the parameter file is available.
       </PARA>
     </ADESC>
-
-    <ADESC title="Changes in the scipts 4.14.0 (December 2021) release">
-      <PARA>
-	Incorporated deadtime correction from reference observation to
-	better bound the time range the randomly sampled time values
-	assigned to the blanksky events. 
-      </PARA>
-    </ADESC>
-
 
 <!--//    
     <BUGS>
@@ -358,6 +366,6 @@ ute
       </PARA>
     </BUGS>
 //-->    
-    <LASTMODIFIED>December 2022</LASTMODIFIED>
+    <LASTMODIFIED>November 2023</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
`blanksky`, `blanksky_image`, are `blanksky_sample` have undergone linting and clean up.

`blanksky` will make use of the `CHKVFPHA` keyword introduced by `acis_process_events` in CIAO 4.16, but the fragile history parsing approach to determine if `status=0` event filtering for ACIS VFaint data is also retained for reference event files haven't been reprocessed using 4.16.

`blanksky_sample` also will replace the `Merged`-valued keywords in the `psf_bkg_out` and `fill_out` files files, which combine source `infile` events and background events via `dmmerge` with more helpful information using the keyword values from the original `infile`.