### PR TITLE
Chandra repro hrc ssc

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -10,8 +10,19 @@ New Scripts
     Automate the typical steps needed to apply fine astrometric
     correction to a set of Chandra observations.
 
+  patch_hrc_ssc
+  
+    Identify and patch (replace) corrupt dead time factor values
+    due to Secondary Science Corruption in HRC data.
+
 
 Updated scripts
+
+  chandra_repro
+  
+    Added a new parameter: patch_hrc_ssc, which when set to "yes"
+    run the new patch_hrc_ssc script to patch the dead time factor
+    values that occur during a Secondary Science Corruption event.
 
   convert_xspec_user_model
 
@@ -37,7 +48,7 @@ Updated modules
     The module has been updated to match the CIAO 4.17 parameter files
     and add support for new tools and scripts, including:
 
-      fine_astro, mkosip
+      chandra_repro, fine_astro, mkosip, patch_hrc_ssc
 
   sherpa_contrib.notebook_plotter
 

--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "07 May 2024"
+version = "25 November 2024"
 
 # import standard python modules as required
 #
@@ -74,7 +74,10 @@ import ciao_contrib.cxcdm_wrapper as cdw
 
 from ciao_contrib.param_wrapper import open_param_file
 
-from ciao_contrib.runtool import acis_build_badpix, acis_find_afterglow, dmkeypar, dmmakepar, hrc_build_badpix, destreak, acis_process_events, dmhedit, hrc_process_events, hrc_dtfstats, tgdetect, tg_create_mask, celldetect, tgidselectsrc, tgmatchsrc, tg_resolve_events, tgextract, dmcopy, dmappend, set_pfiles, dmhistory, acis_set_ardlib, skyfov
+from ciao_contrib.runtool import acis_build_badpix, acis_find_afterglow, dmkeypar, dmmakepar, \
+    hrc_build_badpix, destreak, acis_process_events, dmhedit, hrc_process_events, hrc_dtfstats, \
+    tgdetect, tg_create_mask, celldetect, tgidselectsrc, tgmatchsrc, tg_resolve_events, tgextract, \
+    dmcopy, dmappend, set_pfiles, dmhistory, acis_set_ardlib, skyfov
 from ciao_contrib.caldb import get_caldb_dir, get_caldb_installed
 import stk
 
@@ -656,6 +659,7 @@ def process_command_line(argv):
     tg_zo_position    = pio.pgetstr( fp, "tg_zo_position")
     boresight       = pio.pgetstr(fp, "asol_update") == "yes"
     pi_filter       = pio.pgetb(fp, "pi_filter")
+    patch_hrc_ssc   = pio.pgetb(fp, "patch_hrc_ssc")
     cleanup         = pio.pgetb(fp, "cleanup")
     verbose         = pio.pgeti(fp, "verbose")
     clobber         = pio.pgetstr(fp, "clobber")
@@ -693,6 +697,7 @@ def process_command_line(argv):
         pp["tg_zo_position"] =  tg_zo_position
         pp["asol_update"] =     boresight
         pp["pi_filter"] =       pi_filter
+        pp["patch_hrc_ssc"] =   patch_hrc_ssc
         pp["cleanup"] =         cleanup
         pp["clobber"] =         clobber
         pp["verbose"] =         verbose
@@ -1055,7 +1060,7 @@ def get_inputs(params):
 
             check_name_in_hdr( "msk1", params["msk1_file"], params["hdr_maskfile"] )
 
-        ### find ACIS mtl files ###
+        ### find mtl files ###
         elif re.search(".*"+cycle+"mtl1.fits.*",ff):
 
             if params["mtl1_file"]:
@@ -1688,6 +1693,47 @@ def process_acis_events(params, eventdef=None):
 
     return params
 
