### PR TITLE
chandra_repro: tweak for pre-repro3 (very early mission) data

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010-2022  Smithsonian Astrophysical Observatory
-#
-#
+# Copyright (C) 2010-2022, 2024 
+# Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,7 +33,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "22 January 2023"
+version = "07 May 2024"
 
 # import standard python modules as required
 #
@@ -1511,7 +1510,9 @@ def r4_header_update(params):
     from ciao_contrib.runtool import r4_header_update
 
     r4_header_update.punlearn()
-    r4_header_update.infile=params["evt1_file"]
+    r4_header_update.infile = params["evt1_file"]
+    r4_header_update.pbkfile = params["pbk0_file"] if "pbk0_file" in params else ""
+    r4_header_update.asolfile = "@"+params["asol1_file"]
     out=r4_header_update()
 
     if out:

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -820,6 +820,15 @@ tg_zo_position="5:35:15.7594,-5:23:10.191"
       </PARAM>
     </PARAMLIST>
 
+<ADESC title="Changes in the scripts 4.16.2 (Q2/Q3 2024) release">
+  <PARA>
+    Internal change to how the r4_header_update script is run to 
+    deal with observations that are missing the "*FILE" keywords needed
+    to automatically locate the parameter block file and aspect solution
+    file(s).
+  </PARA>
+</ADESC>
+
 <ADESC title="Changes in the scripts 4.15.0 (December 2022) release">
   <PARA>
     A problem when multiple SSO eph1 files are found has been
@@ -1303,6 +1312,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2022</LASTMODIFIED>
+    <LASTMODIFIED>May 2024</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Vinay found an observation in the archive that has not been through repro3 so the *FILE keywords used to automatically locate auxillary files are missing. Ref hd tix 25280.

This PR updates the way `chandra_repro` calls `r4_header_update` to specify the pbk and asol files names.  This works whether the *FILE keywords are present or not.  (There is other logic in chandra_repro that already checks that the *FILE keywords matches what it finds when globbing through the primary and secondary dirs.)
