### PR TITLE
Chandra repro obc mode update

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "07 April 2024"
+version = "07 May 2024"
 
 # import standard python modules as required
 #
@@ -1564,7 +1564,9 @@ def r4_header_update(params):
     from ciao_contrib.runtool import r4_header_update
 
     r4_header_update.punlearn()
-    r4_header_update.infile=params["evt1_file"]
+    r4_header_update.infile = params["evt1_file"]
+    r4_header_update.pbkfile = params["pbk0_file"] if "pbk0_file" in params else ""
+    r4_header_update.asolfile = "@"+params["asol1_file"]
     out=r4_header_update()
 
     if out:

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -770,17 +770,21 @@ def event1_inputs(params):
             params["dec_targ"] = keys["DEC_TARG"].value
 
             # Only standard datasets taken in KALMAN lock are supported.
-            # Other modes such as OBC use the on-board-computer
+            # Other modes such as OBC use the on-board-computer 
             # aspect solution and don't have *_asol1.fits files. They
             # only have the *_osol1.fits files.  We can't handle that
             # right now.
-
+            
             if 'KALMAN' != keys["ASPTYPE"].value:
-                msg = "ASPTYPE='{}' mode data is not currently supported."
-                raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
+                #msg = "ASPTYPE='{}' mode data is not currently supported."
+                #raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
+                params["__obc_mode__"] = True
+                v0("\nThis observation did not use any guide-stars; the on-board-computer determined aspect solution will be used\n")
 
+            else:
+                params["__obc_mode__"] = False
 
-            if params["instrume"] == 'ACIS':
+            if params["instrume"] == 'ACIS':  
                 params["readmode"] = keys["READMODE"].value
             if params["instrume"] == 'HRC':
                 try:
@@ -987,7 +991,11 @@ def get_inputs(params):
     #!### Now check for secondary data products to use ###
     try:
         secondary_products=os.listdir(params["secondarydir"])
-    except:
+        if params["__obc_mode__"] is True:
+            asp_sec = os.path.join( params["secondarydir"],"aspect")
+            asp_sec_dir = os.listdir( asp_sec )
+            secondary_products.extend( asp_sec_dir)
+    except Exception as e:
         error_out(params,"Could not read input directory '%s'" % params["secondarydir"], 'read error')
 
     v2("Using products found in secondary data directory: " + params["secondarydir"])
@@ -1112,7 +1120,7 @@ def get_inputs(params):
 
                 path=os.path.join(params["outdir"], os.path.basename(newbias))
                 link_or_copy(newbias, path)
-
+  
                 uff=ff.split(".gz")[0]
                 params["cleanup_files"].append(os.path.join(params["outdir"], uff))
 
@@ -1134,6 +1142,44 @@ def get_inputs(params):
             biaslist.write(newbias + '\n')
             biaslist.close()
 
+        elif params["__obc_mode__"] is True and re.search(".*osol1.fits.*",ff) is not None:
+            #
+            # For OBC mode, we look for the osol files and use them for the asol
+            #
+            params["asol1_file"] = os.path.join(params["outdir"], params["root"] + '_asol1.lis')
+
+            if reset_asol_list:
+                datestamp_existing_file(params["asol1_file"])
+                reset_asol_list=0
+
+            sec_asp_dir = os.path.join( params["secondarydir"], "aspect")
+            if indir_is_outdir:
+                newasol = os.path.basename(gunzip(ff))
+            else:
+                newasol = gunzip(os.path.join( sec_asp_dir,ff))
+
+                path=os.path.join(params["outdir"], os.path.basename(newasol))
+                link_or_copy(newasol, path)
+                
+            #!### always make sorted asol list ###
+            if os.path.isfile(params["asol1_file"]):
+                #!### Just append to existing list ###
+                try:
+                    asollist = open(params["asol1_file"],'a')
+                except:
+                    error_out(params,"Could not open list file '%s'" % params["asol1_file"], 'read error')
+            else:
+                #!### Create list ###
+                try:
+                    asollist = open(params["asol1_file"], 'w')
+                except:
+                    error_out(params,"Could not create list file '%s'" % params["asol1_file"], 'write error')
+                        
+            #!### In both cases above we write current file to list ###
+            asollist.write(newasol + '\n')
+            asollist.close() 
+
+            check_name_in_hdr( "asol1", newasol, params["hdr_asolfile"] )
 
     # Look for the V&V report in the top level indir
 
