### PR TITLE
MaskedIMAGECrate: add check for column ranges in addition to subspace/region

### DIFF
--- a/crates_contrib/masked_image_crate.py
+++ b/crates_contrib/masked_image_crate.py
@@ -77,6 +77,7 @@ class MaskedIMAGECrate(IMAGECrate):
 
         xcol = 'x'
         ycol = 'y'
+
         def get_col_range(col_name):
             'Get column range'
             col_range = self.get_subspace_data(1, col_name)
@@ -89,12 +90,12 @@ class MaskedIMAGECrate(IMAGECrate):
         def check_col_range(col_range, col_val):
             'Check if val is in ranges'
             if col_range is None or len(col_range) == 0:
-                return 1
+                return True
 
             for low, hi in zip(*col_range):
-                if low <= col_val and col_val < hi:
-                    return 1
-            return 0
+                if low <= col_val < hi:
+                    return True
+            return False
 
         xrange_vals = get_col_range(xcol)
         yrange_vals = get_col_range(ycol)


### PR DESCRIPTION

This update adds a check for the `range_min` and `range_max` on the axes.  This matches a recent-ish change to the C dmimgio routines that also now check the axes ranges.   Without it, there were cases where the top most and right most pixels at the image edge would be inside the subspace, but the center of the pixel would be outside the range. Ie a partial pixel. 

We need this range change to bring the python code in sync w/ the C code so they agree on which pixels are valid. 
