### PR TITLE
vtbin: tweak verbose output for numpy2

### DIFF
--- a/bin/vtbin
+++ b/bin/vtbin
@@ -176,8 +176,10 @@ def make_polygon(cell, img_shape):
         if len(p) == 0:
             raise RuntimeError("Bad polygon")
     except Exception as bad:
-        print(f"Cellx: {cell.cellx}")
-        print(f"Celly: {cell.celly}")
+        pp = ", ".join([str(x) for x in cell.cellx])
+        print(f"Cellx: [{pp}]")
+        pp = ", ".join([str(x) for x in cell.celly])
+        print(f"Celly: [{pp}]")
         raise bad
 
     # Loop over pixels just inside extent of polygon

--- a/bin/vtbin
+++ b/bin/vtbin
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2014-2020, 2023
+# Copyright (C) 2014-2020, 2023,2025
 # Smithsonian Astrophysical Observatory
 #
 # This program is free software; you can redistribute it and/or modify
@@ -28,7 +28,7 @@ import ciao_contrib.logger_wrapper as lw
 
 
 __toolname__ = "vtbin"
-__revision__ = "24 August 2023"
+__revision__ = "21 August 2025"
 
 __lgr__ = lw.initialize_logger(__toolname__)
 verb0 = __lgr__.verbose0


### PR DESCRIPTION
expand list to get `str` of each `np.float64` value. 

This fixes #977 