### PR TITLE
chandra_repro: multiple files gzip only

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2010-2024  Smithsonian Astrophysical Observatory
+# Copyright (C) 2010-2025  Smithsonian Astrophysical Observatory
 #
 #
 #
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "25 November 2024"
+version = "24 February 2025"
 
 # import standard python modules as required
 #
@@ -563,7 +563,7 @@ def setup_dirs_and_root( indir, outdir, root, cycle="" ):
     #!### Make sure there are some files ###
     evt1check=[]
     for dir in [indir, secondarydir]:
-        products=os.listdir(dir)
+        products=clean_dir(os.listdir(dir))
         for ff in products:
             if re.search(".*"+cycle+"evt1.fits*",ff):
                 evt1check.append(ff)
@@ -751,7 +751,7 @@ def event1_inputs(params):
     v2("Gathering chandra_repro input files and parameter information.")
 
     try:
-        secondary_products=os.listdir(params["secondarydir"])
+        secondary_products=clean_dir(os.listdir(params["secondarydir"]))
         secondary_products.sort()
     except:
         error_out(params,"Could not read input directory '%s'" % params["secondarydir"], 'read error')
@@ -839,6 +839,19 @@ def event1_inputs(params):
     return params
 
 
+def clean_dir(dir_list):
+    '''Check for file names that are the same except ending in .gz; remove
+    .gz version'''
+
+    retval = list(dir_list).copy()
+    
+    for _dir in dir_list:
+        check = _dir+".gz"
+        if check in retval:
+            retval.remove(check)
+    return retval
+
+
 def get_inputs(params):
     "Gather chandra_repro inputs"
 
@@ -874,6 +887,7 @@ def get_inputs(params):
                "which is different from the expected value read from "+
                "the header of the event file.")
 
+    primary_products = clean_dir(primary_products)
 
     for ff in primary_products:
 
@@ -1003,7 +1017,7 @@ def get_inputs(params):
         secondary_products=os.listdir(params["secondarydir"])
         if params["__obc_mode__"] is True:
             asp_sec = os.path.join( params["secondarydir"],"aspect")
-            asp_sec_dir = os.listdir( asp_sec )
+            asp_sec_dir = clean_dir(os.listdir( asp_sec ))
             secondary_products.extend( asp_sec_dir)
     except Exception as e:
         error_out(params,"Could not read input directory '%s'" % params["secondarydir"], 'read error')
@@ -1012,6 +1026,8 @@ def get_inputs(params):
 
     #!### Set a flag if this indir is equal to outdir (dont bother copying handy files) ###
     indir_is_outdir = os.path.samefile(params["secondarydir"],params["outdir"])
+
+    secondary_products = clean_dir(secondary_products)
 
     for ff in secondary_products:
 
@@ -1193,7 +1209,7 @@ def get_inputs(params):
 
     # Look for the V&V report in the top level indir
 
-    toplevel_products=os.listdir(params["indir"])
+    toplevel_products=clean_dir(os.listdir(params["indir"]))
     
     for ff in toplevel_products:
         if ff.endswith("vv2.pdf.gz"):

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -852,6 +852,16 @@ tg_zo_position="5:35:15.7594,-5:23:10.191"
     </PARAMLIST>
 
 
+<ADESC title="Changes in the scripts 4.17.1 (February 2025) release">
+  <PARA>
+    Adjusted the logic that deals with finding multiple file names for the
+    same file type (eg two bad pixel files). If the files names differ only in the
+    presence of the ".gz" suffix, then now the ".gz" file is ignored. Previously
+    this would trigger an error.
+  </PARA>
+</ADESC>
+
+
 <ADESC title="Changes in the scripts 4.17.0 (December 2024) release">
   <PARA title="New HRC Science Science Corruption tool">
     A new parameter has been added: patch_hrc_ssc, which when set to 
@@ -1372,6 +1382,6 @@ The script now runs tgdetect2 for grating data when recreate_tg_mask=yes
       </PARA>
     </BUGS>
 
-    <LASTMODIFIED>December 2024</LASTMODIFIED>
+    <LASTMODIFIED>February 2025</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
This fixes #904 

This relaxes the multiple-files warning. If multiple files of the same type (bpix, evt, fov, etc) are found and the only difference is the presence of the `.gz` suffix then the compressed file is omitted.

This still produces the warning since there's a check in the `gunzip` routine that looks for `filename`+`.gz` which is good; it's just no longer in conflict with the `os.listdir` loop logic.