@@ -2082,8 +2128,20 @@ def get_asol_times( params ):
 
     outroot = os.path.join( params["outdir"], params["root"])
 
-    dmtcalc( params["flt1_file"], outroot+"_addcol_flt1.fits", "time=0", clobber=params["clobber"])
-    dmcopy( dmtcalc.outfile+"[time={}:{}]".format(min_a,max_a), outroot+"_repro_flt1.fits", clobber=params["clobber"] )
+
+    if params["__obc_mode__"] is True:
+        new_limits = outroot+"_obc_lim1.fits"
+        new_gti = outroot+"_repro_flt1.fits"
+
+        filter_obc_gti_limit( params["mtl1_file"], new_limits, clobber=params["clobber"])
+        make_new_obc_gti( params["mtl1_file"], new_limits, new_gti, clobber=params["clobber"])
+        params["cleanup_files"].append(new_limits)
+
+    else:
+        dmtcalc( params["flt1_file"], outroot+"_addcol_flt1.fits", "time=0", clobber=params["clobber"])    
+        dmcopy( dmtcalc.outfile+"[time={}:{}]".format(min_a,max_a), outroot+"_repro_flt1.fits", clobber=params["clobber"] )
+
+
 
     # CC times cannot be fixed with the gti_align script since times are
     # affected by _TARG coordinates.
@@ -2098,6 +2156,120 @@ def get_asol_times( params ):
 
 
     return outroot+"_repro_flt2.fits"
+
+
+
+
+def filter_obc_gti_limit( mtlfile, outlimfile, clobber=True ):
+    """Filters the LIMITS block of the mission time line file
+    to remove the limits associated with OBC (on-board-computer)
+    mode.
+    
+    The LIMITS extension is just a single string column in the mtl1.fits
+    file.  Each row is a separate limit.  The 'limit_status' column
+    in the MTL_S extension of the mtl1.fits file maps to the LIMITS block.
+    Each bit in the limit_status maps to a row.  Here we count
+    bits left-to-right starting at 1. [Ugh!]
+    
+    So if we have
+    
+    % dmlist "acisf02469_001N004_mtl1.fits[mtl_s][cols limit_status][#row=1]" data,clean
+    #  limit_status[3]
+                                                     01000000000000000010000
+
+    we see that bits #2 and bits #19 are set.  Looking at the LIMITS blocks we see
+
+    % dmlist "acisf02469_001N004_mtl1.fits[limits][#row=2,19]" data,clean
+    #  gti_limits
+    (fabs(Point_MoonLimbAng:1)>=6.0)
+    (ASPTYPE:1!="OBC") 
+
+    We want to remove these limits -- but we can't rely on the row numbers.
+    We need to check (regex) the contents of each line to look for the lines
+    to remove.    
+    """
+
+    from re import search
+    from pycrates import read_file
+
+    def is_point_limbang( limit ):
+        """Remove the Earth, Sun, Moon limb angle pointing limits.
+        We could try to be clever here and pick the right one, 
+        but its just as easy to remove them all"""
+        if search('point_.*limbang', limit) is None:
+            return False
+        return True
+
+
+    def is_asptype( limit ):
+        """Remove the check on ASPTYPE"""
+        if search( 'asptype.*=.*obc.*', limit) is None:
+            return False
+        return True
+
+
+    def obc_limits( limit ):
+        """Combine the two limit checks above"""
+        ul = limit.lower()
+        return (is_point_limbang(ul) or is_asptype(ul))
+
+
+    limits = read_file(mtlfile+"[limits]").get_column("gti_limits").values
+    mod_limits = [ l for l in limits if obc_limits(l) is False]
+
+    write_new_limits( mod_limits, outlimfile, clobber)
+
+    
+
+def write_new_limits( mod_limits, outlimfile, clobber=True ):
+    """Write the output limits file.  We don't need all the
+    header meta data, just the single column with the 
+    subset of the filter strings"""
+
+    from crates_contrib.utils import write_columns
+    write_columns( outlimfile, mod_limits, format="fits", clobber=clobber, colnames=["gti_limits"])
+
+
+def make_new_obc_gti( mtlfile, outlimfile, outgtifile, clobber=True):
+    """Compute the new GTI; write out new filter 
+    """
+    from ciao_contrib.runtool import make_tool
+    dmgti = make_tool("dmgti")
+    dmgti.infile=mtlfile
+    dmgti.outfile=outgtifile
+    dmgti.mtlfile=""
+    dmgti.userlimit=""  # The limits are input via the lkupfile parameter
+    dmgti.lkupfile=outlimfile
+    vv = dmgti( clobber=clobber)
+    if (vv): v3(vv)
+
+    summarize_results( outgtifile)
+
+
+    
+def summarize_results(outgtifile):
+    """Show a summary of the GTI information"""
+    from pycrates import read_file
+    gti=read_file(outgtifile)
+    ontime = gti.get_key_value("ONTIME")
+    dss = gti.get_subspace_data(1, "TIME")
+    num_gti = len( dss.range_max)
+    msg="Total recovered OBC ONTIME={:.2f}ks in {} time interval(s)"
+    v1(msg.format( ontime/1000.0, num_gti))
+    
+
+    
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010-2022  Smithsonian Astrophysical Observatory
+# Copyright (C) 2010-2024  Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "22 January 2023"
+version = "07 April 2024"
 
 # import standard python modules as required
 #
