### PR TITLE
support long region expressions in excess of 1023 characters

### DIFF
--- a/bin/srcflux
+++ b/bin/srcflux
@@ -18,7 +18,7 @@
 #
 
 toolname = "srcflux"
-__revision__ = "17 April 2024"
+__revision__ = "10 June 2025"
 
 import os
 
@@ -178,15 +178,15 @@ def locate_fovfile( myparams ):
 
 def make_optimized_regions(myparams):
     '''Create point source optimized regions using new psf_countour and
-    bkg_fixed_counts scripts.      
+    bkg_fixed_counts scripts.
     '''
     from region import CXCRegion
-    
+
     fov = locate_fovfile( myparams)
-    
+
     verb1("Creating optimized source regions")
     psf_contour = make_tool("psf_contour")
-    psf_contour.infile = myparams.infile 
+    psf_contour.infile = myparams.infile
     psf_contour.pos = myparams.outroot+"srcs.fits"
     psf_contour.outroot = myparams.outroot
     psf_contour.method = "contour"
@@ -203,7 +203,7 @@ def make_optimized_regions(myparams):
 
     src_list = myparams.outroot+"src.lis"
     out_lis = stk.build(myparams.outroot+"_i*_src.reg")
-    out_lis.sort()    
+    out_lis.sort()
     with open(src_list, "w") as fptr:
         for reg_file in out_lis:
             reg = CXCRegion(reg_file)
@@ -217,7 +217,7 @@ def make_optimized_regions(myparams):
     tab = read_file(myparams.outroot+"srcs.fits")
     inst = tab.get_key_value("INSTRUME")
     if inst == "ACIS":
-        bg_infile += "[energy=500:7000]"   #  Use broad band for bg 
+        bg_infile += "[energy=500:7000]"   #  Use broad band for bg
 
     verb1("Creating optimized background regions")
     bkg_fixed = make_tool("bkg_fixed_counts")
@@ -232,10 +232,10 @@ def make_optimized_regions(myparams):
     chat = bkg_fixed(clobber=True)
     if chat:
         verb2(chat)
-    
+
     bkg_list = myparams.outroot+"bkg.lis"
     out_lis = stk.build(myparams.outroot+"_i*_bkg.reg")
-    out_lis.sort()    
+    out_lis.sort()
     with open(bkg_list, "w") as fptr:
         for reg_file in out_lis:
             reg = CXCRegion(reg_file)
@@ -246,7 +246,7 @@ def make_optimized_regions(myparams):
         gorm(to_del)
         for suffix in [".psf", ".smpsf", "_projrays.fits", "_src.reg"]:
             gorm(to_del.replace("_bkg.reg", suffix))
-        
+
     return f"@-{src_list}", f"@-{bkg_list}"
 
 
@@ -314,13 +314,18 @@ def validate_src_and_bkg_regions( myroot, infile, tmpdir, src, bkg ):
         tfile = tmproot.name
         tmproot.close()
 
-        dmmakereg.region=reg
-        dmmakereg.outfile=tfile
-        dmmakereg.kernel='fits'
-        dmmakereg.wcsfile=infile
-        dmmakereg.clobber=True
-        dmmakereg.verbose=0
-        dmmakereg()
+        with NamedTemporaryFile() as longreg:
+
+            CXCRegion(reg).write(longreg.name, fits=False, clobber=True)
+            dmmakereg.region = f"region({longreg.name})"
+
+            #dmmakereg.region=reg
+            dmmakereg.outfile=tfile
+            dmmakereg.kernel='fits'
+            dmmakereg.wcsfile=infile
+            dmmakereg.clobber=True
+            dmmakereg.verbose=0
+            dmmakereg()
 
         rr=CXCRegion(dmmakereg.outfile)
         gorm( tfile )
@@ -329,9 +334,10 @@ def validate_src_and_bkg_regions( myroot, infile, tmpdir, src, bkg ):
 
     def validate_region( reg ):
         "See if it is a file, need to open w/ DM to check filters/etc"
-        try:
-            read_file(reg)
-            reg = f"region({reg})"
+        try:            
+            if os.path.isfile( (reg[:reg.find("[")] if "[" in reg else reg) ): # this is needed since read_file core dumps if it checks a really long string, e.g. region intersected by polygonal FOV expression
+                read_file(reg)
+                reg = f"region({reg})"
             try:
                 check = CXCRegion(reg)
             except:
