### PR TITLE
download_chandra_obsid: fix GET command when downloading from mirror

### DIFF
--- a/ciao_contrib/downloadutils.py
+++ b/ciao_contrib/downloadutils.py
@@ -780,7 +780,7 @@ def download_progress(url, size, outfile,
     headers['Range'] = 'bytes={}-{}'.format(startfrom, size - 1)
 
     time0 = time.time()
-    conn.request('GET', url, headers=headers)
+    conn.request('GET', purl.path, headers=headers)
     with conn.getresponse() as rsp:
 
         # Assume that rsp.status != 206 would cause some form


### PR DESCRIPTION
This fixes #773 

The fix is to change the `GET` argument.  Instead of `GET`ting the fully qualified URL, we just need to get the `.path`.  The `conn` object has already opened the connection to the server -- irregarless if it is to CDA or to MIRROR_SITE.   The change to use `purl.path` works both with CDA and MIRROR_SITE. 

I'm actually kinda surprised that the CDA server is returning right file even with the "wrong" path .. but our web servers are ... well, let's say ... _creatively configured_ :tm:.  