### PR TITLE
cgs: fix problem with PHAII files that do not contain background spectra

### DIFF
--- a/bin/combine_grating_spectra
+++ b/bin/combine_grating_spectra
@@ -178,15 +178,22 @@ def split_II_to_I( instk, arfs, rmfs, outroot, verbose, clobber ):
         outs = [delme(x) for x in glob.glob( tmproot+"_?eg_??.pha")]
         bkgs = [delme(x) for x in glob.glob( tmproot+"_?eg_??_bkg.pha")]
 
+        outs.sort()
         retsrc.extend(outs)
 
         if ( 0 == len(bkgs) ):
             retbkg.extend([None]*len(outs))
-        else:
+        elif len(bkgs) == len(outs):
+            bkgs.sort()
             retbkg.extend(bkgs)
-            retbkg.sort()
+        else:  # should never happen but just in case
+            raise IOError("Mismatch in number of source and background PHA files")
 
-    retsrc.sort()
+    for sss,bbb in zip(retsrc,retbkg):
+        if bbb:
+            sroot = sss.rstrip(".pha")
+            broot = bbb.rstrip("_bkg.pha")
+            assert sroot == broot, "Something is messed up in sort/bkg matching"
 
     return retsrc,retbkg
 

--- a/bin/combine_grating_spectra
+++ b/bin/combine_grating_spectra
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # 
-# Copyright (C) 2013,2014,2016,2018,2019, 2022 
+# Copyright (C) 2013,2014,2016,2018,2019,2022,2024 
 # Smithsonian Astrophysical Observatory
 # 
 # This program is free software; you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 # 
 
 toolname = "combine_grating_spectra"
-__revision__ = "25 February 2022"
+__revision__ = "17 April 2024"
 
 from pycrates import read_file
 import stk
@@ -184,9 +184,9 @@ def split_II_to_I( instk, arfs, rmfs, outroot, verbose, clobber ):
             retbkg.extend([None]*len(outs))
         else:
             retbkg.extend(bkgs)
-    
+            retbkg.sort()
+
     retsrc.sort()
-    retbkg.sort()
 
     return retsrc,retbkg
 

--- a/share/doc/xml/combine_grating_spectra.xml
+++ b/share/doc/xml/combine_grating_spectra.xml
@@ -750,6 +750,13 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
 </ADESC>
 
 
+    <ADESC title="Changes in the scripts 4.16.2 (Q2/Q3 2024) release">
+      <PARA>
+        Fix a bug when trying to combine PHA2 files that do not contain
+        background spectra.
+      </PARA>    
+    </ADESC>
+
   <ADESC title="Changes in the scripts 4.14.2 (April 2022) release">
     <PARA>
         The final output files now have "_combo_" appended to the output
@@ -812,7 +819,7 @@ SOURCE_BACKSCAL = (src_exp1*src_backscal1) + ... + (src_expN*src_backscalN) / (s
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2022</LASTMODIFIED>
+    <LASTMODIFIED>April 2024</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes problem reported in CXC hd ticket 25247.

The tgcat PHA2 files don't always have background spectra.  The script handles this case mostly ok, but is failing when it tries to .sort() a list with all `None`s.   Not sure if this a change in python behavior, but trivial to fix.  (Only sort if values are not `None`).