+
+def patch_hrc_ssc(params):
+    '''
+        Correct HRC DTF values for Secondary Science Corruption (SSC)    
+    '''
+
+    v3("Checking HRC for secondary science corruption")
+
+    if params["dtf1_file"].lower() in ["", "none"]:
+        v0("Warning: No DTF file found; cannot evaluate Secondary Science Corruption")
+        return
+    
+    if params["mtl1_file"].lower() in ["", "none"]:
+        v0("Warning: No MTL file found; cannot evaluate Secondary Science Corruption")
+
+    root = os.path.join(params["outdir"], params["root"])
+
+    from ciao_contrib.runtool import make_tool
+    patch_ssc = make_tool("patch_hrc_ssc")
+    
+    patch_ssc.dtf_infile = params["dtf1_file"]
+    patch_ssc.mtl_infile = params["mtl1_file"]
+    patch_ssc.evt_infile = params["evt1_file"]
+    patch_ssc.evt_outfile = f"{root}_dtffix_evt1.fits"
+    patch_ssc.gti_outfile = f"{root}_repro_flt1.fits"
+    patch_ssc.dtf_outfile = f"{root}_repro_dtf1.fits"
+    patch_ssc.clobber = params["clobber"]
+    
+    out = patch_ssc()
+    v5(out)
+    
+    if not os.path.exists(patch_ssc.gti_outfile):
+        v1("HRC SSC not detected")
+        return
+
+    params["flt1_file"] = patch_ssc.gti_outfile
+    params["dtf1_file"] = patch_ssc.dtf_outfile
+    params["evt1_file"] = patch_ssc.evt_outfile
+    params["cleanup_files"].append(patch_ssc.evt_outfile)
+
+
 def process_hrc_events(params):
     '''Thread to create new L1 and L2 products
        Executes: hrc_process_events
@@ -1720,6 +1766,10 @@ def process_hrc_events(params):
         error_out(params,"Required asol1 input not found for hrc_process_events: "+asol1,'input error')
     if not os.path.isfile(flt1):
         error_out(params,"Required flt1 input not found for hrc_process_events: "+flt1,'input error')
+
+    if params["patch_hrc_ssc"]:
+        patch_hrc_ssc(params)
+        evt1 = params["evt1_file"]
 
     #!### add RANGELEV value to header, if missing ###
     if rangelev:

--- a/bin/patch_hrc_ssc
+++ b/bin/patch_hrc_ssc
@@ -263,7 +263,7 @@ def main():
 
     # TODO: REMOVE SMOOTHING PARAMETER FOR DTFs
     patch_dtf(pars["dtf_infile"], pars["dtf_outfile"], pars["threshold"],
-              "1", median_dtf, median_dtf_err)
+              pars["smooth_count"], median_dtf, median_dtf_err)
 
     mod_mtl = join_dtf_cols_to_mtl(pars["mtl_infile"], pars["dtf_infile"],
                                    pars["tmpdir"])

--- a/bin/patch_hrc_ssc
+++ b/bin/patch_hrc_ssc
@@ -1,0 +1,292 @@
+#!/usr/bin/env python
+
+
+'Patch "Secondary Science Corruption" (SSC) in HRC data.'
+
+
+#  SSC for HRC is described in
+#    POG \S 7.12;  <https://cxc.harvard.edu/proposer/POG/html/chap7.html#tth_sEc7.12>
+#     or  <https://cxc.harvard.edu/proposer/POG/pdf/MPOG.pdf> page 205
+#
+#   Technical notes:
+#     <https://cxc.harvard.edu/contrib/juda/memos/anomaly/sec_sci/index.html>
+#     <https://cxc.harvard.edu/contrib/juda/memos/anomaly/sec_sci/byte_shift.html>
+#
+#   Detailed info on HRC Secondary Science invalid data:
+#     <https://sot.github.io/cheta/pseudo_msids.html>
+#
+#
+#  SSC results from a byte-shift anomaly which occasionally causes a
+#  portion of the housekeeping data to be corrupted.  The symptom is
+#  dropouts in the dead-time-factor (dtf) which can be seen in a plot
+#  of the dtf1 file's dtf valuse vs time, where the dtf is
+#  significantly (>10%) below the median value (~1.0).
+#
+#  In the dtf1 file are several rate columns.  The one that seems to
+#  reliably flag SSC is the TOTAL_EVT_COUNT, when it is anomalously
+#  high, with values > 4000 (2000 count/s; the default binning is 2s,
+#  the dtf file values are integrated over time bins)
+#
+#  Event data are good during the SSC times.  Standard data
+#  processing, however, will create multiple GTI intervals around the
+#  low dtf times, rejecting some events, and lowering the
+#  dead-time-correction factor (DTDOR).
+#
+#  Note: telemetry saturation from a bright source can also cause
+#  lower the dtf.  That tends to be a more continuous and sustained
+#  lowering of the value.  Hence, inspection of the dtf and
+#  total_evt_count vs time is recommended.
+#
+#  This is a prototype script with a simple positional parameter interface
+# (pending conversion to a CIAO version with a standard paramio interface).
+
+# Example:
+#
+#  patch_hrc_ssc.sh obs_22802/dtf1 obs_22802/mtl1 obs_22802/evt1 evt1_new flt1_new 4000
+#
+#  dtf1 is the archival level 1 DTF file (input)
+#  mtl1 is the archival level 1 MTL file (input)
+#  evt1 is the archival Level 1 event file (input)
+#
+#  evt1_new is the output evt1 (with updated header keywords)
+#  flt1_new is the updated FLT file (a GTI table) (output)
+#
+#  4000  is the threshold for the total_evt_rate column, above which
+#        we assume means SSC.  If the value is <1.0, then we assume it
+#        is a dtf threshold, below which the dtf is considered bad
+#        due to SSC  (input)
+#
+# The output evt and flt files can then be used in standard
+# processing (hrc_process_events on)
+#
+
+import os
+import sys
+from tempfile import NamedTemporaryFile
+import numpy as np
+
+import ciao_contrib.logger_wrapper as lw
+from ciao_contrib.runtool import make_tool
+from pycrates import read_file, set_key
+
+__toolname__ = "patch_hrc_ssc"
+__revision__ = "10 October 2024"
+
+lw.initialize_logger(__toolname__)
+VERB0 = lw.get_logger(__toolname__).verbose0
+VERB1 = lw.get_logger(__toolname__).verbose1
+VERB2 = lw.get_logger(__toolname__).verbose2
+
+
+def check_for_bad_values(dtf_in, threshold):
+    '''# First, see if we have any total_evt_count values greater than the
+    # threshold:'''
+
+    infile = f"{dtf_in}[total_evt_count>{threshold}]"
+    tab = read_file(infile)
+
+    if tab.get_nrows() == 0:
+        return False
+    return True
+
+
+def get_median_values(dtf_in, threshold):
+    '''# Determine the median DTF and DTF_ERR where values are good:'''
+
+    infile = f"{dtf_in}[total_evt_count<={threshold}]"
+    tab = read_file(infile)
+
+    dtf_median = np.median(tab.get_column("DTF").values)
+    dtf_err_median = np.median(tab.get_column("DTF_ERR").values)
+
+    VERB1(f"DTF_MEDIAN = {dtf_median} ({dtf_err_median})")
+    return dtf_median, dtf_err_median
+
+
+def join_dtf_cols_to_mtl(mtl_in, dtf_in, tmpdir):
+    'add the DTF info to the MTL file: (NOTE: column DTF is already present in the MTL)'
+
+    outfile = NamedTemporaryFile(suffix="_mtl.fits",
+                                 dir=tmpdir, delete=False)
+
+    dmjoin = make_tool("dmjoin")
+
+    dmjoin.infile = mtl_in
+    dmjoin.joinfile = f"{dtf_in}[cols time,TOTAL_EVT_COUNT,DTF_ERR]"
+    dmjoin.outfile = outfile.name
+    dmjoin.interpolate = "first"
+    dmjoin.join = "time"
+    vv = dmjoin(clobber=True)
+    if vv:
+        VERB2(vv)
+
+    return dmjoin.outfile
+
+
+def patch_dtf(infile, outfile, threshold, smooth_count, median_dtf, median_dtf_err):
+    'Replace bad DTF w/ median values'
+
+    dmtcalc = make_tool("dmtcalc")
+    dmtcalc.infile = infile
+    dmtcalc.outfile = outfile
+    dmtcalc.expression = f"if(total_evt_count:{smooth_count}>{threshold})then(dtf={median_dtf};dtf_err={median_dtf_err})else(dtf=dtf;dtf_err=dtf_err)"
+    vv = dmtcalc(clobber=True)
+    if vv:
+        VERB2(vv)
+
+
+def create_new_limits(mtl_in, tmpdir):
+    'Create new "limits" table excluding the row containing the HRC "*LV" filters'
+
+    outfile = NamedTemporaryFile(suffix="_limits.fits",
+                                 dir=tmpdir, delete=False)
+
+    tab = read_file(f"{mtl_in}[LIMITS]")
+
+    rows = [f"{i+1}" for i, x in enumerate(tab.get_column(0).values) if 'LV' in x]
+
+    rows_str = ",".join(rows)
+    exclude = f"[exclude #row={rows_str}]"
+
+    dmcopy = make_tool("dmcopy")
+    dmcopy.infile = f"{mtl_in}[LIMITS]{exclude}"
+    dmcopy.outfile = outfile.name
+    vv = dmcopy(clobber=True)
+    if vv:
+        VERB2(vv)
+
+    return outfile.name
+
+
+def make_new_gti(mtl_file, gti_out, mod_limits):
+    '''# make  new output file w/ gti table, fflt_out
+    # using the edited "limits" table:'''
+
+    VERB1("Make new flt file...")
+
+    dmgti = make_tool("dmgti")
+    dmgti.infile = mtl_file
+    dmgti.outfile = gti_out
+    dmgti.lkupfile = mod_limits
+    vv = dmgti(clobber=True)
+    if vv:
+        VERB2(vv)
+
+
+def compute_dtcor(dtf_file, gti_file, tmpdir):
+    'Re run hrc_dtfstats to compute new DTCOR'
+
+    outfile = NamedTemporaryFile(suffix="_dtfstats.fits",
+                                 dir=tmpdir, delete=False)
+    dtfstats = make_tool("hrc_dtfstats")
+    dtfstats.infile = dtf_file
+    dtfstats.outfile = outfile.name
+    dtfstats.gtifile = gti_file
+    vv = dtfstats(clobber=True)
+    if vv:
+        VERB2(vv)
+
+    tab = read_file(dtfstats.outfile)
+    dtcor = tab.get_column("dtcor").values
+    VERB1(f"New DTCOR={dtcor[-1]}")
+    os.unlink(dtfstats.outfile)
+
+    return dtcor[-1]
+
+
+def update_events_dtcor(evt_in, evt_out, dtcor, tmpdir):
+    'Need to make a temp copy to update DTCOR in header'
+
+    outfile = NamedTemporaryFile(suffix="_evt.fits", dir=tmpdir,
+                                 delete=False)
+    dmcopy = make_tool("dmcopy")
+    dmcopy(evt_in, outfile.name, clobber=True)
+
+    tab = read_file(outfile.name, "rw")
+    set_key(tab, "DTCOR", dtcor)
+    tab.write()
+
+    vv = dmcopy(f"{outfile.name}[time=:]", evt_out, clobber=True)
+    if vv:
+        VERB2(vv)
+
+    os.unlink(outfile.name)
+
+
+def add_metadata(outfile, pars):
+    """# - add new keywords to flt:  SSC=[T/F] SSCFIX=[T/F]
+    #
+    # TBR: could be, e.g., SSC=0 (not present),  SSC=1 (present), SSC=2 (present, patched)
+    #  instead of using two keywords.
+    #
+    """
+    from ciao_contrib.runtool import add_tool_history
+
+    tab = read_file(outfile, "rw")
+    set_key(tab, "SSC", True)
+    set_key(tab, "SCCFIX", True)
+    tab.write()
+
+    add_tool_history(outfile, __toolname__, pars,
+                     toolversion=__revision__)
+
+
+def get_parameters():
+    'Load parameters from parameter file'
+    from ciao_contrib.param_soaker import get_params
+
+    pars = get_params(__toolname__, "rw", sys.argv,
+                      verbose={"set": lw.set_verbosity, "cmd": VERB2},
+                      revision=__revision__)
+
+    from ciao_contrib._tools.fileio import outfile_clobber_checks
+    for outfile in ("evt_outfile", "gti_outfile", "dtf_outfile"):
+        outfile_clobber_checks(pars["clobber"], pars[outfile])
+
+    return pars
+
+
+@lw.handle_ciao_errors(__toolname__, __revision__)
+def main():
+    'Main routine'
+
+    pars = get_parameters()
+
+    if check_for_bad_values(pars["dtf_infile"], pars["threshold"]) is False:
+        VERB0("SCC not detected, no action required.")
+        return
+
+    VERB1("SSC detected; patching")
+
+    median_dtf, median_dtf_err = get_median_values(pars["dtf_infile"],
+                                                   pars["threshold"])
+
+    # TODO: REMOVE SMOOTHING PARAMETER FOR DTFs
+    patch_dtf(pars["dtf_infile"], pars["dtf_outfile"], pars["threshold"],
+              "1", median_dtf, median_dtf_err)
+
+    mod_mtl = join_dtf_cols_to_mtl(pars["mtl_infile"], pars["dtf_infile"],
+                                   pars["tmpdir"])
+
+    outfile = NamedTemporaryFile(suffix="_mtl.fits",
+                                 dir=pars["tmpdir"],
+                                 delete=False)
+    patch_dtf(mod_mtl, outfile.name, pars["threshold"],
+              pars["smooth_count"], median_dtf, median_dtf_err)
+    os.unlink(mod_mtl)
+
+    mod_limits = create_new_limits(pars["mtl_infile"], pars["tmpdir"])
+
+    make_new_gti(outfile.name, pars["gti_outfile"], mod_limits)
+    os.unlink(mod_limits)
+
+    dtcor = compute_dtcor(pars["dtf_outfile"], pars["gti_outfile"],
+                          pars["tmpdir"])
+    os.unlink(outfile.name)
+
+    update_events_dtcor(pars["evt_infile"], pars["evt_outfile"], dtcor,
+                        pars["tmpdir"])
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/patch_hrc_ssc
+++ b/bin/patch_hrc_ssc
@@ -73,9 +73,19 @@ __toolname__ = "patch_hrc_ssc"
 __revision__ = "10 October 2024"
 
 lw.initialize_logger(__toolname__)
