### PR TITLE
fine_astro: error checking on outroot

### DIFF
--- a/bin/fine_astro
+++ b/bin/fine_astro
@@ -31,7 +31,7 @@ from pycrates import read_file
 
 
 __toolname__ = "fine_astro"
-__revision__ = "23 October 2024"
+__revision__ = "18 February 2025"
 
 WARN_LARGE_SHIFT = 3.0
 WARN_LARGE_OFFSET = 4.0
@@ -418,7 +418,7 @@ def detect_sources(obis, pars, out_dirs):
         verb1("Running pre-detect merge_obs")
         evtlist = [f"{oo.get_evtfile()}{pars['det_filter']}" for oo in obis]
 
-        merge_dir = os.path.join(out_dirs.root_dir,out_dirs.pre_detect)
+        merge_dir = os.path.join(out_dirs.root_dir, out_dirs.pre_detect)
         if merge_dir:
             os.makedirs(merge_dir, exist_ok=True)
 
@@ -520,10 +520,14 @@ def main():
     # ~ from ciao_contrib._tools.fileio import outfile_clobber_checks
     # ~ outfile_clobber_checks(pars["clobber"], pars["outfile"])
 
-    out_dirs = OutputDirs()
+    if pars["outroot"] == "":
+        raise IOError("ERROR: outroot is blank")
 
-    out_dirs.root_base = os.path.basename(pars["outroot"])
+    out_dirs = OutputDirs()
     out_dirs.root_dir = os.path.dirname(pars["outroot"])
+    out_dirs.root_base = os.path.basename(pars["outroot"])
+    if out_dirs.root_base == "":
+        raise IOError("ERROR: outroot must have an output root file name with an optional path name.")
 
     from ciao_contrib._tools import merging
     obis = merging.validate_obsinfo(pars["infile"])

--- a/share/doc/xml/fine_astro.xml
+++ b/share/doc/xml/fine_astro.xml
@@ -651,6 +651,14 @@ ahelp -b PARAM -t scales wavdetect
           </PARA>
     </ADESC>
 
+    <ADESC title="Changes in scripts 4.17.1 (February 2025) release">
+      <PARA>
+        The script fails if the outroot only contains a directory. Added
+        a check to make sure that the outroot also contains an output root 
+        file name.
+      </PARA>    
+    </ADESC>
+
     <ADESC title="About Contributed Software">
       <PARA>
         This script is not an official part of the CIAO release but is
@@ -672,6 +680,6 @@ ahelp -b PARAM -t scales wavdetect
         listing of known bugs.
       </PARA>
     </BUGS>
-    <LASTMODIFIED>December 2024</LASTMODIFIED>
+    <LASTMODIFIED>February 2025</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
Force user to specify an output root **file** name ; not just a directory.  Different scripts behave differently w/ only dir name and trying to guess/discover filenames is fragile.

Ref HD 25612