@@ -2787,7 +2787,7 @@ def process_sso(pars, is_gratings=False):
     Run sso_freeze to add solar system object coordinates to the 
     event file and the aspect solution file.    
     """
-    from ciao_contrib.runtool import sso_freeze
+    from ciao_contrib.runtool import sso_freeze, dmmerge
 
     sso_eph = pars["sso_file"]
     if sso_eph is None:
@@ -2802,27 +2802,43 @@ def process_sso(pars, is_gratings=False):
 
     evt1=pars[evt]
     eph1=pars["eph1_file"]
-    asol1="@"+pars["asol1_file"]
+
         
     if len(eph1) == 0:
         v0("WARNING: Could not find definitive orbit ephemeris file, orbit*eph1.fits, skipping sso_freeze")
+        return
 
     tab = pyc.read_file(sso_eph)
     obj = tab.get_key_value("OBJECT")        
     v1("\nRunning sso_freeze to add solar system coordinates for object: "+obj)
+    
+    asol1="@"+pars["asol1_file"]
+    dmmerge.punlearn()
+    dmmerge.infile = asol1
+    dmmerge.outfile = os.path.join(pars["outdir"], pars["root"] + '_tmp_asol1.fits')
+    out = dmmerge()
+    v5(out)
+    pars["cleanup_files"].append(dmmerge.outfile)
     
     out_asol1 = os.path.join(pars["outdir"], pars["root"] + '_repro_sso_asol1.fits')
 
     sso_freeze.infile = evt1
     sso_freeze.scephemfile = eph1
     sso_freeze.ssoephemfile = sso_eph
-    sso_freeze.asolfile = asol1
+    sso_freeze.asolfile = dmmerge.outfile
     sso_freeze.outfile = out_evt1
     sso_freeze.ocsolfile = out_asol1
     sso_freeze.clobber = pars["clobber"]
     sso_freeze.verbose = pars["verbose"]
-    out = sso_freeze()
-    
+
+    try:
+        out = sso_freeze()
+        pars[evt] = out_evt1
+    except Exception as failed:
+        v0("WARNING: Could not run sso_freeze to compute solar system centered coordinates; skipping it. Error message:")
+        v0(str(failed))
+        return
+        
     v5("sso_freeze returned")
     v5(out)
     

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -191,6 +191,11 @@ def filter_aspsolobi_from_aspsol(asol_list,mydir,params):
             v1("No boresight correction update to asol file is needed.")
         return content_values["ASPSOLOBI"]
 
+    if "OBCSOL" in content_values:
+        if params["asol_update"]:
+            v1("No boresight correction update to asol file is needed.")
+        return content_values["OBCSOL"]
+
     if "ASPSOL" in content_values:
         new_asol = update_aspsol_to_aspsolobi(content_values["ASPSOL"], 
                                               mydir, params)
@@ -1051,7 +1056,7 @@ def get_inputs(params):
             check_name_in_hdr( "msk1", params["msk1_file"], params["hdr_maskfile"] )
 
         ### find ACIS mtl files ###
-        elif params["instrume"] == 'ACIS' and re.search(".*"+cycle+"mtl1.fits.*",ff):
+        elif re.search(".*"+cycle+"mtl1.fits.*",ff):
 
             if params["mtl1_file"]:
                 error_out(params,"Multiple input mtl1 files found, please select one and restart. If this is a multi-obi OBS_ID, try running the splitobs script first.",'input error')
@@ -1212,6 +1217,8 @@ def get_inputs(params):
         error_out(params,"Could not locate pbk0 fits file in: " + params["secondarydir"],'input error')
     if not os.path.isfile(params["bias0_file"]) and params["instrume"] == 'ACIS' and params["badpixel"] == True:
         error_out(params,"Could not locate bias0 fits file in: " + params["secondarydir"],'input error')
+    if not os.path.isfile(params["mtl1_file"]) and params["__obc_mode__"] is True:
+        error_out(params,"Could not locate mtl1 fits file in OBC mode")
 
     #!### Verify asol1 list exists and is in chronological order ###
     v5("Asol1 file before verify list: " + params["asol1_file"])
@@ -2729,7 +2736,8 @@ def choose_skyfov_method( asolfiles ):
     from pycrates import read_file
     import stk as stk
 
-    skyfov_choices={ 'ASPSOLOBI' : 'convexhull' , 'ASPSOL' : 'minmax' }
+    skyfov_choices={ 'ASPSOLOBI' : 'convexhull' , 'ASPSOL' : 'minmax',
+                     'OBCSOL': 'minmax'}
     if asolfiles is None: 
         return skyfov_choices["ASPSOL"]
 

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -820,6 +820,25 @@ tg_zo_position="5:35:15.7594,-5:23:10.191"
       </PARAM>
     </PARAMLIST>
 
+<ADESC title="Changes in the scripts 4.16.2 (Q2/3) release">
+  <PARA title="On Board Computer (OBC) mode">
+    Some observations, mostly of either the Earth or the Moon, were
+    done without using the aspect camera to determine attitude and pointing.
+    These observations rely on the On Board Computer (OBC) aspect 
+    solution, osol1.fits.  This update allows chandra_repro to use the
+    OBC solution files for these observations.  
+  </PARA>
+  <PARA title="Solar System Objects">
+    This fixes a problem with some solar system objects, including
+    the OBC mode objects, that have multiple aspect solution files;
+    they must be merged into a single file before running sso_freeze.
+    This change also makes a failure in sso_freeze non-fatal. The
+    rest of the event processing will proceed if sso_freeze is unable to
+    compute object-centered coordinates. This happens for most of the EARTH
+    observations. 
+  </PARA>
+</ADESC>
+
 <ADESC title="Changes in the scripts 4.15.0 (December 2022) release">
   <PARA>
     A problem when multiple SSO eph1 files are found has been
@@ -1303,6 +1322,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2022</LASTMODIFIED>
+    <LASTMODIFIED>April 2024</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -837,6 +837,12 @@ tg_zo_position="5:35:15.7594,-5:23:10.191"
     compute object-centered coordinates. This happens for most of the EARTH
     observations. 
   </PARA>
+  <PARA title="Fix for older datasets">
+    Internal change to how the r4_header_update script is run to 
+    deal with observations that are missing the "*FILE" keywords needed
+    to automatically locate the parameter block file and aspect solution
+    file(s).
+  </PARA>
 </ADESC>
 
 <ADESC title="Changes in the scripts 4.15.0 (December 2022) release">
@@ -1322,6 +1328,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>April 2024</LASTMODIFIED>
+    <LASTMODIFIED>May 2024</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Changes to allow chandra_repro to process OBC mode observations. This will close #59 

There are two parts
- Find/use the `secondar/aspect/*osol1.fits` files instead of the `primary/*asol1.fits` files 
- Create a new GTI (`flt1`) file that omits the limits on the Earth/Sun/Moon pointing angles (most OBC are either Earth or Moon observations), and omits the `asptype != obc`. 

There is a secondary bug fix in the `sso_freeze` thread that will now `dmmerge` the aspect solution files together.  This isn't really needed for the non OBC case since there is now only 1 aspect solution file per obi; but in the OBC case there may be multiple osol files and the need to be combined before running sso_freeze.