-VERB0 = lw.get_logger(__toolname__).verbose0
-VERB1 = lw.get_logger(__toolname__).verbose1
-VERB2 = lw.get_logger(__toolname__).verbose2
+
+
+def log_wrapper(func):
+    'wrapper around logger to check for None'
+    def wrapped(msg):
+        if msg:
+            func(msg)
+    return wrapped
+
+
+verb0 = log_wrapper(lw.get_logger(__toolname__).verbose0)
+verb1 = log_wrapper(lw.get_logger(__toolname__).verbose1)
+verb2 = log_wrapper(lw.get_logger(__toolname__).verbose2)
 
 
 def check_for_bad_values(dtf_in, threshold):
@@ -84,6 +94,9 @@ def check_for_bad_values(dtf_in, threshold):
 
     infile = f"{dtf_in}[total_evt_count>{threshold}]"
     tab = read_file(infile)
+
+    if tab.get_key_value("SSCFIX") is not None:
+        raise IOError(f"This file, {dtf_in}, has already been patched and cannot be patched again.")
 
     if tab.get_nrows() == 0:
         return False
@@ -99,7 +112,7 @@ def get_median_values(dtf_in, threshold):
     dtf_median = np.median(tab.get_column("DTF").values)
     dtf_err_median = np.median(tab.get_column("DTF_ERR").values)
 
