### PR TITLE
merge_too_small add join parameter

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -16,7 +16,10 @@ Updated scripts
 
     When using method=counts, it no longer skips regions with 0 counts.
     Pixels must share an edge to be considered neighbors (so diagonally
-    adjacent pixels are no-longer considered touching).
+    adjacent pixels are no-longer considered touching).  Added "join"
+    parameter to allow users to select whether small regions should be
+    merged with adjacent regions with fewest (min) or most (max) 
+    area or counts.
 
 
 ## 4.16.0 - December 2023

--- a/bin/merge_too_small
+++ b/bin/merge_too_small
@@ -22,12 +22,12 @@
 
 import sys
 import numpy as np
-
-
-__toolname__ = "merge_too_small"
-__revision__ = "12 January 2023"
+import pycrates as pc
 
 import ciao_contrib.logger_wrapper as lw
+__toolname__ = "merge_too_small"
+__revision__ = "14 February 2024"
+
 verb0 = lw.initialize_logger(__toolname__).verbose0
 verb1 = lw.initialize_logger(__toolname__).verbose1
 verb2 = lw.initialize_logger(__toolname__).verbose2
@@ -62,7 +62,7 @@ def find_neighbors(mask, maskval):
     return list(retvals)
 
 
-def purge_too_small(mask, minarea, counts):
+def purge_too_small(mask, minarea, counts, joinfunc):
     """
     The idea is to check the area or total counts of each
     mask value.  If it is below the threshold then the map value
@@ -108,14 +108,36 @@ def purge_too_small(mask, minarea, counts):
               if (x[1] != working_on[1]) and (x[1] not in skiplist) and (x[1] in mask_ids)]
 
         if len(zz) > 0:
-            smallest_index = min(zz)
-            replace_val = int(smallest_index[1])
+            join_index = joinfunc(zz)
+            replace_val = int(join_index[1])
             mask[np.where(mask == int(working_on[1]))] = replace_val
             verb2(f"Replacing {working_on[1]} with {replace_val}")
         else:
             skiplist.append(working_on[1])  # There are no pixel with this mapval
 
         mask_ids.remove(working_on[1])
+
+
+def parse_parameters(pars):
+    '''
+    Parse the input parameters that need parsing:
+
+    '''
+    if "counts" == pars["method"]:
+        counts = pc.read_file(pars["imgfile"]).get_image().values
+    elif "area" == pars["method"]:
+        counts = None
+    else:
+        raise ValueError("Unknown value for method parameter")
+
+    if "min" == pars["join"]:
+        joinfunc = min
+    elif "max" == pars["join"]:
+        joinfunc = max
+    else:
+        raise ValueError("Unknown value for join parameter")
+
+    return counts, joinfunc
 
 
 @lw.handle_ciao_errors(__toolname__, __revision__)
@@ -133,18 +155,12 @@ def main():
     outfile_clobber_checks(pars["clobber"], pars["outfile"])
     outfile_clobber_checks(pars["clobber"], pars["binimg"])
 
-    import pycrates as pc
     inimg = pc.read_file(pars["infile"])
     mask = inimg.get_image().values.astype(int)
 
-    if "counts" == pars["method"]:
-        counts = pc.read_file(pars["imgfile"]).get_image().values
-    elif "area" == pars["method"]:
-        counts = None
-    else:
-        raise ValueError("Unknown value for method parameter")
+    counts, joinfunc = parse_parameters(pars)
 
-    purge_too_small(mask, int(pars["minvalue"]), counts)
+    purge_too_small(mask, int(pars["minvalue"]), counts, joinfunc)
 
     inimg.get_image().values = mask
     pc.write_file(inimg, pars["outfile"], clobber=pars["clobber"])

--- a/ciao_contrib/runtool.py
+++ b/ciao_contrib/runtool.py
@@ -3356,7 +3356,7 @@ parinfo['merge_obs'] = {
 parinfo['merge_too_small'] = {
     'istool': True,
     'req': [ParValue("infile","f","Input map",None),ParValue("outfile","f","Output map",None)],
-    'opt': [ParSet("method","s","Apply minval threshold to area of region or counts in region?",'counts',["counts","area"]),ParValue("imgfile","f","Input counts image file, required for method=counts",None),ParValue("binimg","f","Optional output image file",None),ParRange("minvalue","i","Minimum counts or area (logical pixels)",0,0,None),ParRange("verbose","i","Tool chatter level",0,0,5),ParValue("clobber","b","Remove outfile if it already exists?",False)],
+    'opt': [ParSet("method","s","Apply minval threshold to area of region or counts in region?",'counts',["counts","area"]),ParValue("imgfile","f","Input counts image file, required for method=counts",None),ParValue("binimg","f","Optional output image file",None),ParRange("minvalue","i","Minimum counts or area (logical pixels)",0,0,None),ParSet("join","s","Join deficient region with which neighbor?",'min',["min","max"]),ParRange("verbose","i","Tool chatter level",0,0,5),ParValue("clobber","b","Remove outfile if it already exists?",False)],
     }
 
 

--- a/param/merge_too_small.par
+++ b/param/merge_too_small.par
@@ -4,6 +4,7 @@ method,s,h,"counts","counts|area",,"Apply minval threshold to area of region or 
 imgfile,f,h,"",,,"Input counts image file, required for method=counts"
 binimg,f,h,"",,,"Optional output image file"
 minvalue,i,h,0,0,,"Minimum counts or area (logical pixels)"
+join,s,h,min,min|max,,"Join deficient region with which neighbor?"
 verbose,i,h,0,0,5,"Tool chatter level"
 clobber,b,h,no,,,"Remove outfile if it already exists?"
 mode,s,h,"ql",,,

--- a/share/doc/xml/merge_too_small.xml
+++ b/share/doc/xml/merge_too_small.xml
@@ -16,19 +16,21 @@
         may contain small, insignificant groups which were 
         the result of filling in the gaps between neighboring 
         groups.  The merge_too_small script reassigns these
-        small regions to the largest neighbor.  The 
+        small regions to the smallest neighbor (by default).  The 
         script will identify groups with a small geometric
         area (ie few pixels), or with low number of counts 
         (requires imgfile be supplied).
         </PARA>
         <PARA>
-        The deficient groups are always merged in to the 
-        largest neighboring group; where largest is the 
-        same metric (largest area or largest counts).
+        The deficient groups are merged in to the 
+        smallest neighboring group by default; where smallest is the 
+        same metric (smallest area or fewest counts).  The join parameter
+        can be used to change the logic and assign deficient groups to the
+        largest neighboring group.
         </PARA>
         <PARA>
         The output is a new map file with the deficient 
-        regions pixel values replaced with the largest neighbor.
+        regions pixel values replaced with the largest or smallest neighbor.
         </PARA>
         <PARA>
         With method=area, the minvalue is the minimum number of image 
@@ -81,6 +83,21 @@
             most counts.
             The imgfile, img.fits, must be supplied so
             we can obtain the counts.
+            </PARA>
+          </DESC>
+        </QEXAMPLE>
+        <QEXAMPLE>
+          <SYNTAX>
+            <LINE>
+            % merge_too_small scales_min10px.map scales_min10px+100cts_min.map join=max method=counts minvalue=100 imgfile=img.fits
+            </LINE>
+          </SYNTAX>
+          <DESC>
+            <PARA>
+            This is the same as the previous example with the addition of
+            setting the parameter join=max.  With this change, deficient
+            groups are assigned to the largest adjacent neighbor rather
+            than the largest.
             </PARA>
           </DESC>
         </QEXAMPLE>
@@ -175,6 +192,18 @@
             </DESC>
         </PARAM>
 
+        <PARAM name="join" type="string" def="min">
+            <SYNOPSIS>Logic to use when joining neighboring groups</SYNOPSIS>
+            <DESC>
+                <PARA>
+                With join=min (default), deficient groups are assigned
+                to the smallest adjacent neighbor (using the same counts or
+                area metric determined by the method parameter).  With join=max,
+                deficient groups are assigned to the largest adjacent neighbor.
+                </PARA>            
+            </DESC>
+        </PARAM>
+
         <PARAM name="verbose" type="integer" def="1" min="0" max="5">
             <SYNOPSIS>
             Amount of chatter from the tool.
@@ -188,12 +217,25 @@
     </PARAMLIST>
 
     <ADESC title="Changes in scripts 4.16.1 (Q1 2024) release">
-      <PARA>
+      <PARA title="Zero counts">
         When using method=counts, the tool would skip regions with
-        0 counts. This has been fixed.   The tool now only
+        0 counts. This has been fixed.  
+      </PARA>
+      <PARA title="join parameter">
+        Added the join parameter to control the logic to use when
+        assigning small regions to neighbors: largest neighbor (max)
+        or smallest neighbor (min, default).  The help file for the
+        initial release of the tool indicated that it was using the
+        join=max logic; however, the actual code was using the
+        equivalent of the join=min logic.
+      </PARA>
+      <PARA title="Neighbor Rules">
+         The tool now only
         considers pixels that share an edge to be neighbors, instead
-        of treating diagonally touching pixel to be neighbors.  Also
-        some internal speed improvements.
+        of treating diagonally touching pixel to be neighbors. 
+      </PARA>
+      <PARA title="Performance">
+        Some internal changes to improve runtime speed.
       </PARA>    
     </ADESC>
     


### PR DESCRIPTION
This closes #857 

Users can now select whether to combine deficient groups with the smallest (min) or largest (max) neighbor.  Default set to min to match existing **code**.  The existing docs were wrong.  Doing some testing, it's easy to see why max is not a good default since.  Consider a case where lots of deficient groups are clustered together.  With max, they will all tend to coalesce into a single mega group whereas with min they will tend to cluster into several smaller groups that just exceed the threshold.  Of course the single mega group may be what some folks want -- that's why we added it as an option.

 