### PR TITLE
dax: interactive gratings coords calculator, force region format to ds9

### DIFF
--- a/bin/ds9_itgcoords_launch
+++ b/bin/ds9_itgcoords_launch
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-#  Copyright (C) 2022  Smithsonian Astrophysical Observatory
+#  Copyright (C) 2022, 2025  Smithsonian Astrophysical Observatory
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -94,7 +94,7 @@ physical
 line({x0},{y0},{x1},{y1}) # line=0 1 callback=edit {{run_tgcoords}} "0" callback=move {{run_tgcoords}} "0" color=goldenrod dashlist=4 4 tag={{tgcoords}}
 """
 
-    xpaset(xpa, "regions", reg_str)
+    xpaset(xpa, "regions -format ds9", reg_str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes #960 

If users have preferences to use regions in eg CIAO format then region would not load correct. Need to force to use ds9 format. 

No need to update Changes/ahelp IMO.
