### PR TITLE
csccli: use context manager for urlopen to close connection

### DIFF
--- a/ciao_contrib/cda/csccli.py
+++ b/ciao_contrib/cda/csccli.py
@@ -407,17 +407,17 @@ def make_URL_request( resource, vals ):
     # make easy to ID in logs
     request.add_header('User-Agent', 'ciao_contrib.cda.csccli/1.1')
 
-    try:
-        response = urlopen( request )
-        page = response.read()
+    with urlopen(request) as response:
+        try:
+            page = response.read()
 
-        verb5( "URL Code: {0}".format( response.getcode() ))
-        if response.getcode() != 200:
-            # If we get a redirect, 30x, then fall through to curl too
-            raise Exception( page )
+            verb5( "URL Code: {0}".format( response.getcode() ))
+            if response.getcode() != 200:
+                # If we get a redirect, 30x, then fall through to curl too
+                raise Exception( page )
 
-    except Exception:
-        page = make_CURL_request( resource, vals )
+        except Exception:
+            page = make_CURL_request( resource, vals )
 
     if len(page) == 0:
         raise Exception("Problem accessing resource {0}".format(resource))


### PR DESCRIPTION
Looking at the code in response to Dong-Woo's intermittent failure problem I noticed that I was not explicitly closing the urlopen. It would eventually get closed by `__del__` method during garbage collection when the `response` variable goes out of scope. So it could be possible to have multiple connections open for a brief time between GC.    This cannot be the actual cause of Dong-Woo's problem though because the connections were remaining open between calls to the script which won't happen since the GC will have run at the script shutdown.

But, it cleans it up a bit so might as well close it a bit more explicitly. 