### PR TITLE
distutils/setuptools 'msvccompiler' dependency

### DIFF
--- a/bin/convert_xspec_user_model
+++ b/bin/convert_xspec_user_model
@@ -67,7 +67,7 @@ for a description of the model.dat format.
 """
 
 toolname = "convert_xspec_user_model"
-toolver  = "4 July 2024"
+toolver  = "29 October 2024"
 
 import sys
 import os
@@ -759,7 +759,7 @@ def build_setup(modname, sources, fortransources, extrafiles,
         v2(f"   - found: {head:8s}  {matches[0]}")
         out = Path(matches[0]).stem
         return out[3:]  # drop the "lib" prefix
-    
+
     hdsp_version = find_libname("hdsp")
     ccfits_version = find_libname("CCfits")
 
@@ -1009,7 +1009,7 @@ where = src
     # build a version of Sherpa, which saves time.
     #
     out = '''[build-system]
-requires = ["setuptools >= 49.1.2",
+requires = ["setuptools >= 49.1.2, < 74",
             "wheel",
             "oldest-supported-numpy"
            ]


### PR DESCRIPTION
From a recent helpdesk ticket, `convert_xspec_user_model` uses `pip` to compile and install the model.  `pip` is ultimately calling on `numpy.distutils` modules that points to `numpy.distutils.mingw32ccompiler` which has a dependency on `distutils.msvccompiler`.

In `setuptools` 74.0.0 (https://setuptools.pypa.io/en/latest/history.html#v74-0-0), which reflects `distutils` development, it drops this functionality which subsequently leads to `pip` failing to build the model.  Adding an additional restriction of `setuptools < 74` in `convert_xspec_user_model` works around the issue.

This affects both CIAO 4.16 and 4.17 beta(s).