### PR TITLE
change contrib version used in setup.py to 4.17.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def list_files(pattern):
     return sorted(files)
 
 
-VERSION = "4.17.0"
+VERSION = "4.17.2"
 for val in sys.argv:
     if val.startswith("--version="):
         VERSION = val.split("=")[1]


### PR DESCRIPTION
bump up the contrib version to 4.17.2 for those using the git repository to install via `pip`