### PR TITLE
Fix and clean-up of check_ciao_version

### DIFF
--- a/bin/check_ciao_version
+++ b/bin/check_ciao_version
@@ -48,7 +48,7 @@ import sys
 from optparse import OptionParser
 
 toolname = "check_ciao_version"
-version = "14 November 2023"
+version = "15 November 2023"
 
 try:
     from ciao_contrib import logger_wrapper as lw
@@ -99,7 +99,7 @@ def report_update_info_ciao_install():
     "Write out generic 'how to install CIAO' info"
 
     print("\nPlease use the ciao-install script from")
-    print("    https://cxc.harvard.edu/ciao/download/")
+    print("    https://cxc.harvard.edu/ciao/download/ciao_install.html")
     print("to update your CIAO installation.")
 
 
@@ -121,13 +121,16 @@ def compare_versions(ciao, latest, installed):
     vlatest = latest["CIAO"]
     vinstalled = installed["CIAO"]
 
-    # automatically error out if this fails
+    # Automatically error out if this fails, as we do not
+    # need to do the package check. We return False so
+    # we can check the CALDB as that may be up to date.
+    #
     if vlatest != vinstalled:
         print(f"The CIAO installation at {ciao}")
         print(f"   has version             {vinstalled}")
         print(f"   the released version is {vlatest}")
-        report_update_info_ciao_install()
-        sys.exit(1)
+        print("")
+        return False
 
     updates = []
     for (ik, iv) in installed.items():
@@ -150,7 +153,7 @@ def compare_versions(ciao, latest, installed):
         print("The following packages:")
 
     for (pname, iver, _) in updates:
-        print("    {pname:10s}:  {iver}")
+        print(f"    {pname:10s}:  {iver}")
 
     if nu == 1:
         print("\nneeds updating to:")
@@ -158,7 +161,7 @@ def compare_versions(ciao, latest, installed):
         print("\nneed updating to:")
 
     for (pname, _, lver) in updates:
-        print("    {pname:10s}:  {lver}")
+        print(f"    {pname:10s}:  {lver}")
 
     print("")
     return False
@@ -181,7 +184,7 @@ def compare_caldb():
         cinfo += f" (link to {lname})"
 
     if rval is None:
-        print(f"{caldb} is up to date.")
+        print(f"{cinfo} is up to date.")
         return True
 
     print(cinfo)
@@ -231,7 +234,7 @@ def doit():
     ciao = os.getenv("ASCDS_INSTALL")
     if ciao is None:
         # unlikely to get here since able to load ciao_contrib
-        raise IOError("$ASCDS_INSTALL is not defined; has CIAO been started?")
+        raise OSError("$ASCDS_INSTALL is not defined; has CIAO been started?")
 
     # How was CIAO installed?
     #  - ciao-install            has $ASCDS_INSTALL/binexe directory
@@ -239,7 +242,7 @@ def doit():
     #
     canary = os.path.join(ciao, "binexe")
     if not os.path.isdir(canary):
-        # We rely on conda for all the checks so can exit here
+        # We rely on conda for all the checks so can exit here.
         #
         flag = versioninfo.check_conda_versions(ciao)
         sys.exit(0 if flag else 1)

