### PR TITLE
bkg_fixed_counts: fix for null srcreg

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -26,6 +26,11 @@ Updated scripts
     merged with adjacent regions with fewest (min) or most (max) 
     area or counts.
 
+  srcflux
+  
+    Fixed a problem using the new optimized source region option
+    when source positions are located outside the field-of-view.
+    
 
 ## 4.16.0 - December 2023
 

--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,6 +1,11 @@
-## 4.16.1 - February 2024
+## 4.16.1 - April 2024
 
 Updated scripts
+
+  bkg_fixed_counts
+  
+    Fix the case when the input source regions are NULLs (eg when the 
+    source region is outside the field-of-view).
 
   centroid_map
 

--- a/bin/bkg_fixed_counts
+++ b/bin/bkg_fixed_counts
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2022, 2023 Smithsonian Astrophysical Observatory
+# Copyright (C) 2022-2024 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ import ciao_contrib.logger_wrapper as lw
 
 
 toolname = "bkg_fixed_counts"
-__revision__ = "27 March 2023"
+__revision__ = "28 March 2024"
 
 lw.initialize_logger(toolname)
 verb0 = lw.get_logger(toolname).verbose0
@@ -98,6 +98,10 @@ def make_swiss_cheese(coords, src_region_list):
         srcregs = CXCRegion()
         for src_file in src_stk:
             src = CXCRegion(src_file)
+
+            # skip if srcreg is null
+            if len(src) == 0:
+                continue
 
             # Why [0]?  (See long comment in psf_contour re:
             # region area and FOV boundaries.

--- a/bin/psf_contour
+++ b/bin/psf_contour
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2022-2023 Smithsonian Astrophysical Observatory
+# Copyright (C) 2022-2024 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ MIN_FRACTION = 0.6
 FRACTION_STEP = 0.1
 
 toolname = "psf_contour"
-__revision__ = "26 September 2023"
+__revision__ = "29 March 2024"
 
 lw.initialize_logger(toolname)
 verb0 = lw.get_logger(toolname).verbose0
@@ -421,7 +421,7 @@ def get_positions(params):
 
 def shrink_psfs(first_psf, second_psf):
     'We shrink the PSFs until the area of the overlapping regions is 0'
-    verb1(f"Shrinking regions for {first_psf.params['outroot']} and {first_psf.params['outroot']}")
+    verb1(f"Shrinking regions for {first_psf.params['outroot']} and {second_psf.params['outroot']}")
 
     keep_going = True
     while keep_going:

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2013-2023 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013-2024 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 #
 
 toolname = "srcflux"
-__revision__ = "02 November 2023"
+__revision__ = "29 March 2024"
 
 import os
 
@@ -207,6 +207,8 @@ def make_optimized_regions(myparams):
     with open(src_list, "w") as fptr:
         for reg_file in out_lis:
             reg = CXCRegion(reg_file)
+            if len(reg) == 0:
+                reg = "point(0,0)"
             fptr.write(str(reg)+"\n")
 
     # For background we use broad band (ACIS) to determine the number

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -2995,6 +2995,10 @@ def check_parameters( myparams ):
                 raise ValueError("Cannot locate HRC dead time factors file.  Please specify 'dtffile' parameter.")
         elif "none" == myparams.dtffile.lower():
             verb0("\nWARNING: dead time factors file parmater set to 'none'; DTF information will not be use.  This may lead to inaccuracies in the results\n")
+    
+    if myparams.regions == "optimized" and myparams.psfmethod == "quick":
+        raise ValueError("ERROR: Invalid parameter combination. psfmethod=quick requires circular source regions, however, regions=optimized creates polygon shaped regions. These two options cannot be used together.")
+
 
 def check_nom_keywords(evt_files):
     """If there is more than 1 event files, then they must have the 

--- a/share/doc/xml/bkg_fixed_counts.xml
+++ b/share/doc/xml/bkg_fixed_counts.xml
@@ -285,6 +285,14 @@ inner 95% ECF region.
 
     </PARAMLIST>
 
+    <ADESC title="Changes in scripts 4.16.1 (April 2024) release">
+      <PARA>
+        Fixed an issue when the stack of input source regions contains
+        empty/NULL regions; for example when a source region is
+        entirely outside the field-of-view. 
+      </PARA>
+    </ADESC>
+
 
   <ADESC title="Changes in scripts 4.15.2 (April 2023) release">
     <PARA>
@@ -319,7 +327,7 @@ inner 95% ECF region.
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>March 2023</LASTMODIFIED>
+    <LASTMODIFIED>March 2024</LASTMODIFIED>
 
 
   </ENTRY>

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -2523,6 +2523,13 @@ for a detailed example.
 
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.16.1 (April 2024) release">
+        <PARA>
+        Fixed a bug when using the new optimized region option when
+        the source position is outside the field-of-view of the observation(s).
+        </PARA>    
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.16.0 (December 2023) release">
       <PARA title="New 'regions' parameter">
         The regions parameter has been added.  It allows the user to select 

--- a/share/doc/xml/srcflux.xml
+++ b/share/doc/xml/srcflux.xml
@@ -2841,6 +2841,6 @@ for a detailed example.
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>September 2023</LASTMODIFIED>
+    <LASTMODIFIED>March 2024</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
From helpdesk ...

running bkg_fixed_counts with a stack of source regions; where some/any of those regions are NULLs (ie FITS region files w/ 0 rows) the script would error out with an index array error.

This fix adds a check that there is at least 1 shape before accessing the first shape.
