### PR TITLE
Clearify aplimits examples

### DIFF
--- a/share/doc/xml/aplimits.xml
+++ b/share/doc/xml/aplimits.xml
@@ -174,7 +174,8 @@
       The defaults for exposure time and area are 1.0 for each value. So, we can also view
       this example as follows: We expect 1.23 background counts in the source area
       over the entire exposure time and and the upper limit to the source flux is
-      2.44206 counts over the entire exposure time.
+      2.44206 counts over the entire exposure time. To convert the upper limit on the
+      source flux into a rate of cts/s, we can divide 2.44206 by the exposure time in seconds.
          </PARA>
         </DESC>
       </QEXAMPLE>


### PR DESCRIPTION
This is in response to a helpdesk user question asking when the limits returned are per exposure vs. per second.