### PR TITLE
update tarball build script with the README_CIAO file dropped in 4.16.0

### DIFF
--- a/mk_script_tarfile
+++ b/mk_script_tarfile
@@ -149,7 +149,7 @@ Platform: UNKNOWN
 
     # Copy files over
     #
-    for infile in ["Changes.CIAO_scripts", "README_CIAO_scripts"]:
+    for infile in ["Changes.CIAO_scripts"]: #, "README_CIAO_scripts"]:
         shutil.copy2(infile, str(outdir / infile))
 
     # Create version file


### PR DESCRIPTION
Dropped copying of the README_CIAO file in the tarball build script which has been dropped for the 4.16.0 release.