### PR TITLE
added `xpaset` region formatting specification

### DIFF
--- a/bin/ds9_snap2.sh
+++ b/bin/ds9_snap2.sh
@@ -56,7 +56,7 @@ fi
 new=`pget dmstat out_cntrd_phys`
 
 xpaset -p $ds9 regions delete all
-cat $DAX_OUTDIR/$$_all.reg | sed "s/$old/$new/" | xpaset $ds9 regions
+cat $DAX_OUTDIR/$$_all.reg | sed "s/$old/$new/" | xpaset $ds9 regions -format ds9 -system physical
 \rm -f  $DAX_OUTDIR/$$_all.reg
 
 

--- a/bin/ds9_tgcoord.sh
+++ b/bin/ds9_tgcoord.sh
@@ -127,7 +127,7 @@ do
             
             echo "point $ex $ey # "point=circle text="{${energy},L${order}}"
             echo "point $ex $ey # "point=circle text="{${energy},L${order}}" | \
-              xpaset ${ds9} regions
+              xpaset ${ds9} regions -format ds9 -system physical
           
         else # HETG, do both
 
@@ -139,7 +139,7 @@ do
             
             echo "point $ex $ey # "point=circle text="{${energy},H${order}}"
             echo "point $ex $ey # "point=circle text="{${energy},H${order}}" | \
-              xpaset ${ds9} regions
+              xpaset ${ds9} regions format ds9 -system physical
 
             punlearn dmcoords
             dmcoords "${f}" op=cel ra=$razo dec=$deczo energy=$energy order=$order \
@@ -149,7 +149,7 @@ do
             
             echo "point $ex $ey # "point=circle text="{${energy},M${order}}"
             echo "point $ex $ey # "point=circle text="{${energy},M${order}}" | \
-              xpaset ${ds9} regions
+              xpaset ${ds9} regions format ds9 -system physical
 
         fi
 


### PR DESCRIPTION
The `dax` regression tests were failing on a system where the DS9 preference file has region file formatting set to `ciao` rather than the default `ds9`.  The two shell scripts have been modified so that the `xpaset` region calls also specifies the formatting.

The regression tests subsequently run without any further changes on RHEL8 or modifying/deleting the preference file. 

However, on MacOS it seems that the regression test will persist to fail unless `bash` is upgraded to a version > 3 and at this time, the regression test itself may need modification to also set the region formatting for the `xpaset` calls... I'm still exploring this.