-    VERB1(f"DTF_MEDIAN = {dtf_median} ({dtf_err_median})")
+    verb1(f"DTF_MEDIAN = {dtf_median} ({dtf_err_median})")
     return dtf_median, dtf_err_median
 
 
@@ -117,8 +130,7 @@ def join_dtf_cols_to_mtl(mtl_in, dtf_in, tmpdir):
     dmjoin.interpolate = "first"
     dmjoin.join = "time"
     vv = dmjoin(clobber=True)
-    if vv:
-        VERB2(vv)
+    verb2(vv)
 
     return dmjoin.outfile
 
@@ -126,17 +138,37 @@ def join_dtf_cols_to_mtl(mtl_in, dtf_in, tmpdir):
 def patch_dtf(infile, outfile, threshold, smooth_count, median_dtf, median_dtf_err):
     'Replace bad DTF w/ median values'
 
-    dmtcalc = make_tool("dmtcalc")
-    dmtcalc.infile = infile
-    dmtcalc.outfile = outfile
-    dmtcalc.expression = f"if(total_evt_count:{smooth_count}>{threshold})then(dtf={median_dtf};dtf_err={median_dtf_err})else(dtf=dtf;dtf_err=dtf_err)"
-    vv = dmtcalc(clobber=True)
-    if vv:
-        VERB2(vv)
+    verb1(f"Patching DTF values in {infile}")
+
+    tab = read_file(infile)
+
+    total_evt_count = tab.get_column("total_evt_count").values
+    dtf = tab.get_column("dtf").values
+    dtf_err = tab.get_column("dtf_err").values
+
+    kern = np.ones(int(smooth_count))/float(smooth_count)
+    tec_smooth = np.convolve(total_evt_count, kern, mode="same")
+
+    idx, = np.where(tec_smooth > float(threshold))
+
+    dtf[idx] = median_dtf
+    dtf_err[idx] = median_dtf_err
+
+    tab.write(outfile, clobber=True)
+
+    # Keep here for reference
+    # ~ dmtcalc = make_tool("dmtcalc")
+    # ~ dmtcalc.infile = infile
+    # ~ dmtcalc.outfile = outfile
+    # ~ dmtcalc.expression = f"if(total_evt_count:{smooth_count}>{threshold})then(dtf={median_dtf};dtf_err={median_dtf_err})else(dtf=dtf;dtf_err=dtf_err)"
+    # ~ vv = dmtcalc(clobber=True)
+    # ~ verb2(vv)
 
 
 def create_new_limits(mtl_in, tmpdir):
     'Create new "limits" table excluding the row containing the HRC "*LV" filters'
+
+    verb1("Creating new GTI limits")
 
     outfile = NamedTemporaryFile(suffix="_limits.fits",
                                  dir=tmpdir, delete=False)
@@ -152,8 +184,7 @@ def create_new_limits(mtl_in, tmpdir):
     dmcopy.infile = f"{mtl_in}[LIMITS]{exclude}"
     dmcopy.outfile = outfile.name
     vv = dmcopy(clobber=True)
-    if vv:
-        VERB2(vv)
+    verb2(vv)
 
     return outfile.name
 
@@ -162,19 +193,20 @@ def make_new_gti(mtl_file, gti_out, mod_limits):
     '''# make  new output file w/ gti table, fflt_out
     # using the edited "limits" table:'''
 
-    VERB1("Make new flt file...")
+    verb1("Make new flt file...")
 
     dmgti = make_tool("dmgti")
     dmgti.infile = mtl_file
     dmgti.outfile = gti_out
     dmgti.lkupfile = mod_limits
     vv = dmgti(clobber=True)
-    if vv:
-        VERB2(vv)
+    verb2(vv)
 
 
 def compute_dtcor(dtf_file, gti_file, tmpdir):
     'Re run hrc_dtfstats to compute new DTCOR'
+
+    verb1("Recomputing DTF stats")
 
     outfile = NamedTemporaryFile(suffix="_dtfstats.fits",
                                  dir=tmpdir, delete=False)
@@ -183,12 +215,11 @@ def compute_dtcor(dtf_file, gti_file, tmpdir):
     dtfstats.outfile = outfile.name
     dtfstats.gtifile = gti_file
     vv = dtfstats(clobber=True)
-    if vv:
-        VERB2(vv)
+    verb2(vv)
 
     tab = read_file(dtfstats.outfile)
     dtcor = tab.get_column("dtcor").values
-    VERB1(f"New DTCOR={dtcor[-1]}")
+    verb1(f"New DTCOR={dtcor[-1]}")
     os.unlink(dtfstats.outfile)
 
     return dtcor[-1]
@@ -197,18 +228,22 @@ def compute_dtcor(dtf_file, gti_file, tmpdir):
 def update_events_dtcor(evt_in, evt_out, dtcor, tmpdir):
     'Need to make a temp copy to update DTCOR in header'
 
+    verb1("Updating DTCOR in event file and recomputing EXPOSURE time")
+
     outfile = NamedTemporaryFile(suffix="_evt.fits", dir=tmpdir,
                                  delete=False)
     dmcopy = make_tool("dmcopy")
-    dmcopy(evt_in, outfile.name, clobber=True)
+    vv = dmcopy(evt_in, outfile.name, clobber=True)
+    verb2(vv)
+    verb2("Copy 1 done")
 
-    tab = read_file(outfile.name, "rw")
-    set_key(tab, "DTCOR", dtcor)
-    tab.write()
+    dmhedit = make_tool("dmhedit")
+    dmhedit(outfile.name, file="", op="add", key="DTCOR", value=dtcor)
+    verb2("Update done")
 
     vv = dmcopy(f"{outfile.name}[time=:]", evt_out, clobber=True)
