### PR TITLE
download_obsid_caldb: get p2_resp files for all temperatures

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -19,6 +19,11 @@ Updated scripts
     use the meson-python build backend rather than setuptools. As part
     of this change the --local is no-longer supported.
 
+  download_obsid_caldb
+
+    The script has been updated to support the multiple
+    temperature-dependent P2_RESP calibration files for ACIS.
+
 
 New modules
 

--- a/bin/download_obsid_caldb
+++ b/bin/download_obsid_caldb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2013-2022 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013-2022, 2024 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ import ciao_contrib.logger_wrapper as lw
 
 
 toolname = "download_obsid_caldb"
-__revision__ = "25 February 2022"
+__revision__ = "25 November 2024"
 
 lw.initialize_logger(toolname)
 
@@ -37,7 +37,6 @@ verb3 = lgr.verbose3
 verb5 = lgr.verbose5
 
 CDA_SERVER="https://cxc.cfa.harvard.edu/cdaftp/arcftp/ChandraCalDB"
-
 
 def wrap_urlopen(url):
     """Wrap simple urlopen with a Request object w/ custom User-Agent
@@ -463,7 +462,8 @@ def get_tools(infile):
                ### 'rmf_file' : None,  # ???
                ### 'gain_file' : None # ???
                }
-    mkacisrmf = {'sc_matrix' : None, }  # infile
+    temps = ",".join([str(x) for x in range(153,178,2)])
+    mkacisrmf = {'sc_matrix' : {'fp_temp': temps} }  # infile
     mkarf = { 'dead_area' :   None  }  # 'dafile'
     mkwarf = { 'fef_pha' : None }  # + dead_area
     mkpsfmap = {'reef' : None }

--- a/share/doc/xml/download_obsid_caldb.xml
+++ b/share/doc/xml/download_obsid_caldb.xml
@@ -355,7 +355,7 @@ they are skipped and only the background files are actually retrieved.
 
     </PARAMLIST>
 
-    <ADESC title="Changes in the script 4.17.0 (December 2022) release">
+    <ADESC title="Changes in the script 4.17.0 (December 2024) release">
       <PARA>
         The mkacisrmf P2_RESP calibration files will be available at multiple
         focal plane temperatures. The script has been updated to retrieve all the 

--- a/share/doc/xml/download_obsid_caldb.xml
+++ b/share/doc/xml/download_obsid_caldb.xml
@@ -355,6 +355,16 @@ they are skipped and only the background files are actually retrieved.
 
     </PARAMLIST>
 
+    <ADESC title="Changes in the script 4.17.0 (December 2022) release">
+      <PARA>
+        The mkacisrmf P2_RESP calibration files will be available at multiple
+        focal plane temperatures. The script has been updated to retrieve all the 
+        P2_RESP files (for a given observation) since the focal plane
+        temperature may vary during an observation and the 
+        response products will need to be combined.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the script 4.14.2 (April 2022) release">
         <PARA>
         Add an extra file validity check to skip files that cannot be
@@ -445,6 +455,6 @@ they are skipped and only the background files are actually retrieved.
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2022</LASTMODIFIED>
+    <LASTMODIFIED>December 2024</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #920 .

Still needs ahelp update.

Confirmed works w/ current caldb and with Dale's test_3 w/ fp_temp dependent files.

Wish I could figure out a way to do it w/o needing to have range hard-coded, but doesn't look like caldb module will let me.