@@ -637,10 +643,10 @@ def get_counts( myparams, at_energy, src, bkg ):
 
 
 def run_simulate_psf(sim_psf):
-    "Run a single instance of simulate_psf"        
+    "Run a single instance of simulate_psf"
     verb1("Simulating PSF: "+sim_psf.outroot)
 
-    # The make_tool object can't be pickled so I'm just 
+    # The make_tool object can't be pickled so I'm just
     # going to copy parameters using the Params object.
     simulate_psf = make_tool("simulate_psf")
     for attr in dir(sim_psf):
@@ -1527,18 +1533,18 @@ def add_variability_to_output(myparams, at_energy, lcfiles ):
     odds = []
     prob = []
     varindex = []
-    
+
     for ff in lcfiles:
         tab = read_file(ff)
         odds.append(tab.get_key_value("ODDS"))
         prob.append(tab.get_key_value("PROB"))
         varindex.append(tab.get_key_value("VARINDEX"))
-    
+
     from crates_contrib.utils import add_colvals
     tab = read_file(myroot+__osuf__, mode="rw")
     add_colvals(tab, "SRC_VAR_ODDS", odds, desc="Odds for variable signal 10Log")
     add_colvals(tab, "SRC_VAR_PROB", prob, desc="Probability of variable signal")
-    add_colvals(tab, "SRC_VAR_INDEX", varindex, desc="Variability index")    
+    add_colvals(tab, "SRC_VAR_INDEX", varindex, desc="Variability index")
     tab.write()
 
 
@@ -2061,7 +2067,7 @@ def run_dither_region(myparams,outroot, src, suffix):
     asol_files = obs.get_asol() if 0 == len(myparams.asolfile) else myparams.asolfile
     msk = obs.get_ancillary("mask") if 0 == len(myparams.mskfile) else myparams.mskfile
     bpix = obs.get_ancillary("bpix") if 0 == len(myparams.bpixfile) else myparams.bpixfile
-    
+
     punlearn("ardlib")
     detnam = obs.get_keyword("DETNAM")
     if detnam.startswith("ACIS"):
@@ -2074,7 +2080,7 @@ def run_dither_region(myparams,outroot, src, suffix):
         dtf = obs.get_ancillary("dtf") if 0 == len(myparams.dtffile) else myparams.dtffile
         dtf_val = "DTF"
     elif detnam == "HRC-S":
-        pset("ardlib", "AXAF_HRC-S_BADPIX_FILE", bpix)            
+        pset("ardlib", "AXAF_HRC-S_BADPIX_FILE", bpix)
         dtf = obs.get_ancillary("dtf") if 0 == len(myparams.dtffile) else myparams.dtffile
         dtf_val = "DTF"
     else:
@@ -2114,7 +2120,7 @@ def run_dither_region(myparams,outroot, src, suffix):
 
 def run_glvary(at_energy, ii, src, bkg, myparams):
     """
-    We run glvary, but only on the source region    
+    We run glvary, but only on the source region
     """
 
     verb1("Making Lightcurve for source "+str(ii))
@@ -2123,17 +2129,17 @@ def run_glvary(at_energy, ii, src, bkg, myparams):
         tab = read_file("{}[sky={}]".format(infile,region))
         if tab.get_key_value("INSTRUME") == "HRC":
             return ""
-        
+
         if tab.get_nrows() == 0:
             return ""  #   Doesn't matter which GTI if there are no counts
-        
+
         #
         # I want to get a list of the ccd_id values, but
         # if there is more than 1 chip, I want to _try_
         # to use the GTI of the chip with the most
         # events.
         #
-        ccd_val = tab.get_column("CCD_ID").values        
+        ccd_val = tab.get_column("CCD_ID").values
         ccds = list(np.unique(ccd_val))
         most_common = np.bincount(ccd_val).argmax()
         ccds.remove(most_common)
@@ -2158,7 +2164,7 @@ def run_glvary(at_energy, ii, src, bkg, myparams):
     with newpf(tmpdir=myparams.tmpdir, copyuser=False, ardlib=False) as foo:
         src_eff_file = run_dither_region(myparams, outroot, src, "src")
         bkg_eff_file = run_dither_region(myparams, outroot, bkg, "bkg")
-        
+
     glvary = make_tool("glvary")
     glvary.infile = inroot+"[sky={}]{}".format(src,ccd_id_filter)
     glvary.outfile = outroot+".prob"
