### PR TITLE
Fix issue 883

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,4 +1,4 @@
-## 4.17.1 - Spring 2024
+## 4.17.1 - March 2025
 
 Updated scripts
 
@@ -6,6 +6,18 @@ Updated scripts
   
     Updates to fix retrieval problem for new temperature dependent
     P2_RESP files used by mkacisrmf.
+
+  find_chandra_repro
+
+    The script better handles the case when there is no matching
+    Chandra observation.
+
+Updated modules
+
+  ciao_contrib.cda.search
+
+    The search_chandra_archive routine now returns None if there was
+    no match.
 
 
 ## 4.17.0 - December 2024
@@ -27,7 +39,7 @@ New Scripts
     sherpa_contrib.matrix_model module.
 
   patch_hrc_ssc
-  
+
     Identify and patch (replace) corrupt dead time factor values
     due to Secondary Science Corruption in HRC data.
 
@@ -35,7 +47,7 @@ New Scripts
 Updated scripts
 
   chandra_repro
-  
+
     Added a new parameter: patch_hrc_ssc, which when set to "yes"
     run the new patch_hrc_ssc script to patch the dead time factor
     values that occur during a Secondary Science Corruption event.

--- a/bin/find_chandra_obsid
+++ b/bin/find_chandra_obsid
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2022, 2023
+#  Copyright (C) 2012 - 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -80,7 +80,7 @@ import coords.format as coords
 from coords import resolver
 
 toolname = "find_chandra_obsid"
-version = "06 January 2023"
+version = "30 January 2025"
 
 lw.initialize_logger(toolname)
 

--- a/ciao_contrib/cda/search.py
+++ b/ciao_contrib/cda/search.py
@@ -1,6 +1,6 @@
 #
-#  Copyright (C) 2011, 2015, 2016, 2018, 2019
-#            Smithsonian Astrophysical Observatory
+#  Copyright (C) 2011, 2015, 2016, 2018, 2019, 2025
+#  Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -466,24 +466,28 @@ def search_chandra_archive(ra, dec, size=0.1,
     # interface, so do it manually (if there is any filtering
     # needed).
     #
-    if out is None:
+    nsearch = len(out)
+    if out is None or nsearch == 0:
         v3("Search returned no matches")
         return None
-    elif grating is None:
-        v3("Search returned {} rows".format(len(out)))
+
+    if grating is None:
+        v3(f"Search returned {nsearch} rows")
         return out
-    else:
-        v3("Original search has {} rows".format(len(out)))
-        v3("Applying grating filters: {}".format(gfilters))
-        idx = False
-        for g in gfilters:
-            idx |= out['Grating'] == g
-        if np.any(idx):
-            v3("Filtering leaves {} rows".format(idx.sum()))
-            return out[idx]
-        else:
-            v3("Filtered out all rows")
-            return None
+
+    v3(f"Original search has {nsearch} rows")
+    v3(f"Applying grating filters: {gfilters}")
+    idx = False
+    for g in gfilters:
+        idx |= out['Grating'] == g
+
+    nmatch = idx.sum()
+    if nmatch > 0:
+        v3(f"Filtering leaves {nmatch} rows")
+        return out[idx]
+
+    v3("Filtered out all rows")
+    return None
 
 
 # Why not return a sturctured array?
@@ -516,6 +520,7 @@ def get_chandra_obs(sr, ra=None, dec=None, fmt=None):
       decstr         dec in format given by fmt
 
     The values are stored in Python lists, not NumPy arrays.
+
     """
 
     colmap = [('ObsId', 'obsid'),

--- a/share/doc/xml/cda_search.xml
+++ b/share/doc/xml/cda_search.xml
@@ -8,7 +8,7 @@
                       search_chandra_archive get_chandra_obs
                       footprint server fov overlap near point position pos
 		      cda chandra data archive public
-                      SIA simple image access endpoint 
+                      SIA simple image access endpoint
 		      python"
          displayseealsogroups="contrib.coords"
 	 seealsogroups="contrib.cda">
@@ -24,7 +24,7 @@
       <LINE/>
       <LINE>ra and dec are in decimal degrees (ICRS). The size argument is a radius, in
             degrees. The instrument argument can be one of "acis", "acis-i", "acis-s",
-            "hrc", "hrc-i", or "hrc-s". The grating argument can be "none", "letg", 
+            "hrc", "hrc-i", or "hrc-s". The grating argument can be "none", "letg",
             or "hetg".</LINE>
       <LINE/>
       <LINE>The fmt argument can be " " or ":" .</LINE>
@@ -105,7 +105,7 @@ from ciao_contrib.cda.search import *
 	</SYNTAX>
 	<DESC>
 	  <PARA>
-            The get_chandra_obs() routine takes the return value from 
+            The get_chandra_obs() routine takes the return value from
             search_chandra_obsid and converts it to a dictionary (actually
             <HREF link="https://docs.python.org/3/library/collections.html#collections.OrderedDict">a
             collections.OrderedDict object</HREF>), ensures there's only
@@ -206,6 +206,13 @@ from ciao_contrib.cda.search import *
 
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.17.1 (February 2025) release">
+      <PARA>
+	Fix up search_chandra_archive so that it returns None if there
+	is no match.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.5.4 (August 2013) release">
       <PARA>
 	Documentation for the ciao_contrib.cda.search module is new in this release.
@@ -221,7 +228,7 @@ from ciao_contrib.cda.search import *
       </PARA>
     </ADESC>
 
-    <LASTMODIFIED>November 2023</LASTMODIFIED>
+    <LASTMODIFIED>January 2025</LASTMODIFIED>
 
   </ENTRY>
 </cxchelptopics>

--- a/share/doc/xml/find_chandra_obsid.xml
+++ b/share/doc/xml/find_chandra_obsid.xml
@@ -804,6 +804,13 @@ Download [y, n, q, a, h]: y
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.17.1 (February 2025) release">
+      <PARA>
+	Better handling of the case where there is no matching Chandra
+	observation.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.15.1 (January 2023) release">
       <PARA>
 	Improved handling of non-ASCII PI names.
@@ -907,6 +914,6 @@ Download [y, n, q, a, h]: y
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>January 2023</LASTMODIFIED>
+    <LASTMODIFIED>January 2025</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
I assume that something was changed in the 4.15.x series to deal with non-ASCII PI names which had unforseen consequences for the error checks. Or something has changed in how a null result is returned from the CXC Footprint Service. Otherwise I don't see how I could have not seen this problem.

Fix #883 