### PR TITLE
Merge too small fix

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,3 +1,14 @@
+## 4.16.1 - February 2024
+
+Updated scripts
+
+  merge_too_small
+
+    When using method=counts, it no longer skips regions with 0 counts.
+    Pixels must share an edge to be considered neighbors (so diagonally
+    adjacent pixels are no-longer considered touching).
+
+
 ## 4.16.0 - December 2023
 
 CIAO 4.16 is the first release with native macos ARM support.

--- a/bin/merge_too_small
+++ b/bin/merge_too_small
@@ -44,18 +44,19 @@ def find_neighbors(mask, maskval):
     # For each pixel with a given maskval value
     for ee in zip(xxyy[1], xxyy[0]):
 
-        # Go +/- 1 in Y direction
-        for dy in [ee[1]-1, ee[1], ee[1]+1]:
+        # Go +/- 1 in Y and X directions
+        for dy, dx in [(ee[1]-1, ee[0]),
+                       (ee[1]+1, ee[0]),
+                       (ee[1], ee[0]-1),
+                       (ee[1], ee[0]+1)]:
+
             if dy < 0 or dy >= mask.shape[0]:
                 continue
+            if dx < 0 or dx >= mask.shape[1]:
+                continue
 
-            # Go +/- 1 in the X direction
-            for dx in [ee[0]-1, ee[0], ee[0]+1]:
-                if dx < 0 or dx >= mask.shape[1]:
-                    continue
-
-                if mask[dy, dx] != maskval:
-                    retvals.append(int(mask[dy, dx]))
+            if mask[dy, dx] != maskval and mask[dy, dx] != 0:
+                retvals.append(int(mask[dy, dx]))
 
     retvals = set(retvals)
     return list(retvals)
@@ -67,6 +68,8 @@ def purge_too_small(mask, minarea, counts):
     mask value.  If it is below the threshold then the map value
     is reassigned to the neighbor with the smallest area/counts.
     """
+
+    mask_ids = list(np.unique(mask))
     mask_max = int(np.max(mask))
     skiplist = []   # The list of maskidvals that have been reassigned
 
@@ -78,39 +81,41 @@ def purge_too_small(mask, minarea, counts):
         hh = np.histogram(mask, bins=mask_max, range=(1, mask_max+1),
                           weights=counts)
         area = hh[0]
-        maskid = hh[1][:-1]
+        maskid = hh[1][:-1].astype(int)
 
         am = list(zip(area, maskid))
-        am.sort()
+        am = [x for x in am if x[1] not in skiplist]
+        am = [x for x in am if x[1] in mask_ids]
 
-        am = [x for x in am if x[0] not in skiplist]
-        am = [x for x in am if x[1] in mask]
+        working_on = min(am)
 
-        if am[0][0] > minarea:
+        if working_on[0] > minarea:
             # When all the mapvals are above the threshold we break out
             # and return.
             break
 
-        verb2(f"Working on mask_id {am[0][1]} with value {am[0][0]}")
-        nn = find_neighbors(mask, am[0][1])
-
+        verb2(f"Working on mask_id {working_on[1]} with value {working_on[0]}")
+        nn = find_neighbors(mask, working_on[1])
         if len(nn) == 0:
-            # If area is 0, then skip it.
-            skiplist.append(am[0][1])
+            # If there are no neighbors, then continue
+            mask_ids.remove(working_on[1])
             continue
 
         nn = [i-1 for i in nn]  # convert mapvalue to histogram index
-        zz = list(zip(area[nn], maskid[nn]))
-        zz.sort()
 
+        zz = list(zip(area[nn], maskid[nn]))
         zz = [x for x in zz
-              if (x[1] != am[0][1]) and (x[1] not in skiplist) and (x[1] in mask)]
+              if (x[1] != working_on[1]) and (x[1] not in skiplist) and (x[1] in mask_ids)]
 
         if len(zz) > 0:
-            replace_val = int(zz[0][1])
-            mask[np.where(mask == int(am[0][1]))] = replace_val
+            smallest_index = min(zz)
+            replace_val = int(smallest_index[1])
+            mask[np.where(mask == int(working_on[1]))] = replace_val
+            verb2(f"Replacing {working_on[1]} with {replace_val}")
         else:
-            skiplist.append(am[0][0])  # There are no pixel with this mapval
+            skiplist.append(working_on[1])  # There are no pixel with this mapval
+
+        mask_ids.remove(working_on[1])
 
 
 @lw.handle_ciao_errors(__toolname__, __revision__)
@@ -130,7 +135,7 @@ def main():
 
     import pycrates as pc
     inimg = pc.read_file(pars["infile"])
-    mask = inimg.get_image().values  # mask pointing to data in the crate
+    mask = inimg.get_image().values.astype(int)
 
     if "counts" == pars["method"]:
         counts = pc.read_file(pars["imgfile"]).get_image().values
@@ -141,6 +146,7 @@ def main():
 
     purge_too_small(mask, int(pars["minvalue"]), counts)
 
+    inimg.get_image().values = mask
     pc.write_file(inimg, pars["outfile"], clobber=pars["clobber"])
 
     from ciao_contrib.runtool import add_tool_history

--- a/bin/merge_too_small
+++ b/bin/merge_too_small
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2014-2023 Smithsonian Astrophysical Observatory
+# Copyright (C) 2014-2024 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ import numpy as np
 
 
 __toolname__ = "merge_too_small"
-__revision__ = "24 August 2023"
+__revision__ = "12 January 2023"
 
 import ciao_contrib.logger_wrapper as lw
 verb0 = lw.initialize_logger(__toolname__).verbose0
@@ -82,7 +82,9 @@ def purge_too_small(mask, minarea, counts):
 
         am = list(zip(area, maskid))
         am.sort()
-        am = [x for x in am if x[0] > 0 and x[0] not in skiplist]
+
+        am = [x for x in am if x[0] not in skiplist]
+        am = [x for x in am if x[1] in mask]
 
         if am[0][0] > minarea:
             # When all the mapvals are above the threshold we break out
@@ -102,7 +104,7 @@ def purge_too_small(mask, minarea, counts):
         zz.sort()
 
         zz = [x for x in zz
-              if (x[1] != am[0][1]) and (x[0] > 0) and (x[1] not in skiplist)]
+              if (x[1] != am[0][1]) and (x[1] not in skiplist) and (x[1] in mask)]
 
         if len(zz) > 0:
             replace_val = int(zz[0][1])

--- a/share/doc/xml/merge_too_small.xml
+++ b/share/doc/xml/merge_too_small.xml
@@ -187,6 +187,16 @@
         </PARAM>
     </PARAMLIST>
 
+    <ADESC title="Changes in scripts 4.16.1 (Q1 2024) release">
+      <PARA>
+        When using method=counts, the tool would skip regions with
+        0 counts. This has been fixed.   The tool now only
+        considers pixels that share an edge to be neighbors, instead
+        of treating diagonally touching pixel to be neighbors.  Also
+        some internal speed improvements.
+      </PARA>    
+    </ADESC>
+    
     <ADESC title="About Contributed Software">
       <PARA>
         This script is not an official part of the CIAO release but is
@@ -203,6 +213,6 @@
             website</HREF> for an up-to-date listing of known bugs.
         </PARA>
     </BUGS>
-    <LASTMODIFIED>August 2023</LASTMODIFIED>
+    <LASTMODIFIED>January 2024</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #849 .

Also improves speed, and fixes problem when diagonal neighbors would lead to disjoint polygons (polygons that don't share a side, just a corner).
