### PR TITLE
update packaging and installation functionality

### DIFF
--- a/mk_script_tarfile
+++ b/mk_script_tarfile
@@ -34,7 +34,7 @@ import sys
 import time
 
 
-def build_dist(version, dirname, outdir, python="python3.10"):
+def build_dist(version, dirname, outdir, python="python3.11"):
     """Build contrib scripts package into a separate temp dir"""
 
     outdir = Path(outdir)
@@ -52,12 +52,15 @@ def build_dist(version, dirname, outdir, python="python3.10"):
 
     # Copy directories over to this directory
     #
-    for basedir in ["bin", "share/doc/xml", "share/xspec/install", "share/sherpa/notebooks", "data", "config", "param"]:
+    for basedir in ["bin", "share/doc/xml", "share/xspec/install", "share/sherpa/notebooks", "data", "data/ebounds-lut", "config", "param"]:
         newdir = outdir / basedir
         newdir.mkdir(parents=True)
         nfiles = 0
         for infile in glob.glob(f"{basedir}/*"):
             if infile.endswith('~'):
+                continue
+
+            if infile == "data/ebounds-lut":
                 continue
 
             bname = os.path.basename(infile)
@@ -241,6 +244,8 @@ if __name__ == "__main__":
     tarfile = os.path.join(cwd, tarfile)
     tarfilegz = f'{tarfile}.gz'
 
+    pyver = f"{(pyver := sys.version_info).major}.{pyver.minor}"
+
     if micro != 'DEV':
         if os.path.exists(tarfile) or os.path.exists(tarfilegz):
             sys.stderr.write("ERROR: output file already exists\n")
@@ -252,6 +257,6 @@ if __name__ == "__main__":
 
     from tempfile import TemporaryDirectory
     with TemporaryDirectory(prefix=dirname) as tmpdir:
-        build_dist(version, dirname, tmpdir)
+        build_dist(version, dirname, tmpdir, f"python{pyver}")
         os.chdir(tmpdir)
         make_tarfile(tarfilegz, dirname)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ Create the CIAO contributed package. Options include:
 
 import glob
 import sys
+import os
 
 from setuptools import setup
 
@@ -20,6 +21,11 @@ def list_files(pattern):
     #
     files = [f for f in files if not (f.endswith('~') or f.startswith('flycheck_'))]
 
+    # Remove sub-directories
+    #
+    #
+    files = [f for f in files if not os.path.isdir(f)]
+    
     if files == []:
         raise ValueError(f"No match for pattern: {pattern}")
 
@@ -41,10 +47,10 @@ scripts = list_files("bin/*")
 data_files = [("param", list_files("param/*.par")),
               ("share/doc/xml", list_files("share/doc/xml/*.xml")),
               ("share/xspec/install", list_files("share/xspec/install/*cxx")),
-              ("share/sherpa/notebooks",
-               list_files("share/sherpa/notebooks/*ipynb")),
+              ("share/sherpa/notebooks", list_files("share/sherpa/notebooks/*ipynb")),
               ("config", list_files("config/*")),
               ("data", list_files("data/*")),
+              ("data/ebounds-lut", list_files("data/ebounds-lut/*")),
               (".", ["Changes.CIAO_scripts"])
 ]
 


### PR DESCRIPTION
- updated `mk_script_tarfile` to default to Python 3.11 for CIAO 4.16 (or use the Python version being used with the CIAO that's active while building the tarball)
- `setup.py` updated to include `data/ebounds-lut` so that the package can be installed with `pip install` from a local repository (brought to attention by @kglotfelty).