### PR TITLE
dax: update to use notice2d instead of notice when saving results

### DIFF
--- a/bin/ds9_imgfit.sh
+++ b/bin/ds9_imgfit.sh
@@ -151,7 +151,7 @@ except DaxCancel:
     print("Cancel button pressed")
     sys.exit(1)
 
-sherpa.notice()
+sherpa.notice2d()
 sherpa.save_model("${DAX_OUTDIR}/out.fits", clobber=True)
 EOF
 


### PR DESCRIPTION
This doesn't seem to really have any effect ; that is w/ 4.16 `notice()` looks to be working as if it were `notice2d()`; but with 4.17 there is a new warning from sherpa, so let's go ahead an update it to use the correct `notice2d` flavor.

(no need for ahelp/Changes methinks) 