### PR TITLE
psf_contour: update for overlapping regions case where regions cannot…

### DIFF
--- a/bin/psf_contour
+++ b/bin/psf_contour
@@ -32,7 +32,7 @@ MIN_FRACTION = 0.6
 FRACTION_STEP = 0.1
 
 toolname = "psf_contour"
-__revision__ = "29 March 2024"
+__revision__ = "15 May 2024"
 
 lw.initialize_logger(toolname)
 verb0 = lw.get_logger(toolname).verbose0
@@ -400,7 +400,7 @@ def get_cli():
     marx_exe = os.path.join(pars["marx_root"], "bin", "marx")
     if not os.path.isfile(marx_exe):
         raise ValueError(f"ERROR: Cannot find marx executable in '{marx_exe}'" +
-                          "; check the marx_root parameter")
+                         "; check the marx_root parameter")
 
     return pars
 
@@ -446,10 +446,13 @@ def shrink_psfs(first_psf, second_psf):
     # If that's the case, then we stop shrinking regions and just exclude
     # them from each other.
 
-    new_first = CXCRegion(first_psf.outfile) - CXCRegion(second_psf.outfile)
+    first_reg = CXCRegion(first_psf.outfile)
+    second_reg = CXCRegion(second_psf.outfile)
+
+    new_first = first_reg - second_reg[0]
     new_first.write(first_psf.outfile, fits=True, clobber=True)
 
-    new_second = CXCRegion(second_psf.outfile) - CXCRegion(first_psf.outfile)
+    new_second = second_reg - first_reg[0]
     new_second.write(second_psf.outfile, fits=True, clobber=True)
 
 

--- a/bin/psf_contour
+++ b/bin/psf_contour
@@ -32,7 +32,7 @@ MIN_FRACTION = 0.6
 FRACTION_STEP = 0.1
 
 toolname = "psf_contour"
-__revision__ = "15 May 2024"
+__revision__ = "15 July 2024"
 
 lw.initialize_logger(toolname)
 verb0 = lw.get_logger(toolname).verbose0
@@ -390,8 +390,13 @@ def get_cli():
         pars[to_real] = float(pars[to_real])
 
     if pars["marx_root"] == '':
-        raise ValueError("ERROR: marx_root parameter cannot be blank;" +
-                         " set to the directory where MARX is installed")
+        from shutil import which
+        marx = which('marx')
+        if marx is None:
+            raise ValueError("ERROR: marx_root parameter cannot be blank;" +
+                             " set to the directory where MARX is installed")
+        bindir = os.path.dirname(marx)               # ie ".."
+        pars["marx_root"] = os.path.dirname(bindir)  # another ".."
 
     if not os.path.isdir(pars["marx_root"]):
         raise ValueError("ERROR: marx_root parameter must be set to " +

--- a/share/doc/xml/psf_contour.xml
+++ b/share/doc/xml/psf_contour.xml
@@ -249,6 +249,10 @@
             <PARA>
             The marx executable should be $marx_root/bin/marx.
             </PARA>
+            <PARA>
+             If blank, then look for marx in the user's PATH and use that
+             directory for marx_root.
+            </PARA>
             </DESC> 
           </PARAM>
       <PARAM name="parallel" type="boolean" def="yes" reqd="no">
@@ -310,9 +314,13 @@
       </PARA>
     </ADESC>
 
-
-    <ADESC title="Changes in the scripts 4.16.2 (Q2/Q3) release">
-        <PARA>
+    <ADESC title="Changes in the scripts 4.16.2 (Q3 2024) release">
+      <PARA title="marx_root parameter">
+        If marx_root is blank, then look for marx in the user's PATH and 
+        derive marx_root from that path.
+      </PARA>
+    
+        <PARA title="shrink region logic update">
         Clean up logic when overlapping sources cannot be shrunk any
         further and they are excluded from each other. In particular if
         more than 2 sources overlap the region logic becomes unnecessarily
@@ -354,7 +362,7 @@
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>May 2023</LASTMODIFIED>
+    <LASTMODIFIED>July 2024</LASTMODIFIED>
 
 
   </ENTRY>

--- a/share/doc/xml/psf_contour.xml
+++ b/share/doc/xml/psf_contour.xml
@@ -311,6 +311,15 @@
     </ADESC>
 
 
+    <ADESC title="Changes in the scripts 4.16.2 (Q2/Q3) release">
+        <PARA>
+        Clean up logic when overlapping sources cannot be shrunk any
+        further and they are excluded from each other. In particular if
+        more than 2 sources overlap the region logic becomes unnecessarily
+        complex (possibly leading to long execution times).
+        </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.15.2 (April 2023) release">
       <PARA>
         The ellipse fitting code can fail under some circumstances,
@@ -345,7 +354,7 @@
       </PARA>
     </BUGS>
     
-    <LASTMODIFIED>March 2023</LASTMODIFIED>
+    <LASTMODIFIED>May 2023</LASTMODIFIED>
 
 
   </ENTRY>


### PR DESCRIPTION
… be shrunk any further; simplifies region logic.

When multiple sources overlap the region logic gets messy really fast using the old code, when all we need to do is exclude the only included shape (which by definition is the first one) from each other. 

