### PR TITLE
initial mamba/micromamba support for check_ciao_version

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -111,6 +111,12 @@ Updated scripts
     infile/sampled background products instead of the 'Merged'-valued
     keywords as a result of using dmmerge.
 
+  check_ciao_version
+
+    The script has been updated to handle the updated ciao-install
+    script and provide initial support for using mamba/micromamba to
+    install CIAO.
+
   convert_xspec_script
 
     Support for the ENERGIES command from XSPEC has been added.

--- a/share/doc/xml/check_ciao_version.xml
+++ b/share/doc/xml/check_ciao_version.xml
@@ -152,7 +152,8 @@ to update your CIAO installation.
     <ADESC title="Changes in the scripts 4.16.0 (December 2023) release">
       <PARA>
 	The script has been updated to support the new version of
-	ciao-install.
+	ciao-install and initial support for using mamba or micromamba
+	to install CIAO.
       </PARA>
     </ADESC>
     


### PR DESCRIPTION
Unfortunately the API we need is not "standardised" so it is a bit annoying to support. Fix #834. Hopefully.