### PR TITLE
install_marx: fix for conda OTS

### DIFF
--- a/bin/install_marx
+++ b/bin/install_marx
@@ -1,5 +1,5 @@
 #!/bin/bash
-#  Copyright (C) 2014,2017-2019, 2021, 2023
+#  Copyright (C) 2014,2017-2019, 2021, 2023, 2025
 #  Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 
 
 tool="install_marx"
-ver="24 March 2024"
+ver="24 February 2025"
 
 #
 # Version setup, paths, filenames
@@ -145,7 +145,7 @@ fi
 
 
 cd marx-${marx_ver}
-(./configure --prefix="$top/marx-${marx_ver}" --with-cfitsio=$ASCDS_INSTALL/ots && make)
+(./configure --prefix="$top/marx-${marx_ver}" --with-cfitsio=$ASCDS_INSTALL && make)
 if test $? -ne 0
 then
   echo "# $tool ($ver): ERROR: Problem building MARX.  Contact MARX team for help: marx-help@space.mit.edu" 1>&2


### PR DESCRIPTION
This fixes #842 

Really a no-op.  Take or don't. 

This only affect marxrsp which isn't used by users. Plus marx is conda so users don't need to build anymore. 

Just wanted to close the other ticket.  