-    if vv:
-        VERB2(vv)
+    verb2(vv)
+    verb2("Copy 2 done")
 
     os.unlink(outfile.name)
 
@@ -222,10 +257,11 @@ def add_metadata(outfile, pars):
     """
     from ciao_contrib.runtool import add_tool_history
 
-    tab = read_file(outfile, "rw")
-    set_key(tab, "SSC", True)
-    set_key(tab, "SCCFIX", True)
-    tab.write()
+    dmhedit = make_tool("dmhedit")
+    dmhedit(outfile, file="", op="add", key="SSC", value="T",
+            datatype="boolean")
+    dmhedit(outfile, file="", op="add", key="SSCFIX", value="T",
+            datatype="boolean")
 
     add_tool_history(outfile, __toolname__, pars,
                      toolversion=__revision__)
@@ -236,7 +272,7 @@ def get_parameters():
     from ciao_contrib.param_soaker import get_params
 
     pars = get_params(__toolname__, "rw", sys.argv,
-                      verbose={"set": lw.set_verbosity, "cmd": VERB2},
+                      verbose={"set": lw.set_verbosity, "cmd": verb1},
                       revision=__revision__)
 
     from ciao_contrib._tools.fileio import outfile_clobber_checks
@@ -253,15 +289,14 @@ def main():
     pars = get_parameters()
 
     if check_for_bad_values(pars["dtf_infile"], pars["threshold"]) is False:
-        VERB0("SCC not detected, no action required.")
+        verb0("SSC not detected, no action required.")
         return
 
-    VERB1("SSC detected; patching")
+    verb1("SSC detected; patching")
 
     median_dtf, median_dtf_err = get_median_values(pars["dtf_infile"],
                                                    pars["threshold"])
 
-    # TODO: REMOVE SMOOTHING PARAMETER FOR DTFs
     patch_dtf(pars["dtf_infile"], pars["dtf_outfile"], pars["threshold"],
               pars["smooth_count"], median_dtf, median_dtf_err)
 
@@ -282,10 +317,15 @@ def main():
 
     dtcor = compute_dtcor(pars["dtf_outfile"], pars["gti_outfile"],
                           pars["tmpdir"])
+
+    add_metadata(pars["dtf_outfile"], pars)
+
     os.unlink(outfile.name)
 
     update_events_dtcor(pars["evt_infile"], pars["evt_outfile"], dtcor,
                         pars["tmpdir"])
+
+    add_metadata(pars["evt_outfile"], pars)
 
 
 if __name__ == '__main__':

--- a/bin/patch_hrc_ssc
+++ b/bin/patch_hrc_ssc
@@ -67,7 +67,7 @@ import numpy as np
 
 import ciao_contrib.logger_wrapper as lw
 from ciao_contrib.runtool import make_tool
-from pycrates import read_file, set_key
+from pycrates import read_file
 
 __toolname__ = "patch_hrc_ssc"
 __revision__ = "10 October 2024"
@@ -225,7 +225,7 @@ def compute_dtcor(dtf_file, gti_file, tmpdir):
     return dtcor[-1]
 
 
-def update_events_dtcor(evt_in, evt_out, dtcor, tmpdir):
+def update_events_dtcor(evt_in, evt_out, dtcor, tmpdir, fltfile, dtffile):
     'Need to make a temp copy to update DTCOR in header'
 
     verb1("Updating DTCOR in event file and recomputing EXPOSURE time")
@@ -239,6 +239,12 @@ def update_events_dtcor(evt_in, evt_out, dtcor, tmpdir):
 
     dmhedit = make_tool("dmhedit")
     dmhedit(outfile.name, file="", op="add", key="DTCOR", value=dtcor)
+
+    basefile = os.path.basename(fltfile)
+    dmhedit(outfile.name, file="", op="add", key="FLTFILE", value=basefile)
+
+    basefile = os.path.basename(dtffile)
+    dmhedit(outfile.name, file="", op="add", key="DTFFILE", value=basefile)
     verb2("Update done")
 
     vv = dmcopy(f"{outfile.name}[time=:]", evt_out, clobber=True)
@@ -323,7 +329,8 @@ def main():
     os.unlink(outfile.name)
 
     update_events_dtcor(pars["evt_infile"], pars["evt_outfile"], dtcor,
-                        pars["tmpdir"])
+                        pars["tmpdir"], pars["gti_outfile"],
+                        pars["dtf_outfile"])
 
     add_metadata(pars["evt_outfile"], pars)
 

--- a/ciao_contrib/runtool.py
+++ b/ciao_contrib/runtool.py
@@ -2705,7 +2705,7 @@ parinfo['centroid_map'] = {
 parinfo['chandra_repro'] = {
     'istool': True,
     'req': [ParValue("indir","f","Input directory",'./'),ParValue("outdir","f","Output directory (default = $indir/repro)",None)],
-    'opt': [ParValue("root","s","Root for output filenames",None),ParValue("badpixel","b","Create a new bad pixel file?",True),ParValue("process_events","b","Create a new level=2 event file?",True),ParValue("destreak","b","Destreak the ACIS-8 chip?",True),ParValue("set_ardlib","b","Set ardlib.par with the bad pixel file?",True),ParValue("check_vf_pha","b","Clean ACIS background in VFAINT data?",False),ParSet("pix_adj","s","Pixel randomization: default|edser|none|randomize",'default',["default","edser","none","randomize","centroid"]),ParValue("tg_zo_position","s","Method to determine gratings 0th order location: evt2|detect|R.A. & Dec.",'evt2'),ParValue("asol_update","b","If necessary, apply boresight correction to aspect solution file?",True),ParValue("pi_filter","b","Apply PI background filter to HRC-S+LETG data?",True),ParValue("cleanup","b","Cleanup intermediate files on exit",True),ParValue("clobber","b","Clobber existing file",False),ParRange("verbose","i","Debug Level(0-5)",1,0,5)],
+    'opt': [ParValue("root","s","Root for output filenames",None),ParValue("badpixel","b","Create a new bad pixel file?",True),ParValue("process_events","b","Create a new level=2 event file?",True),ParValue("destreak","b","Destreak the ACIS-8 chip?",True),ParValue("set_ardlib","b","Set ardlib.par with the bad pixel file?",True),ParValue("check_vf_pha","b","Clean ACIS background in VFAINT data?",False),ParSet("pix_adj","s","Pixel randomization: default|edser|none|randomize",'default',["default","edser","none","randomize","centroid"]),ParValue("tg_zo_position","s","Method to determine gratings 0th order location: evt2|detect|R.A. & Dec.",'evt2'),ParValue("asol_update","b","If necessary, apply boresight correction to aspect solution file?",True),ParValue("pi_filter","b","Apply PI background filter to HRC-S+LETG data?",True),ParValue("patch_hrc_ssc","b","Patch HRC Secondary Science Corruption?",False),ParValue("cleanup","b","Cleanup intermediate files on exit",True),ParValue("clobber","b","Clobber existing file",False),ParRange("verbose","i","Debug Level(0-5)",1,0,5)],
     }
 
 
@@ -3483,6 +3483,13 @@ parinfo['obsid_search_csc'] = {
     'istool': True,
     'req': [ParValue("obsid","s","Chandra Observation ID",None),ParValue("outfile","f","Name of output table (TSV format)",None)],
     'opt': [ParValue("columns","s","List of columns to include",'INDEF'),ParSet("download","s","Download data products for which sources?",'none',["none","ask","all"]),ParValue("root","f","Output root for data products",'./'),ParValue("bands","s","Comma separated list of CSC band names taken from broad, soft, medium, hard, ultrasoft, wide. Blank retrieves all",'broad,wide'),ParValue("filetypes","s","Comma separated list of CSC filetypes.  Blank retrieves all",'regevt,pha,arf,rmf,lc,psf,regexp'),ParSet("catalog","s","Version of catalog",'csc2.1',["csc2.1","csc2","csc1","current","latest"]),ParRange("verbose","i","Tool chatter level",1,0,5),ParValue("clobber","b","Remove existing outfile if it exists?",False)],
+    }
+
+
+parinfo['patch_hrc_ssc'] = {
+    'istool': True,
+    'req': [ParValue("dtf_infile","f","Input dead time factors file",None),ParValue("mtl_infile","f","Input mission time line file",None),ParValue("evt_infile","f","Input Level 1 event file",None),ParValue("evt_outfile","f","Output Level 1 event file",None),ParValue("gti_outfile","f","Output GTI (filter: flt) file",None),ParValue("dtf_outfile","f","Output dead time factors file",None),ParRange("threshold","i","Threshold about which total_evt_count is due to SCC",4000,0,None)],
+    'opt': [ParRange("smooth_count","i","Smoothing applied to total_evt_count to determine bad range",3,1,None),ParValue("tmpdir","f","Temporary directory for intermediate files",'${ASCDS_WORK_PATH}'),ParRange("verbose","i","Amount of tool chatter",1,0,5),ParValue("clobber","b","Overwrite existing files",False)],
     }
 
 

--- a/param/chandra_repro.par
+++ b/param/chandra_repro.par
@@ -10,6 +10,7 @@ pix_adj,s,h,"default",default|edser|none|randomize|centroid,,"Pixel randomizatio
 tg_zo_position,s,h,"evt2",,,"Method to determine gratings 0th order location: evt2|detect|R.A. & Dec."
 asol_update,b,h,yes,,,"If necessary, apply boresight correction to aspect solution file?"
 pi_filter,b,h,yes,,,"Apply PI background filter to HRC-S+LETG data?"
+patch_hrc_ssc,b,h,no,,,"Patch HRC Secondary Science Corruption?"
 cleanup,b,h,yes,,,"Cleanup intermediate files on exit"
 clobber,b,h,no,,,"Clobber existing file"
 verbose,i,h,1,0,5,"Debug Level(0-5)"

--- a/param/patch_hrc_ssc.par
+++ b/param/patch_hrc_ssc.par
@@ -1,0 +1,12 @@
+dtf_infile,f,a,"",,,"Input dead time factors file"
+mtl_infile,f,a,"",,,"Input mission time line file"
+evt_infile,f,a,"",,,"Input Level 1 event file"
+evt_outfile,f,a,"",,,"Output Level 1 event file"
+gti_outfile,f,a,"",,,"Output GTI (filter: flt) file"
+dtf_outfile,f,a,"",,,"Output dead time factors file"
+threshold,i,a,4000,0,,"Threshold about which total_evt_count is due to SCC"
+smooth_count,i,h,3,1,,"Smoothing applied to total_evt_count to determine bad range"
+tmpdir,f,h,"${ASCDS_WORK_PATH}",,,"Temporary directory for intermediate files"
+verbose,i,h,1,0,5,"Amount of tool chatter"
+clobber,b,h,no,,,"Overwrite existing files"
+mode,s,h,ql,,,

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -778,6 +778,37 @@ tg_zo_position="5:35:15.7594,-5:23:10.191"
       </PARAM>
 
 
+      <PARAM name="patch_hrc_ssc" def="no" type="boolean" reqd="no">
+        <SYNOPSIS>
+            Look for evidence of HRC Secondary Science Corruption (SSC) and
+            patch dead-time factors if detected.
+        </SYNOPSIS>
+        <DESC>
+          <PARA>
+             SSC results from a byte-shift anomaly which occasionally causes a
+             portion of the housekeeping data to be corrupted.  The symptom is
+             dropouts in the dead-time-factor (dtf) which can be seen in a plot
+             of the dtf1 file's dtf valuse vs time, where the dtf is
+             significantly (&gt;10%) below the median value (~1.0).
+          </PARA>
+        <PARA>
+         Event data are good during the SSC times.  Standard data
+         processing, however, will create multiple GTI intervals around the
+         low dtf times, rejecting some events, and lowering the
+         dead-time-correction factor (DTDOR).
+        </PARA>
+        <PARA>
+          Note: telemetry saturation from a bright source can also 
+          lower the dtf; however, this tends to be a more continuous and sustained
+          lowering of the value.  
+        </PARA>
+
+
+        </DESC>
+      </PARAM>
+
+
+
       <PARAM name="cleanup" def="yes" type="boolean" reqd="no">
         <SYNOPSIS>
 	  Cleanup intermediate files on exit
@@ -819,6 +850,19 @@ tg_zo_position="5:35:15.7594,-5:23:10.191"
         </DESC>
       </PARAM>
     </PARAMLIST>
+
+
+<ADESC title="Changes in the scripts 4.17.0 (December 2024) release">
+  <PARA title="New HRC Science Science Corruption tool">
+    A new parameter has been added: patch_hrc_ssc, which when set to 
+    "yes" will run the patch_hrc_ssc tool.  This tool looks for
+    corruption in the HRC secondary science data and will replace (patch)
+    the corrupted values in the dead time factors file. This typically results
+    in a very slightly higher average DTCOR value and elimination of some
+    very short, erroneously tagged bad time intervals.
+  </PARA>
+</ADESC>
+
 
 <ADESC title="Changes in the scripts 4.16.2 (August 2024) release">
   <PARA title="On Board Computer (OBC) mode">
@@ -1328,6 +1372,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>May 2024</LASTMODIFIED>
+    <LASTMODIFIED>December 2024</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/patch_hrc_ssc.xml
+++ b/share/doc/xml/patch_hrc_ssc.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0"?>
+<!DOCTYPE cxchelptopics SYSTEM "CXCHelp.dtd">
+<cxchelptopics>
+  <ENTRY key="patch_hrc_ssc" context="Tools::HRC"
+         refkeywords="hrc dtf deadtime dead time factor stat stats statistic statistics secondary science ssc corruption"
+         seealsogroups="hrctools">
+
+    <SYNOPSIS>
+      Identify and patch HRC Secondary Science Corruption (SSC) data
+    </SYNOPSIS>
+
+    <DESC>
+       <PARA>
+  SSC results from a byte-shift anomaly which occasionally causes a
+  portion of the housekeeping data to be corrupted.  The symptom is
+  dropouts in the dead-time-factor (dtf) which can be seen in a plot
+  of the dtf1 file's dtf valuse vs time, where the dtf is
+  significantly (&gt;10%) below the median value (~1.0).
+    </PARA>
+       <PARA>
+
+  In the dtf1 file are several rate columns.  The one that seems to
+  reliably flag SSC is the TOTAL_EVT_COUNT, when it is anomalously
+  high, with values &gt; 4000 (2000 count/s; the default binning is 2s,
+  the dtf file values are integrated over time bins)
+    </PARA>
+       <PARA>
+
+  Event data are good during the SSC times.  Standard data
+  processing, however, will create multiple GTI intervals around the
+  low dtf times, rejecting some events, and lowering the
+  dead-time-correction factor (DTDOR).
+    </PARA>
+       <PARA>
+
+  Note: telemetry saturation from a bright source can also cause
+  lower dtf values.  That tends to be a more continuous and sustained
+  lowering of the value.  Hence, inspection of the dtf and
+  total_evt_count vs time is recommended.
+       </PARA>
+
+      <PARA title="Technical References:">
+        <HREF link="https://cxc.harvard.edu/proposer/POG/html/chap7.html#tth_sEc7.12">
+        Chandra Proposers and Observatory Guide secion on HRC SSC
+        </HREF>          
+      </PARA>
+      <PARA><HREF link="https://cxc.harvard.edu/contrib/juda/memos/anomaly/sec_sci/index.html">
+      HRC Secondary Science Anomaly on Day 2005:349</HREF></PARA>
+      <PARA><HREF link="https://cxc.harvard.edu/contrib/juda/memos/anomaly/sec_sci/byte_shift.html">
+        Secondary Science Byte Shift
+      </HREF></PARA>
+      <PARA><HREF link="https://sot.github.io/cheta/pseudo_msids.html">
+      Pseudo-MSIDs in the engineering archive
+      </HREF></PARA>
+    </DESC>
+
+    <QEXAMPLELIST>
+       <QEXAMPLE>
+         <SYNTAX>
+           <LINE>patch_hrc_ssc dtf_in=primary/hrcf27499_000N001_dtf1.fits \</LINE>
+           <LINE>  mtl_infile=secondary/hrcf27499_000N001_mtl1.fits \</LINE>
+           <LINE>  evt_infile= secondary/hrcf27499_000N001_evt1.fits \</LINE>
+           <LINE>  evt_outfile=patched_evt1.fits \</LINE>
+           <LINE>  dtf_outfile=patched_dtf1.fits \</LINE>
+           <LINE>  gti_outfile=patched_flt1.fits clob+ mode=h</LINE>
+         </SYNTAX>
+         <DESC>
+<VERBATIM>
+patch_hrc_ssc (10 October 2024)
+      dtf_infile = primary/hrcf27499_000N001_dtf1.fits
+      mtl_infile = secondary/hrcf27499_000N001_mtl1.fits
+      evt_infile = secondary/hrcf27499_000N001_evt1.fits
+     evt_outfile = patched_evt1.fits
+     gti_outfile = patched_flt1.fits
+     dtf_outfile = patched_dtf1.fits
+       threshold = 4000
+    smooth_count = 3
+          tmpdir = /tmp
+         verbose = 1
+         clobber = yes
+            mode = h
+
+SSC detected; patching
+DTF_MEDIAN = 0.99117975 (0.0007477008299119561)
+Patching DTF values in primary/hrcf27499_000N001_dtf1.fits
+Patching DTF values in /tmp/tmprtqf975j_mtl.fits
+Creating new GTI limits
+Make new flt file...
+Recomputing DTF stats
+New DTCOR=0.9912249218272523
+Updating DTCOR in event file and recomputing EXPOSURE time
+</VERBATIM>
+           <PARA>
+                In this example, OBS_ID 27499 experiences secondary
+                science corruption which is detected and patched by
+                the script. The output files are a new
+                dead time factors file (dtf1.fits), a new
+                level 1 event file (evt1.fits), and a new
+                good time intervals, aka filter file, (flt1.fits). 
+           </PARA>         
+           <PARA>
+                The script must be run with the level 1 event file since
+                the level 2 event file already has data outside the bad intervals removed.                
+           </PARA>
+
+         </DESC>
+       </QEXAMPLE>
+
+       <QEXAMPLE>
+         <SYNTAX>
+           <LINE>patch_hrc_ssc dtf_in= primary/hrcf01297_000N004_dtf1.fits \</LINE>
+           <LINE>evt_in=secondary/hrcf01297_000N004_evt1.fits \</LINE>
+           <LINE>mtl_in=secondary/hrcf01297_000N004_mtl1.fits \</LINE>
+           <LINE>dtf_out=patched_dtf1.fits evt_out=patched_evt1.fits gti_out=patch_flt1.fits \</LINE>
+           <LINE>mode=h clob+</LINE>
+         </SYNTAX>
+         <DESC>
+<VERBATIM>
+patch_hrc_ssc (10 October 2024)
+      dtf_infile = primary/hrcf01297_000N004_dtf1.fits
+      mtl_infile = secondary/hrcf01297_000N004_mtl1.fits
+      evt_infile = secondary/hrcf01297_000N004_evt1.fits
+     evt_outfile = patched_evt1.fits
+     gti_outfile = patch_flt1.fits
+     dtf_outfile = patched_dtf1.fits
+       threshold = 4000
+    smooth_count = 3
+          tmpdir = /tmp
+         verbose = 1
+         clobber = yes
+            mode = h
+
+SSC not detected, no action required.
+</VERBATIM>
+           <PARA>
+            In this example with OBS_ID 1297, there is no secondary science
+            corruption detected. In this case there are no output files
+            create and the exit status of the tool is 0 (ie good).
+           </PARA>         
+         </DESC>
+       </QEXAMPLE>
+
+    </QEXAMPLELIST>
+
+    <PARAMLIST>
+     <PARAM name="dtf_infile" type="file" filetype="input" reqd="yes">
+       <SYNOPSIS>
+            The input Level 1 dead time factors file, dtf1.fits.
+       </SYNOPSIS>
+     </PARAM>
+     <PARAM name="mtl_infile" type="file" filetype="input" reqd="yes">
+       <SYNOPSIS>
+          The input Level 1 mission time line file, mtl1.fits.
+       </SYNOPSIS>
+     </PARAM>
+     <PARAM name="evt_infile" type="file" filetype="input" reqd="yes">
+       <SYNOPSIS>
+         The input Level 1 event file, evt1.fits. 
+       </SYNOPSIS>
+       <DESC>
+         <PARA>
+            Users should use the Level 1 event file because you cannot
+            recover the updated Good Time Intervals from the already filtered
+            Level 2 event file.  
+         </PARA>
+       </DESC>     
+     </PARAM>
+     <PARAM name="evt_outfile" type="file" filetype="output" reqd="yes">
+       <SYNOPSIS>
+          The output Level 1 event file.
+       </SYNOPSIS>
+       <DESC>
+         <PARA>
+            The output level 1 event file is a copy of the input 
+            level 1 event file with the following keywords modified:
+         </PARA>
+          <LIST>
+            <ITEM>DTCOR : This value is updated based on the patched dead time
+            factor values.</ITEM>
+            <ITEM>DTFFILE : This keyword is updated to be the dtf_outfile file name.</ITEM>
+            <ITEM>FLTFILE : This keyword is updated to be the gti_outfile file name.</ITEM>          
+            <ITEM>SSC = True : This keyword indicates that the secondary science
+            corruption was detected.</ITEM>
+            <ITEM>SSCFIX = True: This keyword indicates that the secondary science
+            correction was fixed (patched).</ITEM>
+          </LIST>
+
+          <PARA>This file should be used in place of the standard archived
+          Level 1 event file in processing.</PARA>
+
+       </DESC>     
+     </PARAM>
+     <PARAM name="gti_outfile" type="file" filetype="output" reqd="yes">
+       <SYNOPSIS>
+          The output good time intervals, aka filter, file.
+       </SYNOPSIS>
+       <DESC>
+         <PARA>
+             The good time intervals are recomputed from the mission time
+             line file based on the patched DTF values and removing the 
+             limit on the IMHVLV and IMHBLV values. 
+         </PARA>
+       </DESC>     
+     </PARAM>
+     <PARAM name="dtf_outfile" type="file" filetype="output" reqd="yes">
+       <SYNOPSIS>
+            The output dead time factors file.
+       </SYNOPSIS>
+       <DESC>
+         <PARA>
+            The median DTF and DTF_ERR values outside the secondary science 
+            correction time are used to replace the values in the dtf_infile.            
+         </PARA>
+       </DESC>     
+     </PARAM>
+     <PARAM name="threshold" type="integer" def="4000" reqd="yes">
+       <SYNOPSIS>
+        The TOTAL_EVT_COUNT threshold used to identify SSC.
+       </SYNOPSIS>
+     </PARAM>
+     <PARAM name="smooth_count" type="integer" def="3" >
+       <SYNOPSIS>
+          Smoothing applied to the TOTAL_EVT_COUNT column 
+       </SYNOPSIS>
+       <DESC>
+         <PARA>
+            The TOTAL_EVT_COUNT column is smoothed over this many rows
+            when looking for values above the threshold parameter.
+         </PARA>
+       </DESC>     
+     </PARAM>
+     <PARAM name="tmpdir" filetype="output" type="file" reqd="no" def="${ASCDS_WORK_PATH}">
+        <SYNOPSIS>Temporary working directory</SYNOPSIS>
+        <DESC>
+          <PARA>
+                Directory used to store temporary file created by the script.
+          </PARA>
+        </DESC>
+      </PARAM>
+     <PARAM name="verbose" type="integer" min="0" max="5" def="1">
+       <SYNOPSIS>
+        Amount of tool chatter level.
+       </SYNOPSIS>
+     </PARAM>
+
+      <PARAM name="clobber" type="boolean" def="no">
+        <SYNOPSIS>
+            Overwrite output files if they already exist?
+        </SYNOPSIS>
+      </PARAM>
+
+   
+   </PARAMLIST>
+
+ 
+    <ADESC title="About Contributed Software">
+      <PARA>
+        This script is not an official part of the CIAO release but is
+        made available as "contributed" software via the
+        <HREF link="https://cxc.harvard.edu/ciao/download/scripts/">CIAO scripts page</HREF>.
+        Please see this page for installation instructions.
+      </PARA>
+    </ADESC>
+    
+
+    <BUGS>
+      <PARA>
+        See the
+        <HREF link="https://cxc.harvard.edu/ciao/bugs/patch_hrc_ssc.html">bug
+        pages</HREF>
+        on the CIAO website for an up-to-date listing of known bugs.
+      </PARA>
+    </BUGS>
+    
+    <LASTMODIFIED>December 2024</LASTMODIFIED>
+
+  </ENTRY>    
+</cxchelptopics>


### PR DESCRIPTION
This PR superceeds #910 .

This includes the new `patch_hrc_ssc` script which is used to identify HRC Secondary Science Corruption which affects the dead time factors (DTF) and good time intervals (GTIs). 

It also add this script to `chandra_repro`.   There is a new parameter `patch_hrc_ssc` which is currently defaulted to `no`. 

