### PR TITLE
removed an extraneous whitespace

### DIFF
--- a/bin/specextract
+++ b/bin/specextract
@@ -2478,7 +2478,7 @@ cannot contain any spaces")
 
 
 
-if __name__  == "__main__":
+if __name__ == "__main__":
     run_specextract(sys.argv)
     # import timeit
     # runtime = timeit.timeit(lambda:run_specextract(sys.argv), number=1)

--- a/bin/specextract
+++ b/bin/specextract
@@ -1061,7 +1061,7 @@ def resp_setup(args,asphist,rmftool):
 
                 sky2tdet()
 
-                # genearte clipped WMAP to speed up response generation
+                # generate clipped WMAP to speed up response generation
                 if wmap_clip:
                     clip_wmap(tdetwmap,wmap_thresh,tmpdir)
 

--- a/ciao_contrib/_tools/specextract.py
+++ b/ciao_contrib/_tools/specextract.py
@@ -27,7 +27,7 @@ Routines to support the specextract tool.
 
 __modulename__ = "_tools.specextract"
 __toolname__ = "specextract"
-__revision__ = "13 November 2023"
+__revision__ = "8 July 2024"
 
 import os
 import sys
@@ -1341,7 +1341,7 @@ and/or background files. Assuming source and background file lists have a matchi
             ewmap_range_check = args["ewmap_range_check"]
 
             try:
-                if not weights_check:
+                if isinstance(weights_check,bool) and not weights_check:
                     return self._check_event_stats(file,
                                                    refcoord_check=refcoord_check,
                                                    weights_check=False)

--- a/ciao_contrib/_tools/specextract.py
+++ b/ciao_contrib/_tools/specextract.py
@@ -443,7 +443,7 @@ data with chandra_repro or add the keywords to the event file(s) with r4_header_
         if counts == "0":
             try:
                 if refcoord_check.lower() in ["","none","indef"]:
-                    raise IOError(f"{file} has zero counts. Check that the region correct (e.g. wrong region, coordinates not in sky pixels or degrees) or use parameter='refcoord'.")
+                    raise IOError(f"{file} has zero counts. Check that the region formatting is correct (e.g. wrong region, coordinates not in sky pixels or degrees) or use the 'refcoord' parameter.")
 
                 if weights_check:
                     v1("WARNING: Unweighted responses will be created at the 'refcoord' position.\n")


### PR DESCRIPTION
take it or leave it for 4.16.1; just noticed extra whitespace preceding a `==`