### PR TITLE
Dax tg coords arbitrary frame

### DIFF
--- a/bin/ds9_itgcoords_launch
+++ b/bin/ds9_itgcoords_launch
@@ -21,7 +21,7 @@
 
 import sys
 
-from dax.utils import xpaset, xpaget
+from dax.utils import xpaset, xpaget, xpaset_p
 
 
 def get_zero_order_location(xpa):
@@ -94,7 +94,8 @@ physical
 line({x0},{y0},{x1},{y1}) # line=0 1 callback=edit {{run_tgcoords}} "0" callback=move {{run_tgcoords}} "0" color=goldenrod dashlist=4 4 tag={{tgcoords}}
 """
 
-    xpaset(xpa, "regions -format ds9", reg_str)
+    xpaset_p(xpa, ["regions format ds9",])
+    xpaset(xpa, "regions", reg_str)
 
 
 if __name__ == "__main__":

--- a/config/chips_startup.tk
+++ b/config/chips_startup.tk
@@ -81,8 +81,14 @@ proc run_tgcoords { frame id } {
 
     global ds9
     global tgcoords_order
+    global current
 
-    set frm [lindex $ds9(frames) $frame]
+    if { $frame == 0 } {
+        set frm $current(frame)
+    } else {
+        set frm [puts $frame]
+    }
+
     set coords [$frm get marker $id line point physical]
     set x0 [lindex $coords 0]
     set y0 [lindex $coords 1]

--- a/share/doc/xml/dax.xml
+++ b/share/doc/xml/dax.xml
@@ -134,7 +134,9 @@ unix% ds9 -analysis $ASCDS_CONTRIB/config/ciao.ds9 ...
 <ADESC title="Changes in scripts 4.17.2 (August 2025) release">
   <PARA>
     The Chandra Interactive Grating coordinates calculator now also displays
-    the value for wavelength in Angstroms.
+    the value for wavelength in Angstroms, it will now work when launched
+    from any frame, and ensure regions can be displayed no-matter what
+    the region preference setting is.
   </PARA>
 
 </ADESC>
@@ -679,6 +681,6 @@ clear which task is being run.
       </PARA>
    </BUGS>
 
-   <LASTMODIFIED>June 2025</LASTMODIFIED>
+   <LASTMODIFIED>August 2025</LASTMODIFIED>
 </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
interactive grating coords was only working if it was launched from the first, initial frame. Change now allows it to work in any frame.

Also fixes issue if prefs are set to CIAO region format, forces the region to be loaded in ds9 format. 
