### PR TITLE
Python3 12 invalid escape seq

### DIFF
--- a/bin/simulate_psf
+++ b/bin/simulate_psf
@@ -2,7 +2,7 @@
 #
 #
 #
-# Copyright (C) 2012, 2014, 2016, 2018, 2020-2023
+# Copyright (C) 2012, 2014, 2016, 2018, 2020-2023, 2025
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -26,7 +26,7 @@ import sys
 import subprocess
 
 toolname = "simulate_psf"
-__revision__ = "15 July 2024"
+__revision__ = "12 June 2025"
 
 
 from cxcdm import *
@@ -186,7 +186,7 @@ def cleanup_saotrace( outroot ):
     import glob as glob
 
     for extn in [ "log", "block", "lua", "summary.yml", "gi", "totwt-in", "totwt-out"]:
-        for tt in glob.glob( outroot+"_00[1346][\._]*"+extn ):
+        for tt in glob.glob( outroot+r"_00[1346][\._]*"+extn ):
             gorm( tt )
         if extn not in ["log", "lua", "gi"]:
             gorm( outroot + "." + extn )

--- a/bin/splitroi
+++ b/bin/splitroi
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2011, 2012, 2018, 2023
+# Copyright (C) 2011, 2012, 2018, 2023, 2025
 # Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
@@ -35,7 +35,7 @@ gives the head/stem of the output files created:
 """
 
 toolname = "splitroi"
-version = "30 January 2023"
+version = "12 June 2025"
 
 import sys
 
@@ -128,7 +128,7 @@ def main():
     if len(arglist) != 3:
         sys.stderr.write("Usage: splitroi infiles outhead\n\n")
         sys.stderr.write("Example:\n")
-        sys.stderr.write("   splitroi src\*.fits sources\n\n")
+        sys.stderr.write("   splitroi src\\*.fits sources\n\n")
         sys.stderr.write("will split the SRCREG and BKGREG blocks from the src*.fits files\n")
         sys.stderr.write("and create the ASCII region files sources.src.reg and sources.bg.reg.\n")
         sys.exit(1)

--- a/bin/srcflux
+++ b/bin/srcflux
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2013-2024 Smithsonian Astrophysical Observatory
+# Copyright (C) 2013-2025 Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 #
 
 toolname = "srcflux"
-__revision__ = "17 April 2024"
+__revision__ = "12 June 2025"
 
 import os
 
@@ -3112,7 +3112,7 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
             has_vals.append(v.name)
 
             # Check for valid name (FITS standard)
-            if re.match("^[A-Za-z0-9][A-Za-z0-9_\-]*$", v.name) is None:
+            if re.match(r"^[A-Za-z0-9][A-Za-z0-9_\-]*$", v.name) is None:
                 verb0(f"WARNING: User plugin failed with an invalid column name '{v.name}'. Only letter, number, dash, and underscore are allowed. Must start with a letter or number.")
                 retval = False
                 continue


### PR DESCRIPTION
Python 3.12 is now printing a warning about invalid escape sequences.  Basically when a `\` is used in a regular string when it's not meant to be an escape. Need to either use raw strings, `r"\foo"` or escape the back slash, `\\`


Updates to

- `srcflux`
- `splitroi`
- `simulate_psf`

I updated the date, but given the minor change, I don't think worth adding to ahelp/changes.