--- a/ciao_contrib/_tools/versioninfo.py
+++ b/ciao_contrib/_tools/versioninfo.py
@@ -313,7 +313,7 @@ def check_conda_versions(ciao):
         out = subprocess.run(["conda", "list", "--json"], check=True,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except FileNotFoundError as fe:
-        raise IOError("Unable to run the conda tool. Was CIAO installed with conda?") from fe
+        raise IOError("Unable to run the conda tool to find out what is installed.") from fe
 
     js = json.loads(out.stdout)
 

--- a/make_versions_file
+++ b/make_versions_file
@@ -11,7 +11,7 @@ Usage:
 Output:
   Screen
 
-Will oftern be used
+Will often be used
   ./make_versions_file > ciao_versions.dat
 
 """

--- a/make_versions_file
+++ b/make_versions_file
@@ -13,7 +13,7 @@ Output:
 
 Will oftern be used
   ./make_versions_file > ciao_versions.dat
-  
+
 """
 
 import os
@@ -32,7 +32,7 @@ def read_vfile(fname):
     # may have blank lines
     cts = [l.strip() for l in cts if l.strip() != ""]
     if len(cts) != 1:
-        raise IOError("Expected 1 line for {0} but read in:\n{1}".format(fname, cts))
+        raise IOError(f"Expected 1 line for {fname} but read in:\n{cts}")
 
     return cts[0]
 
@@ -41,7 +41,7 @@ def package_name(fname):
 
     if fname == "VERSION":
         return "CIAO"
-    
+
     elif fname == "contrib/VERSION.CIAO_scripts":
         return "contrib"
 
@@ -49,7 +49,7 @@ def package_name(fname):
         return fname.split("_")[-1]
 
     else:
-        raise ValueError("Unrecognized file name: {0}".format(fname))
+        raise ValueError(f"Unrecognized file name: {fname}")
 
 def doit():
     """Run the code."""
@@ -65,7 +65,7 @@ def doit():
     vbase = glob.glob(ciao + "/VERSION")
     if vbase == []:
         raise IOError("Unable to find $ASCDS_INSTALL/VERSION")
-        
+
     vfiles = glob.glob(ciao + "/VERSION_*")
     if vfiles == []:
         raise IOError("Unable to find $ASCDS_INSTALL/VERSION_*")
@@ -74,15 +74,15 @@ def doit():
     # later
     cfile = glob.glob(ciao + "/contrib/VERSION*")
     if len(cfile) > 1:
-        raise IOError("Expected 1 entry for contrib VERSION file, found: {0}".format(cfile))
+        raise IOError(f"Expected 1 entry for contrib VERSION file, found: {cfile}")
 
     l = len(ciao) + 1
     for vfile in vbase + vfiles + cfile:
         v = read_vfile(vfile)
 
-        print("{0} {1}".format(package_name(vfile[l:]), v))
-    
+        pname = package_name(vfile[l:])
+        print(f"{pname} {v}")
+
 
 if __name__ == "__main__":
     doit()
-    

--- a/share/doc/xml/check_ciao_version.xml
+++ b/share/doc/xml/check_ciao_version.xml
@@ -37,11 +37,11 @@
 	arguments.
       </PARA>
       <PARA title="How do I upgrade my system: ciao-install">
-	If the tool finds that your CIAO or CALDB installations are out
-	of date then it will point you to the
-	<HREF link="https://cxc.harvard.edu/ciao/download/">download CIAO
-	page</HREF>, from which the ciao-install script can be
-	downloaded. This script will perform the necessary updates.
+	If the tool finds that your CIAO or CALDB installations are
+	out of date then it will point you to the <HREF
+	link="https://cxc.harvard.edu/ciao/download/ciao_install.html">ciao-install
+	download page</HREF>, from which the ciao-install script can
+	be downloaded. This script will perform the necessary updates.
       </PARA>
       <PARA title="Limitations">
 	The tool does not
@@ -79,7 +79,7 @@ CIAO (installed via conda) is up to date.
 	  </PARA>
 <VERBATIM>
 There is one package that need updating:
-  ciao-contrib : 4.13.3 -> 4.13.4
+  ciao-contrib : 4.15.2 -> 4.15.3
 
 The update can be checked with:
 
@@ -116,31 +116,31 @@ The CALDB installation at /soft/ciao/CALDB (link to /data/CALDB/ciao) is up to d
 	    something like:
 	  </PARA>
 <VERBATIM>
-The CIAO  installation at /usr/local/ciao-4.3 is up to date.
-The CALDB installation at /usr/local/ciao-4.3/CALDB
-  has version: 4.4.1
-  latest is:   4.4.2
+The CIAO  installation at /usr/local/ciao-4.16 is up to date.
+The CALDB installation at /usr/local/ciao-4.16/CALDB
+  has version: 4.10.5
+  latest is:   4.10.7
 
 Please use the ciao-install script from
-    https://cxc.harvard.edu/ciao/download/
+    https://cxc.harvard.edu/ciao/download/ciao-install.html
 to update your CIAO installation.
 </VERBATIM>
 	  <PARA>
 	    or
 	  </PARA>
 <VERBATIM>
-Using the CIAO installation at /opt/local/ciao-4.3
+Using the CIAO installation at /opt/local/ciao-4.15
 
 The following package:
-    contrib   :  22 Dec 2010
+    contrib   :  21 Jun 2023
 
 needs updating to:
-    contrib   :  05 Apr 2011
+    contrib   :  21 Aug 2023
 
-The CALDB installation at /opt/local/ciao-4.3/CALDB is up to date.
+The CALDB installation at /opt/local/ciao-4.15/CALDB is up to date.
 
 Please use the ciao-install script from
-    https://cxc.harvard.edu/ciao/download/
+    https://cxc.harvard.edu/ciao/download/ciao_install.html
 to update your CIAO installation.
 </VERBATIM>
 
@@ -149,6 +149,13 @@ to update your CIAO installation.
 
     </QEXAMPLELIST>
 
+    <ADESC title="Changes in the scripts 4.16.0 (December 2023) release">
+      <PARA>
+	The script has been updated to support the new version of
+	ciao-install.
+      </PARA>
+    </ADESC>
+    
     <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
       <PARA>
 	When there is an update for a conda installation the script


### PR DESCRIPTION
I am reasonably confident this should still work in CIAO 4.16.