@@ -2180,7 +2186,7 @@ def run_glvary(at_energy, ii, src, bkg, myparams):
     dmextract.clobber = myparams.clobber
     dmextract.verbose = myparams.verbose
     verb2(dmextract())
-    
+
     gorm(src_eff_file)
     gorm(bkg_eff_file)
 
@@ -2202,7 +2208,7 @@ def get_variability( taskrunner, myparams, at_energy, src, bkg ):
     for ii in range(len(src_stk)):
         outroot = "{}{:04d}_{}.gllc".format( myparams.outroot, ii+1, suffix)
         taskrunner.add_task( outroot, "", run_glvary, at_energy, ii+1, src_stk[ii], bkg_stk[ii], myparams)
-        infiles.append(outroot) 
+        infiles.append(outroot)
 
     return infiles
 
@@ -2359,12 +2365,12 @@ def merge_get_counts( infiles ):
             assert cc in range(10)
             etime = tab.get_key_value("LIVTIME{}".format(cc))
             if etime is None:
-                # For sources right on the edge of the chip, they 
-                # can be inside the FOV (includes dither), but the 
+                # For sources right on the edge of the chip, they
+                # can be inside the FOV (includes dither), but the
                 # chip_id value itself is computed
-                # at the mean pointing, so it may be on another 
+                # at the mean pointing, so it may be on another
                 # chip, which is no turned on. If this happens, just
-                # set exposure time to LIVETIME (to be consistent w/ 
+                # set exposure time to LIVETIME (to be consistent w/
                 # individual obi)
                 etime = tab.get_key_value("LIVETIME")
             retval['exptime'].append(etime)
@@ -3007,22 +3013,22 @@ def check_parameters( myparams ):
                 raise ValueError("Cannot locate HRC dead time factors file.  Please specify 'dtffile' parameter.")
         elif "none" == myparams.dtffile.lower():
             verb0("\nWARNING: dead time factors file parmater set to 'none'; DTF information will not be use.  This may lead to inaccuracies in the results\n")
-    
+
     if myparams.regions == "optimized" and myparams.psfmethod == "quick":
         raise ValueError("ERROR: Invalid parameter combination. psfmethod=quick requires circular source regions, however, regions=optimized creates polygon shaped regions. These two options cannot be used together.")
 
 
 def check_nom_keywords(evt_files):
-    """If there is more than 1 event files, then they must have the 
+    """If there is more than 1 event files, then they must have the
     same tangent point.  Check the RA and DEC_NOM values in the headers.
-    
+
     But, this is only true if regions are in physical coords. If celestial
     then OK.  Unfortunately we don't know the coord sys so we have to
     make this a warning not an error.
     """
 
     def _check_key(nom_key, nom_val):
-        key_val = tab.get_key_value(nom_key)        
+        key_val = tab.get_key_value(nom_key)
         if nom_val is None:
             nom_val = key_val
         if nom_val != key_val:
@@ -3033,7 +3039,7 @@ def check_nom_keywords(evt_files):
 
     ra_nom = None
     dec_nom = None
-    
+
     for evt in evt_files:
         tab = read_file(evt)
         ra_nom = _check_key("RA_NOM", ra_nom)
@@ -3076,9 +3082,9 @@ def build_infile_stacks( pars ):
 
 def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
     """
-    Allow the user to write a plugin that can be run after all the 
+    Allow the user to write a plugin that can be run after all the
     other processing is complete and to collect those results with
