### PR TITLE
Updated specextract warm_temperature_warning() to be consistent with …

### DIFF
--- a/bin/specextract
+++ b/bin/specextract
@@ -2066,10 +2066,10 @@ already exist.
 def warm_temperature_warning(fn_iter):
     """
     check for later warm temperature observations and
-    throw warning after 2020-07-01T00:00:00 (Chandra Time: 709948806)
+    throw warning after 2018-01-01T06:00:00 (Chandra Time: 631173600)
     """
 
-    warm_tstart = 709948806
+    warm_tstart = 631173600
     warm_dict = {}
 
     for fn in fn_iter:
@@ -2082,7 +2082,7 @@ def warm_temperature_warning(fn_iter):
             obsid = kw["OBS_ID"]
             fptemp = kw["FP_TEMP"] - 273.15
 
-            if fptemp > -109:
+            if fptemp > -111:
                 warm_dict[f"{obsid}"] = fptemp
 
     if len(warm_dict) > 0:
@@ -2090,21 +2090,13 @@ def warm_temperature_warning(fn_iter):
             msg = f'''
 Caution:
 
-    The mean ACIS focal plane temperature for ObsID {obsid} is {fptemp:.2f} C which is warmer than the currently calibrated high temperature limit of -109 C (164.15 K).
+    The mean ACIS focal plane temperature for ObsID {obsid} is {fptemp:.2f} C. Users fitting ACIS imaging spectra which include emission and/or absorption features and meet at least one of the following two conditions may see line-centroids shifted by 1-2% from systematic offsets due to calibration uncertainty:
 
-    Users fitting ACIS imaging spectra that fulfill all the following three conditions may see line-centroids shifted by 1-2% from systematic offsets due to calibration uncertainty:
+    (1) Spectra with more than 500 counts on a front-illuminated (FI) chip or more than 1000 counts on a back-illuminated (BI) chip (CCD_ID 5,7) taken with ACIS focal-plane temperature between -105 C to -108 C.
 
-    (1) Spectra with more than 1000 counts on a front-illuminated
-        (FI) chip or more  than 2000 counts on a back-illuminated
-        (BI) chip (CCD_ID 5,7).
+    (2) Spectra with more than 2500 counts on a front-illuminated (FI) chip or more than 4000 counts on a back-illuminated (BI) chip (CCD_ID, 5,7) taken with ACIS focal-plane temperature between -108 C to -111 C.
 
-    (2) More than half of source counts were acquired above the
-        current temperature limit of -109 C.
-
-    (3) More than half of source counts are in emission or
-        absorption lines.
-
-    Under these conditions, users may benefit from trying to identify time periods when the focal plane temperature was within the currently calibrated range, below -109 C, using the following thread:
+    Under these conditions, users may benefit from trying to identify time periods when the focal plane temperature was outside the range where this calibration uncertainty occurs using the following thread:
 
     https://cxc.cfa.harvard.edu/ciao/threads/acisfptemp/
 


### PR DESCRIPTION
…ACIS calibration and CIAO 417 documentation.  The trigger date has changed to 2018-01-01 and the ACIS focal plane temperature trigger has changed from -109 C to -111 C.

This change should be included in the next chance we have to make a new ciaocontrib package update.