### PR TITLE
fine_astro: look for .gz aux files when copying

### DIFF
--- a/bin/fine_astro
+++ b/bin/fine_astro
@@ -305,6 +305,11 @@ def copy_auxfiles(obsid, out_dirs):
 
     for aux in aux_list:
         aux_file = obsid.get_ancillary(aux)
+        if not os.path.exists(aux_file):
+            aux_file += ".gz"
+            if not os.path.exists(aux_file):
+                aux_file.removesuffix(".gz")
+                raise IOError(f"Cannot locate auxiliary file: {aux_file}")
         fname = os.path.basename(aux_file)
         shutil.copyfile(aux_file,
                         os.path.join(out_dirs.root_dir,


### PR DESCRIPTION
The `get_ancillary` method returns the path+filename w/o the `.gz` extension. 

```python
from ciao_contrib._tools import merging
import stk as stack

obsid = "26732"

files_in_dir = stack.build(f"{obsid}/primary/*,{obsid}/secondary/*")
print(files_in_dir)

obi = merging.validate_obsinfo(obsid)
aux_file = obi[0].get_ancillary("mask")
print(aux_file)

if aux_file not in files_in_dir:
    print("File not found, trying .gz")    
    assert aux_file+".gz" in files_in_dir, "Totally missing"
    print("Compressed version of file found.")
```

The DM does some magic to find `.gz` files if they exist, but we're using system copy so we need to check for missing extension before copying. 