-    in the output .flux file.    
+    in the output .flux file.
     """
 
     import importlib
@@ -3095,7 +3101,7 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
         retval = True
         has_vals = []
 
-        for v in vals:            
+        for v in vals:
 
             # Check that value has require attributes
             for k in ["name", "units", "value", "description"]:
@@ -3124,7 +3130,7 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
                                          'vals': [v.value,]}
             else:
                 plugin_values[v.name]["vals"].append(v.value)
-            
+
         # Keep a list of values so that we can easily check all sources
         # return the same set of values.
         if len(list_of_values) == 0:
@@ -3146,7 +3152,7 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
 
         from pycrates import CrateData, add_col
         intab = read_file(outfile, mode="rw")
-        
+
         for newcol in list_of_values:
             _col = CrateData()
             _col.name = newcol
@@ -3154,13 +3160,13 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
             _col.desc = plugin_values[newcol]["desc"]
             _col.values = plugin_values[newcol]["vals"]
             add_col(intab, _col)
-            
+
         intab.write()
 
     if myparams.pluginfile == "" or myparams.pluginfile.lower() == "none":
         return
 
-    # Locate the plugin, add dirname to python path or cwd if no dir        
+    # Locate the plugin, add dirname to python path or cwd if no dir
     try:
         pdir = os.path.dirname(myparams.pluginfile)
         if pdir == "":
@@ -3198,7 +3204,7 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
         _vals = efilt.split("=")[1]
         elo,ehi = [float(x) for x in _vals.split(":")]
 
-    # Get the number of sources    
+    # Get the number of sources
     intab = read_file( myroot+__osuf__, mode="r")
     src_cts = intab.get_column("component").values
     del intab
@@ -3208,11 +3214,11 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
     else:
         infiles = [s.infile for s in stk_params]
 
-    # Loop over sources.  Not running in parallel 
+    # Loop over sources.  Not running in parallel
     # right now.
     for ii in range( len(src_cts) ):
         outroot = myparams.outroot+"{:04d}".format(ii+1)
-            
+
         vals = plugin_cmd(infiles, outroot, band, elo, ehi, ii+1)
 
         if _check_vals(vals, list_of_values, plugin_values) == False:
@@ -3221,7 +3227,7 @@ def run_user_plugin(myparams, at_energy, plugin_name, stk_params=None):
 
     write_plugin_values(myroot+__osuf__, list_of_values, plugin_values)
 
-    
+
 
 def process_single_obi( myparams, pars ):
     """
@@ -3253,9 +3259,9 @@ def process_single_obi( myparams, pars ):
         add_modelflux_to_output( myparams, at_energy, mfluxfiles )
         scale_modelflux_fluxes( myparams, at_energy )
         add_variability_to_output( myparams, at_energy, lcfiles)
-        
+
         run_user_plugin(myparams, at_energy, "srcflux_obsid_plugin")
-        
+
         cleanup_outfile( myparams, pars, at_energy )
 
 
@@ -3309,13 +3315,13 @@ def obi_main(pars):
 @lw.handle_ciao_errors( toolname, __revision__)
 def main():
 
-    __must_have = ("infile", "pos", "outroot", "bands", "srcreg", 
+    __must_have = ("infile", "pos", "outroot", "bands", "srcreg",
                    "bkgreg", "bkgresp", "psfmethod", "psffile", "conf",
-                   "binsize", "rmffile", "arffile", "model", 
-                   "paramvals", "absmodel", "absparams", "abund", 
-                   "pluginfile", "fovfile", "asolfile", "mskfile", 
-                   "bpixfile", "dtffile", "ecffile", "parallel", 
-                   "nproc", "tmpdir", "random_seed", "clobber", 
+                   "binsize", "rmffile", "arffile", "model",
+                   "paramvals", "absmodel", "absparams", "abund",
+                   "pluginfile", "fovfile", "asolfile", "mskfile",
+                   "bpixfile", "dtffile", "ecffile", "parallel",
+                   "nproc", "tmpdir", "random_seed", "clobber",
                    "verbose", "regions", "marx_root",)
 
     # Load parameters
@@ -3351,7 +3357,7 @@ def main():
     merged_fluxes = merge_counts( stk_pars, myparams)
     modelflux_vals = merge_modelflux( stk_pars, myparams )
     merge_write_output( stk_pars, myparams, modelflux_vals, merged_fluxes)
-    
+
     for at_band in stk.build( myparams.bands):
         run_user_plugin(myparams, at_band, "srcflux_merge_plugin", stk_params=stk_pars)
 


### PR DESCRIPTION
This stems from helpdesk ticket #025802 where a user was running into a core dump.  I confirmed the behavior on both RHEL8 x86-64 and macOS 15 ARM64.  

There is a two-fold problem when the `srcreg` and/or `bkgreg` are used with region stacks in `srcflux`.  For sources near the chip edge `roi` (and subsequently the `splitroi` output used by `srcflux`) will return a source region intersected by a polygon region expression defining the detector FOV.  The polygonal region expression, let alone the compound expression, can easily exceed 1023 characters and when `srcflux` is used in this mode, it will first use `pycrates.read_file` to check whether or not the expression is a readable FITS file and then use `dmmakereg` to check the input region expression can be written in sky coordinates.

The core dump comes from `read_file`, which crashes when the input file expression has a long string length. Working around this, then `srcflux` then tries to use the region expression directly with `dmmakereg` fails due to a `region` parameter having a character length limit of 1023; putting the region expression in a temporary region file is then usable with `dmmakereg`.

A whole bunch of trailing white spaces are also eliminated.
