### PR TITLE
map2reg: combine regions using CXCRegion instead of dumping to ascii file

### DIFF
--- a/bin/map2reg
+++ b/bin/map2reg
@@ -1,4 +1,4 @@
-#!/soft/miniconda/envs/contrib_test/bin/python3.11
+#!/usr/bin/env python
 #
 # Copyright (C) 2019, 2024 Smithsonian Astrophysical Observatory
 #

--- a/bin/map2reg
+++ b/bin/map2reg
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
+#!/soft/miniconda/envs/contrib_test/bin/python3.11
 #
-# Copyright (C) 2019, 2023 Smithsonian Astrophysical Observatory
+# Copyright (C) 2019, 2024 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ from region import CXCRegion
 
 
 __toolname__ = "map2reg"
-__revision__ = "09 September 2023"
+__revision__ = "13 January 2024"
 
 __lgr__ = lw.initialize_logger(__toolname__)
 verb0 = __lgr__.verbose0
@@ -55,7 +55,7 @@ def set_nproc(pars):
         return
 
     if pars["nproc"] == "INDEF":
-        # parallel_map doesn't limit to number of CPU's like 
+        # parallel_map doesn't limit to number of CPU's like
         # taskRunner does so we have to set the actual number
         import multiprocessing
         pars["nproc"] = multiprocessing.cpu_count()
@@ -98,10 +98,14 @@ def get_region(n_at):
 
     lasso_reg = CXCRegion(tmpfile.name)
 
+    if lasso_reg is None or len(lasso_reg) == 0:
+        verb0(f"Warning: {n_at} map is empty")
+
     # CXCRegion object's can't be pickled so we have to pass back the
     # string representation.
 
-    return str(lasso_reg)
+    retval = str(lasso_reg)
+    return retval
 
 
 @lw.handle_ciao_errors(__toolname__, __revision__)
@@ -136,20 +140,12 @@ def main():
     outreg = parallel_map(get_region, uniq_vals,
                           numcores=int(pars["nproc"]))
 
-    # Original version adding CXCRegion objects, but it ended up
-    # consuming a huge amount of memory and was slow.  Writing to
-    # an ASCII region file and then reading back in as a single
-    # CXCRegion is much faster
+    # Unfortunately writing all out to an ascii file sometimes fails
+    # so we go with the more memory intense way:
+    myreg = CXCRegion()
+    for oreg in outreg:
+        myreg += CXCRegion(oreg)
 
-    # Combine into single region file
-    tmpfile = NamedTemporaryFile(dir=os.environ["ASCDS_WORK_PATH"],
-                                 suffix=".reg", delete=True)
-    with open(tmpfile.name, "w") as outfile:
-        for myreg in outreg:
-            outfile.write(myreg+"\n")
-
-    # Write output
-    myreg = CXCRegion(tmpfile.name)
     myreg.write(pars["outfile"], fits=True, clobber=True)
 
     from ciao_contrib.runtool import add_tool_history

--- a/share/doc/xml/map2reg.xml
+++ b/share/doc/xml/map2reg.xml
@@ -121,7 +121,15 @@
             </SYNOPSIS>
         </PARAM>
     </PARAMLIST>
-
+    
+    <ADESC title="Changes in scripts 4.16.1 (Q1 2024) release">
+      <PARA>
+        Internal changes to fix possible crash when dealing with 
+        large regions, eg polygons with many sides.  The tool
+        may require more memory and run slower but should now be more
+        robust.
+      </PARA>    
+    </ADESC>
 
     <ADESC title="About Contributed Software">
       <PARA>
@@ -140,6 +148,6 @@
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>August 2023</LASTMODIFIED>
+    <LASTMODIFIED>January 2024</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Unfortunately need to bite the bullet and combine regions using more memory intensive way.  Reading ASCII region with many sided polygon fails.