### PR TITLE
Sherpa function to facilitate loading HETG responses associated with a PHA2 file

### DIFF
--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -2,18 +2,12 @@ import numpy as np
 import glob
 from pathlib import Path
 from sherpa.astro.ui import load_data, load_arf, load_rmf
-from pycrates import (
-    read_file,
-    get_keyval,
-    read_pha,
-    get_history_records,
-    is_pha_type2
-)
+from pycrates import read_file, get_keyval, read_pha, get_history_records, is_pha_type2
 
 
 def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
     """
-    Identifies ARFs and RMFs that are associated with an HETG PHA2 file.  
+    Identifies ARFs and RMFs that are associated with an HETG PHA2 file.
 
     Parameters
     ----------
@@ -43,12 +37,12 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
 
     # load the pha2 file and obtain the crate where relevant information is stored
     pha2_dataset = read_pha(pha2_file_par)
-    
-    #Return Error if file is not a PHA2 file
+
+    # Return Error if file is not a PHA2 file
     if is_pha_type2(pha2_dataset) != True:
         raise ValueError("Input file must be of type PHA2.")
 
-    #grab the spectrum crate to determine tg_m and various header values
+    # grab the spectrum crate to determine tg_m and various header values
     spec_crate_par = pha2_dataset.get_crate(2)
 
     # identify the number of spectra in the PHA2 file
@@ -59,24 +53,24 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
 
     if "Version DS" in creator_key:
 
-        # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp 
+        # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp
         # glob doesn't get any extra unrelated files in the response dir.
 
         # Note, the strings in this section are based on the DS (CXC Data Systems Group) standard naming.
         pha_name = Path(pha2_file_par).name
         pha_root = pha_name.partition("_pha2.fits")[0]
 
-        #uses provided resp_dir to check for files. First check for ARF/RMF.fits and if not found then check compressed.
+        # uses provided resp_dir to check for files. First check for ARF/RMF.fits and if not found then check compressed.
         if resp_dir_par != None:  # use provided resp_dir_par
             resp_list_par = glob.glob(
                 f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits"
             )
             if len(resp_list_par) == 0:
                 resp_list_par = glob.glob(
-                    f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits*" #will grab .gz files
-            )                
+                    f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits*"  # will grab .gz files
+                )
 
-        #if user does not provide a response directory
+        # if user does not provide a response directory
         else:
             pha_dir = Path(
                 pha2_file_par
@@ -86,8 +80,8 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
             )
             if len(resp_list_par) == 0:
                 resp_list_par = glob.glob(
-                    f"{pha_dir}/responses/{pha_root}*{resp_type_par}*.fits*" #will grab .gz files
-                )                
+                    f"{pha_dir}/responses/{pha_root}*{resp_type_par}*.fits*"  # will grab .gz files
+                )
 
     elif (
         "Version CIAO" in creator_key
@@ -97,7 +91,7 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
         hist = get_history_records(spec_crate_par)
         pha_root = ""  # set to "" (blank) so it still works for TGCAT downloaded data which has no root par.
 
-        # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history. 
+        # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history.
         # This identifies that value.
         for i in range(0, len(hist)):
             if ":root=" in hist[i][1]:  # find the line where the :root command was used
@@ -109,34 +103,34 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
                 ]  # remove everything after the root value
                 break  # stops searching hist for the appropriate line after it is found
 
-        #if pha_root is not set then it means the file came from a tgcat downloaded PHA2 file.
+        # if pha_root is not set then it means the file came from a tgcat downloaded PHA2 file.
 
         # use glob and pha_root to find the responses
         if resp_dir_par != None:  # use provided resp_dir_par
             resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}")
             if len(resp_list_par) == 0:
-                resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}*") #will grab .gz files
+                resp_list_par = glob.glob(
+                    f"{resp_dir_par}/{pha_root}*.{resp_type_par}*"
+                )  # will grab .gz files
 
-        #if user does not provide response directory
+        # if user does not provide response directory
         else:
             pha_dir = Path(
                 pha2_file_par
             ).parent  # need to get directory where PHA2 file is located
-            resp_list_par = glob.glob(
-                f"{pha_dir}/tg/{pha_root}*.{resp_type_par}"
-            )  
+            resp_list_par = glob.glob(f"{pha_dir}/tg/{pha_root}*.{resp_type_par}")
             if len(resp_list_par) == 0:
                 resp_list_par = glob.glob(
-                    f"{pha_dir}/tg/{pha_root}*.{resp_type_par}*" #will grab .gz files
-                )                  
-            #TGCAT does not come with a tg directory so check in the pha_dir for response files.
+                    f"{pha_dir}/tg/{pha_root}*.{resp_type_par}*"  # will grab .gz files
+                )
+            # TGCAT does not come with a tg directory so check in the pha_dir for response files.
             if len(resp_list_par) == 0:
                 resp_list_par = glob.glob(
-                    f"{pha_dir}/{pha_root}*.{resp_type_par}" #will grab .gz files
-                )            
+                    f"{pha_dir}/{pha_root}*.{resp_type_par}"  
+                )
             if len(resp_list_par) == 0:
                 resp_list_par = glob.glob(
-                    f"{pha_dir}/{pha_root}*.{resp_type_par}*" #will grab .gz files
+                    f"{pha_dir}/{pha_root}*.{resp_type_par}*"  # will grab .gz files
                 )
 
     # if the creator of the PHA2 file is not DS or CIAO then raise error and exit.
@@ -151,9 +145,11 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
             "Could not identify responses. Please load responses manually."
         )
 
-    #Some response files were found so tell user matching will begin
-    print(f'\n{resp_type_par.upper()} files identified. Attempting to match them to PHA2 spectra:')
-    print('-'*63)
+    # Some response files were found so tell user matching will begin
+    print(
+        f"\n{resp_type_par.upper()} files identified. Attempting to match them to PHA2 spectra:"
+    )
+    print("-" * 63)
 
     # check that the length of the ARF or RMF lists match the number of PHA spec in the PHA2 file
     if len(resp_list_par) != num_spec_par:
@@ -213,34 +209,36 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
     resp_pha2_tg_part_arr = []
     resp_obsid_arr = []
 
-    #start a counter to determine how many response files are missing an OBS_ID header value
+    # start a counter to determine how many response files are missing an OBS_ID header value
     obsid_missing_count = 0
 
     # read each response file and append appropriate header values
-    for i in range(0, len(resp_list_par)):
-        resp_data = read_file(resp_list_par[i])
+    for i in resp_list_par:
+        resp_data = read_file(i)
         resp_m_arr.append(get_keyval(resp_data, "TG_M"))
         resp_pha2_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
-        
-        #As of 3/23/26, TGCAT-provided RMFs do not have a 'OBS_ID' header keyword. This attempts to mitigate the issue.
-        #If there is any error reading the OBS_ID header then it assigns the PHA2 obsid value to the array and prints a
+
+        # As of 3/23/26, TGCAT-provided RMFs do not have a 'OBS_ID' header keyword. This attempts to mitigate the issue.
+        # If there is any error reading the OBS_ID header then it assigns the PHA2 obsid value to the array and prints a
         # warning  so the rest of code will continue. TGCAT RMF data is expected to get OBSID par in near future.
         try:
             resp_obsid_arr.append(get_keyval(resp_data, "OBS_ID"))
         except:
             resp_obsid_arr.append(pha2_tg_obsid)
-            obsid_missing_count = obsid_missing_count+1
+            obsid_missing_count = obsid_missing_count + 1
 
-    #if any number of response files don't have an obsID parameter then warn the user this wont be used to check. Still
-    #continue though because this requirement is likely to almost never be an issue.
+    # if any number of response files don't have an obsID parameter then warn the user this wont be used to check. Still
+    # continue though because this requirement is likely to almost never be an issue.
     if obsid_missing_count > 0:
-        print(f'\nWARNING -- Header keyword OBS_ID is missing from {obsid_missing_count} {resp_type_par.upper()} file(s). {resp_type_par.upper()}(s) will not be checked against obsID for validity. \n')
+        print(
+            f"\nWARNING -- Header keyword OBS_ID is missing from {obsid_missing_count} {resp_type_par.upper()} file(s). {resp_type_par.upper()}(s) will not be checked against obsID for validity. \n"
+        )
 
     # convert obsid lists to numpy arrays for later use with np.where() for obsID checking
     pha2_tg_obsid = np.array(pha2_tg_obsid)
     resp_obsid_arr = np.array(resp_obsid_arr)
 
-    # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the 
+    # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the
     # path to the matched response file
     matched_resp_list_par = np.array([""] * num_spec_pha2, dtype="object")
 
@@ -267,7 +265,9 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
             )
 
     # report the files matched to the screen in a nice format so it is clear it worked or didn't work
-    print(f"\nThe following {resp_type_par.upper()} response files were found for obsID {pha2_tg_obsid}\n")
+    print(
+        f"\nThe following {resp_type_par.upper()} response files were found for obsID {pha2_tg_obsid}\n"
+    )
 
     # name the arm and order something more readable for output message
     arm = lambda x: "HEG" if x == 1 else "MEG" if x == 2 else "ERROR"
@@ -280,9 +280,11 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
         )
     print()
 
-    #check if no responses matched and report to user. Most common issue would be the OBSID parameter is wrong
-    if (matched_resp_list_par == 'no match').all():
-        print(f'\nWARNING -- No {resp_type_par.upper()} files matched the PHA2 spectra. Check that the ARFS and RMFs are from the same obsID\n')
+    # check if no responses matched and report to user. Most common issue would be the OBSID parameter is wrong
+    if (matched_resp_list_par == "no match").all():
+        print(
+            f"\nWARNING -- No {resp_type_par.upper()} files matched the PHA2 spectra. Check that the ARFS and RMFs are from the same obsID\n"
+        )
 
     # returns the array of matched responses in the same order as the PHA2 spectra
     return matched_resp_list_par
@@ -291,10 +293,10 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
 def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1):
     """
 
-    This function loads an HETG PHA2 file and any associated ARF and RMF response files. If matching responses are 
-    found only for a subset of HETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded. 
-    This works only for PHA2 files and not PHA files. If arf_dir or rmf_dir are not provided then this tool will 
-    search for the responses in subdirectories where the PHA2 file is located using standard CIAO directory naming 
+    This function loads an HETG PHA2 file and any associated ARF and RMF response files. If matching responses are
+    found only for a subset of HETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded.
+    This works only for PHA2 files and not PHA files. If arf_dir or rmf_dir are not provided then this tool will
+    search for the responses in subdirectories where the PHA2 file is located using standard CIAO directory naming
     formats.
 
     Example: load_hetg_pha2(pha2_file=16370/repro/acisf16370_repro_pha2.fits, dataset_id_start=1)
@@ -321,36 +323,48 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
     show_all : Display information about one or all of the data sets that have been loaded into the Sherpa session.
 
     """
-    #run find_resp_files() and match_resp_order() and load data into appropriate dataset id.
+    # run find_resp_files() and match_resp_order() and load data into appropriate dataset id.
 
-    #find and match ARFs
-    arf_list = find_resp_files(pha2_file_par = pha2_file, resp_type_par='arf', resp_dir_par=arf_dir)
-    arf_list_matched = match_resp_order(pha2_file_par=pha2_file, resp_list_par=arf_list, resp_type_par='arf')
+    # find and match ARFs
+    arf_list = find_resp_files(
+        pha2_file_par=pha2_file, resp_type_par="arf", resp_dir_par=arf_dir
+    )
+    arf_list_matched = match_resp_order(
+        pha2_file_par=pha2_file, resp_list_par=arf_list, resp_type_par="arf"
+    )
 
-    #find and match RMFs
-    rmf_list = find_resp_files(pha2_file_par = pha2_file, resp_type_par='rmf', resp_dir_par=rmf_dir)
-    rmf_list_matched = match_resp_order(pha2_file_par=pha2_file, resp_list_par=rmf_list, resp_type_par='rmf')
+    # find and match RMFs
+    rmf_list = find_resp_files(
+        pha2_file_par=pha2_file, resp_type_par="rmf", resp_dir_par=rmf_dir
+    )
+    rmf_list_matched = match_resp_order(
+        pha2_file_par=pha2_file, resp_list_par=rmf_list, resp_type_par="rmf"
+    )
 
-    #check for mismatches and unmatched pairs
+    # check for mismatches and unmatched pairs
     if len(arf_list) != len(rmf_list):
-        raise ValueError('The number of ARFs and RMFs identified do not match. Please manually load matching responses')
-    
+        raise ValueError(
+            "The number of ARFs and RMFs identified do not match. Please manually load matching responses"
+        )
+
     if len(arf_list_matched) != len(rmf_list_matched):
-        raise ValueError('Something went wrong matching responses to the PHA2 file. Please manually load responses.')
-    
-    #convert dataset_id_start to an integer if users enters it as a string.
+        raise ValueError(
+            "Something went wrong matching responses to the PHA2 file. Please manually load responses."
+        )
+
+    # convert dataset_id_start to an integer if users enters it as a string.
     if type(dataset_id_start) == str:
         dataset_id_start = int(dataset_id_start)
 
-    #load data first so responses can be assigned after.  
+    # load data first so responses can be assigned after.
     load_data(id=dataset_id_start, filename=pha2_file)
 
-    #for every identified response (arf), load matching arf and rmf. It should be ok to load RMFs with the arf loop
-    #cause an error would be previously thrown if every arf didn't have a matching rmf.
+    # for every identified response (arf), load matching arf and rmf. It should be ok to load RMFs with the arf loop
+    # cause an error would be previously thrown if every arf didn't have a matching rmf.
     for i in range(len(arf_list_matched)):
-        if arf_list_matched[i] != 'no match':
-            #note, i+dataset_id_start here cause sherpa starts with dataset 1 and not 0.
-            load_arf(i+dataset_id_start, arf_list_matched[i]) 
-            load_rmf(i+dataset_id_start, rmf_list_matched[i])
+        if arf_list_matched[i] != "no match":
+            # note, i+dataset_id_start here cause sherpa starts with dataset 1 and not 0.
+            load_arf(i + dataset_id_start, arf_list_matched[i])
+            load_rmf(i + dataset_id_start, rmf_list_matched[i])
 
-    return()
+    return ()

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -1,6 +1,7 @@
-
 import numpy as np
 import glob
+from pathlib import Path
+from sherpa.astro.ui import load_data, load_arf, load_rmf
 from pycrates import (
     read_file,
     get_keyval,
@@ -8,239 +9,308 @@ from pycrates import (
     get_history_records,
 )
 
-from pathlib import Path
-
-def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
+def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1):
     """
-    Identifies ARFs and RMFs that are associated with an HETG PHA2 file.  This currently utilizes the 'response' and
-    'tg' directories created by the data systems and chandra_repro pipelines and thus might not work for all PHA2 HETG
-    files.
+
+    This function loads an HETG PHA2 file and any associated ARF and RMF response files. If matching responses are 
+    found only for a subset of HETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded. 
+    This works only for PHA2 files and not PHA files. If arf_dir or rmf_dir are not provided then this tool will 
+    search for the responses in subdirectories where the PHA2 file is located using standard CIAO directory naming 
+    formats.
+
+    Example: load_hetg_pha2(pha2_file=16370/repro/acisf16370_repro_pha2.fits, dataset_id_start=1)
+             load_hetg_pha2(pha2_file=16371/repro/acisf16371_repro_pha2.fits, dataset_id_start=13)
 
     Parameters
     ----------
 
-    pha2_file_par : PHA2 fits file
+    pha2_file : PHA2 fits file
          PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
          running chandra_repro on a chandra HETG obsID.
-    resp_type_par: 'arf' or 'rmf'
-        The type of response files for matchign to PHA spectra
-    resp_dir_par: directory
-        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
-        will attempt to search for them.
+    arf_dir: str
+        The directory that holds the arfs associated with the pha2_file
+    rmf_dir: str
+        The directory that holds the rmfs associated with the pha2_file
+    dataset_id_start : int
+        A sherpa dataset id into which PHA2 spectra will begin loading. A typical HETG PHA2 spectral file contains
+        12 individual spectra so choosing a value 1 (default) will load dataset ids 1-12.
 
-    Returns
-    ----------
-    resp_list_par: list
-    Returns a list of ARF or RMF files found.
+    Related Sherpa functions
+    ------------------------
+    show_data : Display information on the data sets that have been loaded.
+    list_data_ids : List the identifiers for the loaded data sets.
+    show_all : Display information about one or all of the data sets that have been loaded into the Sherpa session.
 
     """
 
-    # if user enters 'ARF' or 'RMF' then lower case for later glob use
-    resp_type_par = resp_type_par.lower()
 
-    # check to make sure responses are either arf or rmf
-    if resp_type_par != "arf" and resp_type_par != "rmf":
-        raise ValueError("Response type must be either arf or rmf")
+    def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
+        """
+        Identifies ARFs and RMFs that are associated with an HETG PHA2 file.  This currently utilizes the 'response' and
+        'tg' directories created by the data systems and chandra_repro pipelines and thus might not work for all PHA2 HETG
+        files.
 
-    # load the pha2 file and obtain the crate where relevant information is stored
-    pha2_dataset = read_pha(pha2_file_par)
-    spec_crate_par = pha2_dataset.get_crate(2)
+        Parameters
+        ----------
 
-    # identify the number of spectra in the PHA2 file
-    num_spec_par = len(spec_crate_par.TG_M.values)
+        pha2_file_par : PHA2 fits file
+            PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
+            running chandra_repro on a chandra HETG obsID.
+        resp_type_par: 'arf' or 'rmf'
+            The type of response files for matchign to PHA spectra
+        resp_dir_par: directory
+            The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+            will attempt to search for them.
 
-    # determine which pipeline the PHA2 file came from (archive vs CIAO user)
-    creator_key = get_keyval(spec_crate_par, "CREATOR")
+        Returns
+        ----------
+        resp_list_par: list
+        Returns a list of ARF or RMF files found.
 
-    if "Version DS" in creator_key:
+        """
 
-        # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp 
-        # glob doesn't get any extra unrelated files in the response dir.
+        # if user enters 'ARF' or 'RMF' then lower case for later glob use
+        resp_type_par = resp_type_par.lower()
 
-        # Note, the strings in this section are based on the DS standard naming.
-        pha_name = Path(pha2_file_par).name
-        pha_root = pha_name.partition("_pha2.fits")[0]
+        # check to make sure responses are either arf or rmf
+        if resp_type_par != "arf" and resp_type_par != "rmf":
+            raise ValueError("Response type must be either arf or rmf")
 
-        if resp_dir_par != None:  # use provided resp_dir_par
-            resp_list_par = glob.glob(
-                f"{resp_dir_par}/{pha_root}*{resp_type_par}2.fits*"
-            )
+        # load the pha2 file and obtain the crate where relevant information is stored
+        pha2_dataset = read_pha(pha2_file_par)
+        spec_crate_par = pha2_dataset.get_crate(2)
+
+        # identify the number of spectra in the PHA2 file
+        num_spec_par = len(spec_crate_par.TG_M.values)
+
+        # determine which pipeline the PHA2 file came from (archive vs CIAO user)
+        creator_key = get_keyval(spec_crate_par, "CREATOR")
+
+        if "Version DS" in creator_key:
+
+            # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp 
+            # glob doesn't get any extra unrelated files in the response dir.
+
+            # Note, the strings in this section are based on the DS standard naming.
+            pha_name = Path(pha2_file_par).name
+            pha_root = pha_name.partition("_pha2.fits")[0]
+
+            if resp_dir_par != None:  # use provided resp_dir_par
+                resp_list_par = glob.glob(
+                    f"{resp_dir_par}/{pha_root}*{resp_type_par}2.fits*"
+                )
+            else:
+                pha_dir = Path(
+                    pha2_file_par
+                ).parent  # need to get directory where PHA2 file is located
+                resp_list_par = glob.glob(
+                    f"{pha_dir}/responses/{pha_root}*{resp_type_par}2.fits*"
+                )
+
+        elif (
+            "Version CIAO" in creator_key
+        ):  # this is produced via chandra_repro or user custom spectral extraction
+
+            # read the header to search for the PHA2 root name which is often the same root as the responses
+            hist = get_history_records(spec_crate_par)
+            pha_root = ""  # set to '' for checking later in case pha_root not found
+
+            # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history. 
+            # This identifies that value.
+            for i in range(0, len(hist)):
+                if ":root=" in hist[i][1]:  # find the line where the :root command was used
+                    root_line = (
+                        hist[i][1].split("=", 1)[1].strip()
+                    )  # strip the unnecessary stuff but leaves the extra spaces
+                    pha_root = root_line.split(" ")[
+                        0
+                    ]  # remove everything after the root value
+                    break  # stops searching hist for the appropriate line after it is found
+
+            # if pha_root is not overwritten at this point then throw error because it means it was not found
+            if pha_root == "":
+                raise ValueError(
+                    "Could not identify PHA2 file root. Please load responses manually."
+                )
+
+            # use glob and pha_root to find the responses
+            if resp_dir_par != None:  # use provided resp_dir_par
+                resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}")
+            else:
+                pha_dir = Path(
+                    pha2_file_par
+                ).parent  # need to get directory where PHA2 file is located
+                resp_list_par = glob.glob(
+                    f"{pha_dir}/tg/{pha_root}*.{resp_type_par}"
+                )  # use the root name of the PHA2 file to ID the responses. This way users can have many extractions in a 
+                # single dir but it will only grab the appropriate ones.
+
+        # if the creator of the PHA2 file is not DS or CIAO then exit.
         else:
-            pha_dir = Path(
-                pha2_file_par
-            ).parent  # need to get directory where PHA2 file is located
-            resp_list_par = glob.glob(
-                f"{pha_dir}/responses/{pha_root}*{resp_type_par}2.fits*"
-            )
-
-    elif (
-        "Version CIAO" in creator_key
-    ):  # this is produced via chandra_repro or user custom spectral extraction
-
-        # read the header to search for the PHA2 root name which is often the same root as the responses
-        hist = get_history_records(spec_crate_par)
-        pha_root = ""  # set to '' for checking later in case pha_root not found
-
-        # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history. 
-        # This identifies that value.
-        for i in range(0, len(hist)):
-            if ":root=" in hist[i][1]:  # find the line where the :root command was used
-                root_line = (
-                    hist[i][1].split("=", 1)[1].strip()
-                )  # strip the unnecessary stuff but leaves the extra spaces
-                pha_root = root_line.split(" ")[
-                    0
-                ]  # remove everything after the root value
-                break  # stops searching hist for the appropriate line after it is found
-
-        # if pha_root is not overwritten at this point then throw error because it means it was not found
-        if pha_root == "":
             raise ValueError(
-                "Could not identify PHA2 file root. Please load responses manually."
+                "Cannot determine the creator of PHA2 file and responses will have to be loaded manually"
             )
 
-        # use glob and pha_root to find the responses
-        if resp_dir_par != None:  # use provided resp_dir_par
-            resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}")
-        else:
-            pha_dir = Path(
-                pha2_file_par
-            ).parent  # need to get directory where PHA2 file is located
-            resp_list_par = glob.glob(
-                f"{pha_dir}/tg/{pha_root}*.{resp_type_par}"
-            )  # use the root name of the PHA2 file to ID the responses. This way users can have many extractions in a 
-               # single dir but it will only grab the appropriate ones.
-
-    # if the creator of the PHA2 file is not DS or CIAO then exit.
-    else:
-        raise ValueError(
-            "Cannot determine the creator of PHA2 file and responses will have to be loaded manually"
-        )
-
-    # check to make sure at least some files were found
-    if len(resp_list_par) < 1:
-        raise ValueError(
-            "Could not identify responses. Please load responses manually."
-        )
-
-    # check that the length of the arf or RMF lists match the number of PHA spec in the PHA2 file
-    if len(resp_list_par) != num_spec_par:
-        print(
-            f"WARNING-- The identified number of {resp_type_par.upper()}s [{len(resp_list_par)}] does not match the number of PHA spectra [{num_spec_par}] in the PHA2 file. Only the responses found will be included.\n"
-        )
-
-    return resp_list_par
-
-
-def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
-    """
-    This uses the PHA2 file structure and matches the input response file list/array (resp_list_par) to the appropriate
-    PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
-    find_resp_files() and put them in order of the PHA2 spectra.
-
-    Parameters
-    ----------
-
-    pha2_file_par : PHA2 fits file
-         PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
-         running chandra_repro on a chandra HETG obsID.
-    resp_type_par: 'arf' or 'rmf'
-        The type of response files for matchign to PHA spectra
-    resp_dir_par: directory
-        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
-        will attempt to search for them.
-
-    Returns
-    ----------
-
-    matched_resp_list_par: array
-        Returns an array of ARF or RMF file paths matched to the order (arrangement) of the input PHA2 file. The string
-        value 'no match' is returned for elements where there is a spectrum in the PHA2 file but no matching response
-        file.
-
-    """
-
-    # check to make sure responses are either arf or rmf
-    if resp_type_par != "arf" and resp_type_par != "rmf":
-        raise ValueError("Response type must be either arf or rmf")
-
-    # reads in the pha2 file and checks how many spectra (orders) it includes.
-    pha2_dataset = read_pha(pha2_file_par)
-    spec_crate_par = pha2_dataset.get_crate(2)
-
-    # identify the file arrangement of the HETG orders and HEG/MEG arms via the PHA2 file
-    tg_m_arr = spec_crate_par.TG_M.values
-    tg_part_arr = spec_crate_par.TG_PART.values
-    tg_obsid = get_keyval(spec_crate_par, "OBS_ID")
-
-    # determine the number of spectra in the pha2 file based on the length of one of the tg arrays:
-    num_spec_pha2 = len(tg_m_arr)
-
-    # warn user if the number of PHA2 spectra are different than the number of response files (either found 
-    # automatically or provided manually)
-    if len(resp_list_par) != num_spec_pha2:
-        print(
-            f"\nWARNING -- The number of {resp_type_par} files [{len(resp_list_par)}] does not equal the number of spectra in the PHA2 file [{num_spec_pha2}]. Only responses that match with a spectrum will be included.\n"
-        )
-
-    # create empty lists to later append HEG/MEG arm, order and obsID values from the response files headers
-    resp_m_arr = []
-    resp_tg_part_arr = []
-    resp_obsid_arr = []
-
-    # read each response file and append appropriate header value
-    for i in range(0, len(resp_list_par)):
-        resp_data = read_file(resp_list_par[i])
-        resp_m_arr.append(get_keyval(resp_data, "TG_M"))
-        resp_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
-        resp_obsid_arr.append(get_keyval(resp_data, "OBS_ID"))
-
-    # convert obsid lists to numpy arrays for later use with np.where() for obsID checking
-    tg_obsid = np.array(tg_obsid)
-    resp_obsid_arr = np.array(resp_obsid_arr)
-
-    # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the 
-    # path to the matched response file
-    matched_resp_list_par = np.array([""] * num_spec_pha2, dtype="object")
-
-    # for each spectra, use tg_m, tg_part and obsID to match to a single response file. Print appropriate errors.
-    for i in range(0, num_spec_pha2):
-        match_resp = np.where(
-            (resp_m_arr == tg_m_arr[i])
-            & (resp_tg_part_arr == tg_part_arr[i])
-            & (resp_obsid_arr == tg_obsid)
-        )[0].tolist()
-        if len(match_resp) == 1:
-            matched_resp_list_par[i] = resp_list_par[
-                match_resp[0]
-            ]  # this is the element in the response array that match the i_th element of the PHA2 file.
-        elif len(match_resp) > 1:
+        # check to make sure at least some files were found
+        if len(resp_list_par) < 1:
             raise ValueError(
-                f"ERROR, more than one {resp_type_par.upper()} match found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}. "
+                "Could not identify responses. Please load responses manually."
             )
-        elif len(match_resp) == 0:
-            matched_resp_list_par[i] = "no match"
+
+        # check that the length of the arf or RMF lists match the number of PHA spec in the PHA2 file
+        if len(resp_list_par) != num_spec_par:
             print(
-                f"Warning, no {resp_type_par.upper()} found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}."
-            )
-        else:
-            raise ValueError(
-                f"ERROR - Something with wrong identifying {resp_type_par.upper()}s for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}"
+                f"WARNING-- The identified number of {resp_type_par.upper()}s [{len(resp_list_par)}] does not match the number of PHA spectra [{num_spec_par}] in the PHA2 file. Only the responses found will be included.\n"
             )
 
-    # report the files matched to the screen in a nice format so it is clear it worked or didn't work
-    print("\nThe following response files were found\n")
+        return resp_list_par
 
-    # name the arm and order something more readable for output message
-    arm = lambda x: "HEG" if x == 1 else "MEG" if x == 2 else "ERROR"
-    order = lambda x: f"+{x}" if x > 0 else f"-{-1*x}" if x < 0 else "ERROR"
 
-    print()
-    for i in range(0, num_spec_pha2):
-        print(
-            f"{arm(tg_part_arr[i])+order(tg_m_arr[i])} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
-        )
-    print()
+    def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
+        """
+        This uses the PHA2 file structure and matches the input response file list/array (resp_list_par) to the appropriate
+        PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
+        find_resp_files() and put them in order of the PHA2 spectra.
 
-    # returns the array of matched responses in the same order as the PHA2 spectra
-    return matched_resp_list_par
+        Parameters
+        ----------
+
+        pha2_file_par : PHA2 fits file
+            PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
+            running chandra_repro on a chandra HETG obsID.
+        resp_type_par: 'arf' or 'rmf'
+            The type of response files for matchign to PHA spectra
+        resp_dir_par: directory
+            The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+            will attempt to search for them.
+
+        Returns
+        ----------
+
+        matched_resp_list_par: array
+            Returns an array of ARF or RMF file paths matched to the order (arrangement) of the input PHA2 file. The string
+            value 'no match' is returned for elements where there is a spectrum in the PHA2 file but no matching response
+            file.
+
+        """
+
+        # check to make sure responses are either arf or rmf
+        if resp_type_par != "arf" and resp_type_par != "rmf":
+            raise ValueError("Response type must be either arf or rmf")
+
+        # reads in the pha2 file and checks how many spectra (orders) it includes.
+        pha2_dataset = read_pha(pha2_file_par)
+        spec_crate_par = pha2_dataset.get_crate(2)
+
+        # identify the file arrangement of the HETG orders and HEG/MEG arms via the PHA2 file
+        tg_m_arr = spec_crate_par.TG_M.values
+        tg_part_arr = spec_crate_par.TG_PART.values
+        tg_obsid = get_keyval(spec_crate_par, "OBS_ID")
+
+        # determine the number of spectra in the pha2 file based on the length of one of the tg arrays:
+        num_spec_pha2 = len(tg_m_arr)
+
+        # warn user if the number of PHA2 spectra are different than the number of response files (either found 
+        # automatically or provided manually)
+        if len(resp_list_par) != num_spec_pha2:
+            print(
+                f"\nWARNING -- The number of {resp_type_par} files [{len(resp_list_par)}] does not equal the number of spectra in the PHA2 file [{num_spec_pha2}]. Only responses that match with a spectrum will be included.\n"
+            )
+
+        # create empty lists to later append HEG/MEG arm, order and obsID values from the response files headers
+        resp_m_arr = []
+        resp_tg_part_arr = []
+        resp_obsid_arr = []
+
+        # read each response file and append appropriate header value
+        for i in range(0, len(resp_list_par)):
+            resp_data = read_file(resp_list_par[i])
+            resp_m_arr.append(get_keyval(resp_data, "TG_M"))
+            resp_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
+            resp_obsid_arr.append(get_keyval(resp_data, "OBS_ID"))
+
+        # convert obsid lists to numpy arrays for later use with np.where() for obsID checking
+        tg_obsid = np.array(tg_obsid)
+        resp_obsid_arr = np.array(resp_obsid_arr)
+
+        # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the 
+        # path to the matched response file
+        matched_resp_list_par = np.array([""] * num_spec_pha2, dtype="object")
+
+        # for each spectra, use tg_m, tg_part and obsID to match to a single response file. Print appropriate errors.
+        for i in range(0, num_spec_pha2):
+            match_resp = np.where(
+                (resp_m_arr == tg_m_arr[i])
+                & (resp_tg_part_arr == tg_part_arr[i])
+                & (resp_obsid_arr == tg_obsid)
+            )[0].tolist()
+            if len(match_resp) == 1:
+                matched_resp_list_par[i] = resp_list_par[
+                    match_resp[0]
+                ]  # this is the element in the response array that match the i_th element of the PHA2 file.
+            elif len(match_resp) > 1:
+                raise ValueError(
+                    f"ERROR, more than one {resp_type_par.upper()} match found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}. "
+                )
+            elif len(match_resp) == 0:
+                matched_resp_list_par[i] = "no match"
+                print(
+                    f"Warning, no {resp_type_par.upper()} found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}."
+                )
+            else:
+                raise ValueError(
+                    f"ERROR - Something with wrong identifying {resp_type_par.upper()}s for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}"
+                )
+
+        # report the files matched to the screen in a nice format so it is clear it worked or didn't work
+        print("\nThe following response files were found\n")
+
+        # name the arm and order something more readable for output message
+        arm = lambda x: "HEG" if x == 1 else "MEG" if x == 2 else "ERROR"
+        order = lambda x: f"+{x}" if x > 0 else f"-{-1*x}" if x < 0 else "ERROR"
+
+        print()
+        for i in range(0, num_spec_pha2):
+            print(
+                f"{arm(tg_part_arr[i])+order(tg_m_arr[i])} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
+            )
+        print()
+
+        # returns the array of matched responses in the same order as the PHA2 spectra
+        return matched_resp_list_par
+
+
+
+    #run find_resp_files() and match_resp_order() and load data into appropriate dataset id.
+
+    #find and match ARFs
+    arf_list = find_resp_files(pha2_file_par = pha2_file, resp_type_par='arf', resp_dir_par=arf_dir)
+    arf_list_matched = match_resp_order(pha2_file_par=pha2_file, resp_list_par=arf_list, resp_type_par='arf')
+
+    #find and match RMFs
+    rmf_list = find_resp_files(pha2_file_par = pha2_file, resp_type_par='rmf', resp_dir_par=rmf_dir)
+    rmf_list_matched = match_resp_order(pha2_file_par=pha2_file, resp_list_par=rmf_list, resp_type_par='rmf')
+
+    #check for mismatches and unmatched pairs
+    if len(arf_list) != len(rmf_list):
+        raise ValueError('The number of ARFs and RMFs identified do not match. Please manually load matching responses')
+    
+    if len(arf_list_matched) != len(rmf_list_matched):
+        raise ValueError('Something went wrong matching responses to the PHA2 file. Please manually load responses.')
+    
+    #convert dataset_id_start to an integer if users enters it as a string.
+    if type(dataset_id_start) == str:
+        dataset_id_start = int(dataset_id_start)
+
+    #load data first so responses can be assigned after.  
+    load_data(id=dataset_id_start, filename=pha2_file)
+
+    #for every identified response (arf), load matching arf and rmf. It should be ok to load RMFs with the arf loop
+    #cause an error would be previously thrown if every arf didn't have a matching rmf.
+    for i in range(len(arf_list_matched)):
+        if arf_list_matched[i] != 'no match':
+            #note, i+dataset_id_start here cause sherpa starts with dataset 1 and not 0.
+            load_arf(i+dataset_id_start, arf_list_matched[i]) 
+            load_rmf(i+dataset_id_start, rmf_list_matched[i])
+
+    return()

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -7,7 +7,286 @@ from pycrates import (
     get_keyval,
     read_pha,
     get_history_records,
+    is_pha_type2
 )
+
+
+def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
+    """
+    Identifies ARFs and RMFs that are associated with an HETG PHA2 file.  
+
+    Parameters
+    ----------
+
+    pha2_file_par : PHA2 fits file
+        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
+        running chandra_repro on a chandra HETG obsID.
+    resp_type_par: 'arf' or 'rmf'
+        The type of response files for matchign to PHA spectra
+    resp_dir_par: directory
+        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+        will attempt to search for them.
+
+    Returns
+    ----------
+    resp_list_par: list
+    Returns a list of ARF or RMF files found.
+
+    """
+
+    # if user enters 'ARF' or 'RMF' then lower case for later glob use
+    resp_type_par = resp_type_par.lower()
+
+    # check to make sure responses are either arf or rmf
+    if resp_type_par != "arf" and resp_type_par != "rmf":
+        raise ValueError("Response type must be either arf or rmf")
+
+    # load the pha2 file and obtain the crate where relevant information is stored
+    pha2_dataset = read_pha(pha2_file_par)
+    
+    #Return Error if file is not a PHA2 file
+    if is_pha_type2(pha2_dataset) != True:
+        raise ValueError("Input file must be of type PHA2.")
+
+    #grab the spectrum crate to determine tg_m and various header values
+    spec_crate_par = pha2_dataset.get_crate(2)
+
+    # identify the number of spectra in the PHA2 file
+    num_spec_par = len(spec_crate_par.TG_M.values)
+
+    # determine which pipeline the PHA2 file came from (archive vs CIAO user / tgcat download)
+    creator_key = get_keyval(spec_crate_par, "CREATOR")
+
+    if "Version DS" in creator_key:
+
+        # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp 
+        # glob doesn't get any extra unrelated files in the response dir.
+
+        # Note, the strings in this section are based on the DS (CXC Data Systems Group) standard naming.
+        pha_name = Path(pha2_file_par).name
+        pha_root = pha_name.partition("_pha2.fits")[0]
+
+        #uses provided resp_dir to check for files. First check for ARF/RMF.fits and if not found then check compressed.
+        if resp_dir_par != None:  # use provided resp_dir_par
+            resp_list_par = glob.glob(
+                f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits"
+            )
+            if len(resp_list_par) == 0:
+                resp_list_par = glob.glob(
+                    f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits*" #will grab .gz files
+            )                
+
+        #if user does not provide a response directory
+        else:
+            pha_dir = Path(
+                pha2_file_par
+            ).parent  # need to get directory where PHA2 file is located
+            resp_list_par = glob.glob(
+                f"{pha_dir}/responses/{pha_root}*{resp_type_par}*.fits"
+            )
+            if len(resp_list_par) == 0:
+                resp_list_par = glob.glob(
+                    f"{pha_dir}/responses/{pha_root}*{resp_type_par}*.fits*" #will grab .gz files
+                )                
+
+    elif (
+        "Version CIAO" in creator_key
+    ):  # this is produced via chandra_repro or user custom spectral extraction
+
+        # read the header to search for the PHA2 root name which is often the same root as the responses
+        hist = get_history_records(spec_crate_par)
+        pha_root = ""  # set to "" (blank) so it still works for TGCAT downloaded data which has no root par.
+
+        # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history. 
+        # This identifies that value.
+        for i in range(0, len(hist)):
+            if ":root=" in hist[i][1]:  # find the line where the :root command was used
+                root_line = (
+                    hist[i][1].split("=", 1)[1].strip()
+                )  # strip the unnecessary stuff but leaves the extra spaces
+                pha_root = root_line.split(" ")[
+                    0
+                ]  # remove everything after the root value
+                break  # stops searching hist for the appropriate line after it is found
+
+        #if pha_root is not set then it means the file came from a tgcat downloaded PHA2 file.
+
+        # use glob and pha_root to find the responses
+        if resp_dir_par != None:  # use provided resp_dir_par
+            resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}")
+            if len(resp_list_par) == 0:
+                resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}*") #will grab .gz files
+
+        #if user does not provide response directory
+        else:
+            pha_dir = Path(
+                pha2_file_par
+            ).parent  # need to get directory where PHA2 file is located
+            resp_list_par = glob.glob(
+                f"{pha_dir}/tg/{pha_root}*.{resp_type_par}"
+            )  
+            if len(resp_list_par) == 0:
+                resp_list_par = glob.glob(
+                    f"{pha_dir}/tg/{pha_root}*.{resp_type_par}*" #will grab .gz files
+                )                  
+            #TGCAT does not come with a tg directory so check in the pha_dir for response files.
+            if len(resp_list_par) == 0:
+                resp_list_par = glob.glob(
+                    f"{pha_dir}/{pha_root}*.{resp_type_par}" #will grab .gz files
+                )            
+            if len(resp_list_par) == 0:
+                resp_list_par = glob.glob(
+                    f"{pha_dir}/{pha_root}*.{resp_type_par}*" #will grab .gz files
+                )
+
+    # if the creator of the PHA2 file is not DS or CIAO then raise error and exit.
+    else:
+        raise ValueError(
+            "Cannot determine the creator of PHA2 file and responses will have to be loaded manually"
+        )
+
+    # check to make sure at least some files were found
+    if len(resp_list_par) == 0:
+        raise ValueError(
+            "Could not identify responses. Please load responses manually."
+        )
+
+    #Some response files were found so tell user matching will begin
+    print(f'\n{resp_type_par.upper()} files identified. Attempting to match them to PHA2 spectra:')
+    print('-'*63)
+
+    # check that the length of the ARF or RMF lists match the number of PHA spec in the PHA2 file
+    if len(resp_list_par) != num_spec_par:
+        print(
+            f"\nWARNING-- The identified number of {resp_type_par.upper()}s [{len(resp_list_par)}] does not match the number of PHA spectra [{num_spec_par}] in the PHA2 file. Only the responses found will be included.\n"
+        )
+
+    return resp_list_par
+
+
+def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
+    """
+    This uses the PHA2 file structure and matches the input response file list/array (resp_list_par) to the appropriate
+    PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
+    find_resp_files() and put them in order of the PHA2 spectra.
+
+    Parameters
+    ----------
+
+    pha2_file_par : PHA2 fits file
+        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
+        running chandra_repro on a chandra HETG obsID.
+    resp_type_par: 'arf' or 'rmf'
+        The type of response files for matchign to PHA spectra
+    resp_dir_par: directory
+        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+        will attempt to search for them.
+
+    Returns
+    ----------
+
+    matched_resp_list_par: array
+        Returns an array of ARF or RMF file paths matched to the order (arrangement) of the input PHA2 file. The string
+        value 'no match' is returned for elements where there is a spectrum in the PHA2 file but no matching response
+        file.
+
+    """
+
+    # check to make sure responses are either arf or rmf
+    if resp_type_par != "arf" and resp_type_par != "rmf":
+        raise ValueError("Response type must be either arf or rmf")
+
+    # reads in the pha2 file and checks how many spectra (orders) it includes.
+    pha2_dataset = read_pha(pha2_file_par)
+    spec_crate_par = pha2_dataset.get_crate(2)
+
+    # identify the file arrangement of the HETG orders and HEG/MEG arms via the PHA2 file
+    pha2_tg_m_arr = spec_crate_par.TG_M.values
+    pha2_tg_part_arr = spec_crate_par.TG_PART.values
+    pha2_tg_obsid = get_keyval(spec_crate_par, "OBS_ID")
+
+    # determine the number of spectra in the pha2 file based on the length of one of the tg arrays:
+    num_spec_pha2 = len(pha2_tg_m_arr)
+
+    # create empty lists to later append HEG/MEG arm, order and obsID values from the response files headers
+    resp_m_arr = []
+    resp_pha2_tg_part_arr = []
+    resp_obsid_arr = []
+
+    #start a counter to determine how many response files are missing an OBS_ID header value
+    obsid_missing_count = 0
+
+    # read each response file and append appropriate header values
+    for i in range(0, len(resp_list_par)):
+        resp_data = read_file(resp_list_par[i])
+        resp_m_arr.append(get_keyval(resp_data, "TG_M"))
+        resp_pha2_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
+        
+        #As of 3/23/26, TGCAT-provided RMFs do not have a 'OBS_ID' header keyword. This attempts to mitigate the issue.
+        #If there is any error reading the OBS_ID header then it assigns the PHA2 obsid value to the array and prints a
+        # warning  so the rest of code will continue. TGCAT RMF data is expected to get OBSID par in near future.
+        try:
+            resp_obsid_arr.append(get_keyval(resp_data, "OBS_ID"))
+        except:
+            resp_obsid_arr.append(pha2_tg_obsid)
+            obsid_missing_count = obsid_missing_count+1
+
+    #if any number of response files don't have an obsID parameter then warn the user this wont be used to check. Still
+    #continue though because this requirement is likely to almost never be an issue.
+    if obsid_missing_count > 0:
+        print(f'\nWARNING -- Header keyword OBS_ID is missing from {obsid_missing_count} {resp_type_par.upper()} file(s). {resp_type_par.upper()}(s) will not be checked against obsID for validity. \n')
+
+    # convert obsid lists to numpy arrays for later use with np.where() for obsID checking
+    pha2_tg_obsid = np.array(pha2_tg_obsid)
+    resp_obsid_arr = np.array(resp_obsid_arr)
+
+    # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the 
+    # path to the matched response file
+    matched_resp_list_par = np.array([""] * num_spec_pha2, dtype="object")
+
+    # for each spectrum in the PHA2 file, use tg_m, tg_part and obsID to match to a single response file. Print appropriate errors.
+    for i in range(0, num_spec_pha2):
+        match_resp = np.where(
+            (resp_m_arr == pha2_tg_m_arr[i])
+            & (resp_pha2_tg_part_arr == pha2_tg_part_arr[i])
+            & (resp_obsid_arr == pha2_tg_obsid)
+        )[0].tolist()
+        if len(match_resp) == 1:
+            matched_resp_list_par[i] = resp_list_par[
+                match_resp[0]
+            ]  # this is the element in the response array that match the i_th element of the PHA2 file.
+        elif len(match_resp) > 1:
+            raise ValueError(
+                f"ERROR, more than one {resp_type_par.upper()} match found for TG_M={pha2_tg_m_arr[i]}, TG_PART={pha2_tg_part_arr[i]} and obsID={pha2_tg_obsid}. "
+            )
+        elif len(match_resp) == 0:
+            matched_resp_list_par[i] = "no match"
+        else:
+            raise ValueError(
+                f"ERROR - Something with wrong identifying {resp_type_par.upper()}s for TG_M={pha2_tg_m_arr[i]}, TG_PART={pha2_tg_part_arr[i]} and obsID={pha2_tg_obsid}"
+            )
+
+    # report the files matched to the screen in a nice format so it is clear it worked or didn't work
+    print(f"\nThe following {resp_type_par.upper()} response files were found for obsID {pha2_tg_obsid}\n")
+
+    # name the arm and order something more readable for output message
+    arm = lambda x: "HEG" if x == 1 else "MEG" if x == 2 else "ERROR"
+    order = lambda x: f"+{x}" if x > 0 else f"-{-1*x}" if x < 0 else "ERROR"
+
+    print()
+    for i in range(0, num_spec_pha2):
+        print(
+            f"{arm(pha2_tg_part_arr[i])+order(pha2_tg_m_arr[i])} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
+        )
+    print()
+
+    #check if no responses matched and report to user. Most common issue would be the OBSID parameter is wrong
+    if (matched_resp_list_par == 'no match').all():
+        print(f'\nWARNING -- No {resp_type_par.upper()} files matched the PHA2 spectra. Check that the ARFS and RMFs are from the same obsID\n')
+
+    # returns the array of matched responses in the same order as the PHA2 spectra
+    return matched_resp_list_par
+
 
 def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1):
     """
@@ -42,245 +321,6 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
     show_all : Display information about one or all of the data sets that have been loaded into the Sherpa session.
 
     """
-
-
-    def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
-        """
-        Identifies ARFs and RMFs that are associated with an HETG PHA2 file.  This currently utilizes the 'response' and
-        'tg' directories created by the data systems and chandra_repro pipelines and thus might not work for all PHA2 HETG
-        files.
-
-        Parameters
-        ----------
-
-        pha2_file_par : PHA2 fits file
-            PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
-            running chandra_repro on a chandra HETG obsID.
-        resp_type_par: 'arf' or 'rmf'
-            The type of response files for matchign to PHA spectra
-        resp_dir_par: directory
-            The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
-            will attempt to search for them.
-
-        Returns
-        ----------
-        resp_list_par: list
-        Returns a list of ARF or RMF files found.
-
-        """
-
-        # if user enters 'ARF' or 'RMF' then lower case for later glob use
-        resp_type_par = resp_type_par.lower()
-
-        # check to make sure responses are either arf or rmf
-        if resp_type_par != "arf" and resp_type_par != "rmf":
-            raise ValueError("Response type must be either arf or rmf")
-
-        # load the pha2 file and obtain the crate where relevant information is stored
-        pha2_dataset = read_pha(pha2_file_par)
-        spec_crate_par = pha2_dataset.get_crate(2)
-
-        # identify the number of spectra in the PHA2 file
-        num_spec_par = len(spec_crate_par.TG_M.values)
-
-        # determine which pipeline the PHA2 file came from (archive vs CIAO user)
-        creator_key = get_keyval(spec_crate_par, "CREATOR")
-
-        if "Version DS" in creator_key:
-
-            # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp 
-            # glob doesn't get any extra unrelated files in the response dir.
-
-            # Note, the strings in this section are based on the DS standard naming.
-            pha_name = Path(pha2_file_par).name
-            pha_root = pha_name.partition("_pha2.fits")[0]
-
-            if resp_dir_par != None:  # use provided resp_dir_par
-                resp_list_par = glob.glob(
-                    f"{resp_dir_par}/{pha_root}*{resp_type_par}2.fits*"
-                )
-            else:
-                pha_dir = Path(
-                    pha2_file_par
-                ).parent  # need to get directory where PHA2 file is located
-                resp_list_par = glob.glob(
-                    f"{pha_dir}/responses/{pha_root}*{resp_type_par}2.fits*"
-                )
-
-        elif (
-            "Version CIAO" in creator_key
-        ):  # this is produced via chandra_repro or user custom spectral extraction
-
-            # read the header to search for the PHA2 root name which is often the same root as the responses
-            hist = get_history_records(spec_crate_par)
-            pha_root = ""  # set to '' for checking later in case pha_root not found
-
-            # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history. 
-            # This identifies that value.
-            for i in range(0, len(hist)):
-                if ":root=" in hist[i][1]:  # find the line where the :root command was used
-                    root_line = (
-                        hist[i][1].split("=", 1)[1].strip()
-                    )  # strip the unnecessary stuff but leaves the extra spaces
-                    pha_root = root_line.split(" ")[
-                        0
-                    ]  # remove everything after the root value
-                    break  # stops searching hist for the appropriate line after it is found
-
-            # if pha_root is not overwritten at this point then throw error because it means it was not found
-            if pha_root == "":
-                raise ValueError(
-                    "Could not identify PHA2 file root. Please load responses manually."
-                )
-
-            # use glob and pha_root to find the responses
-            if resp_dir_par != None:  # use provided resp_dir_par
-                resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}")
-            else:
-                pha_dir = Path(
-                    pha2_file_par
-                ).parent  # need to get directory where PHA2 file is located
-                resp_list_par = glob.glob(
-                    f"{pha_dir}/tg/{pha_root}*.{resp_type_par}"
-                )  # use the root name of the PHA2 file to ID the responses. This way users can have many extractions in a 
-                # single dir but it will only grab the appropriate ones.
-
-        # if the creator of the PHA2 file is not DS or CIAO then exit.
-        else:
-            raise ValueError(
-                "Cannot determine the creator of PHA2 file and responses will have to be loaded manually"
-            )
-
-        # check to make sure at least some files were found
-        if len(resp_list_par) < 1:
-            raise ValueError(
-                "Could not identify responses. Please load responses manually."
-            )
-
-        # check that the length of the arf or RMF lists match the number of PHA spec in the PHA2 file
-        if len(resp_list_par) != num_spec_par:
-            print(
-                f"WARNING-- The identified number of {resp_type_par.upper()}s [{len(resp_list_par)}] does not match the number of PHA spectra [{num_spec_par}] in the PHA2 file. Only the responses found will be included.\n"
-            )
-
-        return resp_list_par
-
-
-    def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
-        """
-        This uses the PHA2 file structure and matches the input response file list/array (resp_list_par) to the appropriate
-        PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
-        find_resp_files() and put them in order of the PHA2 spectra.
-
-        Parameters
-        ----------
-
-        pha2_file_par : PHA2 fits file
-            PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
-            running chandra_repro on a chandra HETG obsID.
-        resp_type_par: 'arf' or 'rmf'
-            The type of response files for matchign to PHA spectra
-        resp_dir_par: directory
-            The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
-            will attempt to search for them.
-
-        Returns
-        ----------
-
-        matched_resp_list_par: array
-            Returns an array of ARF or RMF file paths matched to the order (arrangement) of the input PHA2 file. The string
-            value 'no match' is returned for elements where there is a spectrum in the PHA2 file but no matching response
-            file.
-
-        """
-
-        # check to make sure responses are either arf or rmf
-        if resp_type_par != "arf" and resp_type_par != "rmf":
-            raise ValueError("Response type must be either arf or rmf")
-
-        # reads in the pha2 file and checks how many spectra (orders) it includes.
-        pha2_dataset = read_pha(pha2_file_par)
-        spec_crate_par = pha2_dataset.get_crate(2)
-
-        # identify the file arrangement of the HETG orders and HEG/MEG arms via the PHA2 file
-        tg_m_arr = spec_crate_par.TG_M.values
-        tg_part_arr = spec_crate_par.TG_PART.values
-        tg_obsid = get_keyval(spec_crate_par, "OBS_ID")
-
-        # determine the number of spectra in the pha2 file based on the length of one of the tg arrays:
-        num_spec_pha2 = len(tg_m_arr)
-
-        # warn user if the number of PHA2 spectra are different than the number of response files (either found 
-        # automatically or provided manually)
-        if len(resp_list_par) != num_spec_pha2:
-            print(
-                f"\nWARNING -- The number of {resp_type_par} files [{len(resp_list_par)}] does not equal the number of spectra in the PHA2 file [{num_spec_pha2}]. Only responses that match with a spectrum will be included.\n"
-            )
-
-        # create empty lists to later append HEG/MEG arm, order and obsID values from the response files headers
-        resp_m_arr = []
-        resp_tg_part_arr = []
-        resp_obsid_arr = []
-
-        # read each response file and append appropriate header value
-        for i in range(0, len(resp_list_par)):
-            resp_data = read_file(resp_list_par[i])
-            resp_m_arr.append(get_keyval(resp_data, "TG_M"))
-            resp_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
-            resp_obsid_arr.append(get_keyval(resp_data, "OBS_ID"))
-
-        # convert obsid lists to numpy arrays for later use with np.where() for obsID checking
-        tg_obsid = np.array(tg_obsid)
-        resp_obsid_arr = np.array(resp_obsid_arr)
-
-        # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the 
-        # path to the matched response file
-        matched_resp_list_par = np.array([""] * num_spec_pha2, dtype="object")
-
-        # for each spectra, use tg_m, tg_part and obsID to match to a single response file. Print appropriate errors.
-        for i in range(0, num_spec_pha2):
-            match_resp = np.where(
-                (resp_m_arr == tg_m_arr[i])
-                & (resp_tg_part_arr == tg_part_arr[i])
-                & (resp_obsid_arr == tg_obsid)
-            )[0].tolist()
-            if len(match_resp) == 1:
-                matched_resp_list_par[i] = resp_list_par[
-                    match_resp[0]
-                ]  # this is the element in the response array that match the i_th element of the PHA2 file.
-            elif len(match_resp) > 1:
-                raise ValueError(
-                    f"ERROR, more than one {resp_type_par.upper()} match found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}. "
-                )
-            elif len(match_resp) == 0:
-                matched_resp_list_par[i] = "no match"
-                print(
-                    f"Warning, no {resp_type_par.upper()} found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}."
-                )
-            else:
-                raise ValueError(
-                    f"ERROR - Something with wrong identifying {resp_type_par.upper()}s for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}"
-                )
-
-        # report the files matched to the screen in a nice format so it is clear it worked or didn't work
-        print("\nThe following response files were found\n")
-
-        # name the arm and order something more readable for output message
-        arm = lambda x: "HEG" if x == 1 else "MEG" if x == 2 else "ERROR"
-        order = lambda x: f"+{x}" if x > 0 else f"-{-1*x}" if x < 0 else "ERROR"
-
-        print()
-        for i in range(0, num_spec_pha2):
-            print(
-                f"{arm(tg_part_arr[i])+order(tg_m_arr[i])} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
-            )
-        print()
-
-        # returns the array of matched responses in the same order as the PHA2 spectra
-        return matched_resp_list_par
-
-
-
     #run find_resp_files() and match_resp_order() and load data into appropriate dataset id.
 
     #find and match ARFs

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -1,0 +1,246 @@
+
+import numpy as np
+import glob
+from pycrates import (
+    read_file,
+    get_keyval,
+    read_pha,
+    get_history_records,
+)
+
+from pathlib import Path
+
+def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
+    """
+    Identifies ARFs and RMFs that are associated with an HETG PHA2 file.  This currently utilizes the 'response' and
+    'tg' directories created by the data systems and chandra_repro pipelines and thus might not work for all PHA2 HETG
+    files.
+
+    Parameters
+    ----------
+
+    pha2_file_par : PHA2 fits file
+         PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
+         running chandra_repro on a chandra HETG obsID.
+    resp_type_par: 'arf' or 'rmf'
+        The type of response files for matchign to PHA spectra
+    resp_dir_par: directory
+        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+        will attempt to search for them.
+
+    Returns
+    ----------
+    resp_list_par: list
+    Returns a list of ARF or RMF files found.
+
+    """
+
+    # if user enters 'ARF' or 'RMF' then lower case for later glob use
+    resp_type_par = resp_type_par.lower()
+
+    # check to make sure responses are either arf or rmf
+    if resp_type_par != "arf" and resp_type_par != "rmf":
+        raise ValueError("Response type must be either arf or rmf")
+
+    # load the pha2 file and obtain the crate where relevant information is stored
+    pha2_dataset = read_pha(pha2_file_par)
+    spec_crate_par = pha2_dataset.get_crate(2)
+
+    # identify the number of spectra in the PHA2 file
+    num_spec_par = len(spec_crate_par.TG_M.values)
+
+    # determine which pipeline the PHA2 file came from (archive vs CIAO user)
+    creator_key = get_keyval(spec_crate_par, "CREATOR")
+
+    if "Version DS" in creator_key:
+
+        # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp 
+        # glob doesn't get any extra unrelated files in the response dir.
+
+        # Note, the strings in this section are based on the DS standard naming.
+        pha_name = Path(pha2_file_par).name
+        pha_root = pha_name.partition("_pha2.fits")[0]
+
+        if resp_dir_par != None:  # use provided resp_dir_par
+            resp_list_par = glob.glob(
+                f"{resp_dir_par}/{pha_root}*{resp_type_par}2.fits*"
+            )
+        else:
+            pha_dir = Path(
+                pha2_file_par
+            ).parent  # need to get directory where PHA2 file is located
+            resp_list_par = glob.glob(
+                f"{pha_dir}/responses/{pha_root}*{resp_type_par}2.fits*"
+            )
+
+    elif (
+        "Version CIAO" in creator_key
+    ):  # this is produced via chandra_repro or user custom spectral extraction
+
+        # read the header to search for the PHA2 root name which is often the same root as the responses
+        hist = get_history_records(spec_crate_par)
+        pha_root = ""  # set to '' for checking later in case pha_root not found
+
+        # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history. 
+        # This identifies that value.
+        for i in range(0, len(hist)):
+            if ":root=" in hist[i][1]:  # find the line where the :root command was used
+                root_line = (
+                    hist[i][1].split("=", 1)[1].strip()
+                )  # strip the unnecessary stuff but leaves the extra spaces
+                pha_root = root_line.split(" ")[
+                    0
+                ]  # remove everything after the root value
+                break  # stops searching hist for the appropriate line after it is found
+
+        # if pha_root is not overwritten at this point then throw error because it means it was not found
+        if pha_root == "":
+            raise ValueError(
+                "Could not identify PHA2 file root. Please load responses manually."
+            )
+
+        # use glob and pha_root to find the responses
+        if resp_dir_par != None:  # use provided resp_dir_par
+            resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}")
+        else:
+            pha_dir = Path(
+                pha2_file_par
+            ).parent  # need to get directory where PHA2 file is located
+            resp_list_par = glob.glob(
+                f"{pha_dir}/tg/{pha_root}*.{resp_type_par}"
+            )  # use the root name of the PHA2 file to ID the responses. This way users can have many extractions in a 
+               # single dir but it will only grab the appropriate ones.
+
+    # if the creator of the PHA2 file is not DS or CIAO then exit.
+    else:
+        raise ValueError(
+            "Cannot determine the creator of PHA2 file and responses will have to be loaded manually"
+        )
+
+    # check to make sure at least some files were found
+    if len(resp_list_par) < 1:
+        raise ValueError(
+            "Could not identify responses. Please load responses manually."
+        )
+
+    # check that the length of the arf or RMF lists match the number of PHA spec in the PHA2 file
+    if len(resp_list_par) != num_spec_par:
+        print(
+            f"WARNING-- The identified number of {resp_type_par.upper()}s [{len(resp_list_par)}] does not match the number of PHA spectra [{num_spec_par}] in the PHA2 file. Only the responses found will be included.\n"
+        )
+
+    return resp_list_par
+
+
+def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
+    """
+    This uses the PHA2 file structure and matches the input response file list/array (resp_list_par) to the appropriate
+    PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
+    find_resp_files() and put them in order of the PHA2 spectra.
+
+    Parameters
+    ----------
+
+    pha2_file_par : PHA2 fits file
+         PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
+         running chandra_repro on a chandra HETG obsID.
+    resp_type_par: 'arf' or 'rmf'
+        The type of response files for matchign to PHA spectra
+    resp_dir_par: directory
+        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+        will attempt to search for them.
+
+    Returns
+    ----------
+
+    matched_resp_list_par: array
+        Returns an array of ARF or RMF file paths matched to the order (arrangement) of the input PHA2 file. The string
+        value 'no match' is returned for elements where there is a spectrum in the PHA2 file but no matching response
+        file.
+
+    """
+
+    # check to make sure responses are either arf or rmf
+    if resp_type_par != "arf" and resp_type_par != "rmf":
+        raise ValueError("Response type must be either arf or rmf")
+
+    # reads in the pha2 file and checks how many spectra (orders) it includes.
+    pha2_dataset = read_pha(pha2_file_par)
+    spec_crate_par = pha2_dataset.get_crate(2)
+
+    # identify the file arrangement of the HETG orders and HEG/MEG arms via the PHA2 file
+    tg_m_arr = spec_crate_par.TG_M.values
+    tg_part_arr = spec_crate_par.TG_PART.values
+    tg_obsid = get_keyval(spec_crate_par, "OBS_ID")
+
+    # determine the number of spectra in the pha2 file based on the length of one of the tg arrays:
+    num_spec_pha2 = len(tg_m_arr)
+
+    # warn user if the number of PHA2 spectra are different than the number of response files (either found 
+    # automatically or provided manually)
+    if len(resp_list_par) != num_spec_pha2:
+        print(
+            f"\nWARNING -- The number of {resp_type_par} files [{len(resp_list_par)}] does not equal the number of spectra in the PHA2 file [{num_spec_pha2}]. Only responses that match with a spectrum will be included.\n"
+        )
+
+    # create empty lists to later append HEG/MEG arm, order and obsID values from the response files headers
+    resp_m_arr = []
+    resp_tg_part_arr = []
+    resp_obsid_arr = []
+
+    # read each response file and append appropriate header value
+    for i in range(0, len(resp_list_par)):
+        resp_data = read_file(resp_list_par[i])
+        resp_m_arr.append(get_keyval(resp_data, "TG_M"))
+        resp_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
+        resp_obsid_arr.append(get_keyval(resp_data, "OBS_ID"))
+
+    # convert obsid lists to numpy arrays for later use with np.where() for obsID checking
+    tg_obsid = np.array(tg_obsid)
+    resp_obsid_arr = np.array(resp_obsid_arr)
+
+    # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the 
+    # path to the matched response file
+    matched_resp_list_par = np.array([""] * num_spec_pha2, dtype="object")
+
+    # for each spectra, use tg_m, tg_part and obsID to match to a single response file. Print appropriate errors.
+    for i in range(0, num_spec_pha2):
+        match_resp = np.where(
+            (resp_m_arr == tg_m_arr[i])
+            & (resp_tg_part_arr == tg_part_arr[i])
+            & (resp_obsid_arr == tg_obsid)
+        )[0].tolist()
+        if len(match_resp) == 1:
+            matched_resp_list_par[i] = resp_list_par[
+                match_resp[0]
+            ]  # this is the element in the response array that match the i_th element of the PHA2 file.
+        elif len(match_resp) > 1:
+            raise ValueError(
+                f"ERROR, more than one {resp_type_par.upper()} match found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}. "
+            )
+        elif len(match_resp) == 0:
+            matched_resp_list_par[i] = "no match"
+            print(
+                f"Warning, no {resp_type_par.upper()} found for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}."
+            )
+        else:
+            raise ValueError(
+                f"ERROR - Something with wrong identifying {resp_type_par.upper()}s for TG_M={tg_m_arr[i]}, TG_PART={tg_part_arr[i]} and obsID={tg_obsid}"
+            )
+
+    # report the files matched to the screen in a nice format so it is clear it worked or didn't work
+    print("\nThe following response files were found\n")
+
+    # name the arm and order something more readable for output message
+    arm = lambda x: "HEG" if x == 1 else "MEG" if x == 2 else "ERROR"
+    order = lambda x: f"+{x}" if x > 0 else f"-{-1*x}" if x < 0 else "ERROR"
+
+    print()
+    for i in range(0, num_spec_pha2):
+        print(
+            f"{arm(tg_part_arr[i])+order(tg_m_arr[i])} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
+        )
+    print()
+
+    # returns the array of matched responses in the same order as the PHA2 spectra
+    return matched_resp_list_par

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -12,13 +12,13 @@ def find_resp_files(pha2_file, resp_type, resp_dir=None):
     Parameters
     ----------
 
-    pha2_file : PHA2 fits file
-        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
+    pha2_file : str
+        Path to a PHA2 fits file which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
         running chandra_repro on a chandra HETG/LETG obsID.
     resp_type: 'arf' or 'rmf'
         The type of response files for matching to PHA spectra
-    resp_dir: directory
-        The directory where the HETG/LETG response files associated with the PHA2 file are located. If none provided, it
+    resp_dir: str
+        The path to a directory where the HETG/LETG response files associated with the PHA2 file are located. If none provided, it
         will attempt to search for them.
 
     Returns
@@ -167,13 +167,13 @@ def match_resp_order(pha2_file, resp_list, resp_type, verbose=False):
     Parameters
     ----------
 
-    pha2_file : PHA2 fits file
-        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
+    pha2_file : str
+        Path to a PHA2 fits file which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
         running chandra_repro on a chandra HETG/LETG obsID.
     resp_type: 'arf' or 'rmf'
         The type of response files for matchign to PHA spectra
-    resp_dir: directory
-        The directory where the HETG/LETG response files associated with the PHA2 file are located. If none provided, it
+    resp_dir: str
+        The path to a directory where the HETG/LETG response files associated with the PHA2 file are located. If none provided, it
         will attempt to search for them.
     verbose: bool, optional
         If 'True' then the matched response files to each spectrum will be printed to the screen. The default is 'False'.
@@ -237,7 +237,7 @@ def match_resp_order(pha2_file, resp_list, resp_type, verbose=False):
                resp_pha2_tg_part_arr.append(3) #note LEG --> tg_part = 3
             else:
                 raise ValueError(
-                    f"ERROR-- Could not identify grating type and/or order. Please check load responses manually.")           
+                    f"ERROR-- Could not identify grating type and/or order. Please load responses manually.")           
         
         #identify the obsID
         try:
@@ -323,12 +323,12 @@ def load_gratings_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_st
     ----------
 
     pha2_file : str
-         PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
+         Path to a PHA2 fits file which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
          running chandra_repro on a chandra HETG/LETG obsID.
     arf_dir: str
-        The directory that holds the arfs associated with the pha2_file
+        The path to a directory that holds the arfs associated with the pha2_file
     rmf_dir: str
-        The directory that holds the rmfs associated with the pha2_file
+        The path to a directory that holds the rmfs associated with the pha2_file
     dataset_id_start: int
         A sherpa dataset id into which PHA2 spectra will begin loading. A typical HETG/LETG PHA2 spectral file contains
         12 individual spectra so choosing a value 1 (default) will load dataset ids 1-12.

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -145,11 +145,6 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
             "Could not identify responses. Please load responses manually."
         )
 
-    # Some response files were found so tell user matching will begin
-    print(
-        f"\n{resp_type_par.upper()} files identified. Attempting to match them to PHA2 spectra:"
-    )
-    print("-" * 63)
 
     # check that the length of the ARF or RMF lists match the number of PHA spec in the PHA2 file
     if len(resp_list_par) != num_spec_par:
@@ -160,8 +155,10 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
     return resp_list_par
 
 
-def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
+def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=False):
     """
+    Matches each response to the appropriate spectrum.
+
     This uses the PHA2 file structure and matches the input response file list/array (resp_list_par) to the appropriate
     PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
     find_resp_files() and put them in order of the PHA2 spectra.
@@ -177,6 +174,8 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
     resp_dir_par: directory
         The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
         will attempt to search for them.
+    verbose_par: bool, optional
+        If 'True' then the matched response files to each spectrum will be printed to the screen. The default is 'False'.
 
     Returns
     ----------
@@ -260,21 +259,20 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
         elif len(match_resp) == 0:
             matched_resp_list_par[i] = "no match"
 
+    if verbose_par is True:
     # report the files matched to the screen in a nice format so it is clear it worked or didn't work
-    print(
-        f"\nThe following {resp_type_par.upper()} response files were found for obsID {pha2_tg_obsid}\n"
-    )
-
-    # name the arm and order something more readable for output message
-    arm = lambda x: "HEG" if x == 1 else "MEG" if x == 2 else "ERROR"
-    order = lambda x: f"+{x}" if x > 0 else f"-{-1*x}" if x < 0 else "ERROR"
-
-    print()
-    for i in range(0, num_spec_pha2):
         print(
-            f"{arm(pha2_tg_part_arr[i])+order(pha2_tg_m_arr[i])} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
+            f"\nThe following {resp_type_par.upper()} response files were found for obsID {pha2_tg_obsid}\n"
         )
-    print()
+
+        # name the arm and order something more readable for output message
+        arm = {1: 'HEG', 2: 'MEG', 3: 'LEG'}
+
+        for i in range(0, num_spec_pha2):
+            print(
+                f"{arm[pha2_tg_part_arr[i]]}{pha2_tg_m_arr[i]:+} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
+            )
+        print() #add one extra line to separate load_hetg_resp text from sherpa text
 
     # check if no responses matched and report to user. Most common issue would be the OBSID parameter is wrong
     if (matched_resp_list_par == "no match").all():
@@ -286,9 +284,10 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
     return matched_resp_list_par
 
 
-def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1):
+def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1, use_errors_par=False, verbose=False):
     """
-
+    Loads the PHA2 spectrum and responses into the sherpa session.
+    
     This function loads an HETG PHA2 file and any associated ARF and RMF response files. If matching responses are
     found only for a subset of HETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded.
     This works only for PHA2 files and not PHA files. If arf_dir or rmf_dir are not provided then this tool will
@@ -310,9 +309,14 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
         The directory that holds the arfs associated with the pha2_file
     rmf_dir: str
         The directory that holds the rmfs associated with the pha2_file
-    dataset_id_start : int
+    dataset_id_start: int
         A sherpa dataset id into which PHA2 spectra will begin loading. A typical HETG PHA2 spectral file contains
         12 individual spectra so choosing a value 1 (default) will load dataset ids 1-12.
+    use_errors_par: bool, optional
+        If 'True' then the statistical errors are taken from the input data, rather than calculated by Sherpa from 
+        the count values. The default is 'False'. 
+    verbose: bool, optional
+        If 'True' then the matched response files to each spectrum will be printed to the screen. The default is 'False'.         
 
     Related Sherpa functions
     ------------------------
@@ -328,7 +332,7 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
         pha2_file_par=pha2_file, resp_type_par="arf", resp_dir_par=arf_dir
     )
     arf_list_matched = match_resp_order(
-        pha2_file_par=pha2_file, resp_list_par=arf_list, resp_type_par="arf"
+        pha2_file_par=pha2_file, resp_list_par=arf_list, resp_type_par="arf", verbose_par=verbose
     )
 
     # find and match RMFs
@@ -336,7 +340,7 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
         pha2_file_par=pha2_file, resp_type_par="rmf", resp_dir_par=rmf_dir
     )
     rmf_list_matched = match_resp_order(
-        pha2_file_par=pha2_file, resp_list_par=rmf_list, resp_type_par="rmf"
+        pha2_file_par=pha2_file, resp_list_par=rmf_list, resp_type_par="rmf", verbose_par=verbose
     )
 
     # check for mismatches and unmatched pairs
@@ -355,7 +359,7 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
         dataset_id_start = int(dataset_id_start)
 
     # load data first so responses can be assigned after.
-    load_data(id=dataset_id_start, filename=pha2_file)
+    load_data(id=dataset_id_start, filename=pha2_file, use_errors=use_errors_par)
 
     # for every identified response (arf), load matching arf and rmf. It should be ok to load RMFs with the arf loop
     # cause an error would be previously thrown if every arf didn't have a matching rmf.
@@ -365,4 +369,4 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
             load_arf(i + dataset_id_start, arf_list_matched[i])
             load_rmf(i + dataset_id_start, rmf_list_matched[i])
 
-    return ()
+    return

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -5,82 +5,82 @@ from sherpa.astro.ui import load_data, load_arf, load_rmf
 from pycrates import read_file, get_keyval, read_pha, get_history_records, is_pha_type2
 
 
-def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
+def find_resp_files(pha2_file, resp_type, resp_dir=None):
     """
-    Identifies ARFs and RMFs that are associated with an HETG PHA2 file.
+    Identifies ARFs and RMFs that are associated with an HETG/LETG PHA2 file.
 
     Parameters
     ----------
 
-    pha2_file_par : PHA2 fits file
-        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
-        running chandra_repro on a chandra HETG obsID.
-    resp_type_par: 'arf' or 'rmf'
+    pha2_file : PHA2 fits file
+        PHA2 spectrum which is typically provided in the chandra archive of a downloaded /LETG observation or after
+        running chandra_repro on a chandra HETG/LETG obsID.
+    resp_type: 'arf' or 'rmf'
         The type of response files for matching to PHA spectra
-    resp_dir_par: directory
-        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+    resp_dir: directory
+        The directory where the HETG/LETG response files associated with the PHA2 file are located. If none provided, it
         will attempt to search for them.
 
     Returns
     --------
-    resp_list_par: list
+    resp_list: list
         Returns a list of ARF or RMF files found.
 
     """
 
     # if user enters 'ARF' or 'RMF' then lower case for later glob use
-    resp_type_par = resp_type_par.lower()
+    resp_type = resp_type.lower()
 
     # check to make sure responses are either arf or rmf
-    if resp_type_par != "arf" and resp_type_par != "rmf":
+    if resp_type != "arf" and resp_type != "rmf":
         raise ValueError("Response type must be either arf or rmf")
 
     # load the pha2 file and obtain the crate where relevant information is stored
-    pha2_dataset = read_pha(pha2_file_par)
+    pha2_dataset = read_pha(pha2_file)
 
     # Return Error if file is not a PHA2 file
     if is_pha_type2(pha2_dataset) != True:
         raise ValueError("Input file must be of type PHA2.")
 
     # grab the spectrum crate to determine tg_m and various header values
-    spec_crate_par = pha2_dataset.get_crate(2)
+    spec_crate = pha2_dataset.get_crate(2)
 
     # identify the number of spectra in the PHA2 file
-    num_spec_par = len(spec_crate_par.TG_M.values)
+    num_spec = len(spec_crate.TG_M.values)
 
     # determine which pipeline the PHA2 file came from (archive vs CIAO user / tgcat download)
-    creator_key = get_keyval(spec_crate_par, "CREATOR")
+    creator_key = get_keyval(spec_crate, "CREATOR")
 
     if "Version DS" in creator_key:
 
-        # if users pha2_file_par is a long path or a single file, strip the name and check for the root so the resp
+        # if users pha2_file is a long path or a single file, strip the name and check for the root so the resp
         # glob doesn't get any extra unrelated files in the response dir.
 
         # Note, the strings in this section are based on the DS (CXC Data Systems Group) standard naming.
-        pha_name = Path(pha2_file_par).name
+        pha_name = Path(pha2_file).name
         pha_root = pha_name.partition("_pha2.fits")[0]
 
         # uses provided resp_dir to check for files. First check for ARF/RMF.fits and if not found then check compressed.
-        if resp_dir_par is not None:  # use provided resp_dir_par
-            resp_list_par = glob.glob(
-                f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits"
+        if resp_dir is not None:  # use provided resp_dir
+            resp_list = glob.glob(
+                f"{resp_dir}/{pha_root}*{resp_type}*.fits"
             )
-            if len(resp_list_par) == 0:
-                resp_list_par = glob.glob(
-                    f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits*"  # will grab .gz files
+            if len(resp_list) == 0:
+                resp_list = glob.glob(
+                    f"{resp_dir}/{pha_root}*{resp_type}*.fits.gz"  # will grab fits.gz files
                 )
 
         # if user does not provide a response directory
         else:
             pha_dir = Path(
-                pha2_file_par
+                pha2_file
             ).parent  # need to get directory where PHA2 file is located
-            resp_list_par = glob.glob(
-                f"{pha_dir}/responses/{pha_root}*{resp_type_par}*.fits"
+            resp_list = glob.glob(
+                f"{pha_dir}/responses/{pha_root}*{resp_type}*.fits"
             )
-            if len(resp_list_par) == 0:
-                resp_list_par = glob.glob(
-                    f"{pha_dir}/responses/{pha_root}*{resp_type_par}*.fits*"  # will grab .gz files
+            if len(resp_list) == 0:
+                resp_list = glob.glob(
+                    f"{pha_dir}/responses/{pha_root}*{resp_type}*.fits.gz"  # will grab fits.gz files
                 )
 
     elif (
@@ -88,7 +88,7 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
     ):  # this is produced via chandra_repro or user custom spectral extraction
 
         # read the header to search for the PHA2 root name which is often the same root as the responses
-        hist = get_history_records(spec_crate_par)
+        hist = get_history_records(spec_crate)
         pha_root = ""  # set to "" (blank) so it still works for TGCAT downloaded data which has no root par.
 
         # if chandra_repro was used to produce the PHA2 file then a ':root" value is saved in the header history.
@@ -104,33 +104,34 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
                 break  # stops searching hist for the appropriate line after it is found
 
         # if pha_root is not set then it means the file came from a tgcat downloaded PHA2 file.
+        # TGCAT files also do not include '.fits' so have to only check resp_type or .gz
 
         # use glob and pha_root to find the responses
-        if resp_dir_par != None:  # use provided resp_dir_par
-            resp_list_par = glob.glob(f"{resp_dir_par}/{pha_root}*.{resp_type_par}")
-            if len(resp_list_par) == 0:
-                resp_list_par = glob.glob(
-                    f"{resp_dir_par}/{pha_root}*.{resp_type_par}*"
+        if resp_dir != None:  # use provided resp_dir
+            resp_list = glob.glob(f"{resp_dir}/{pha_root}*.{resp_type}")
+            if len(resp_list) == 0:
+                resp_list = glob.glob(
+                    f"{resp_dir}/{pha_root}*.{resp_type}*"
                 )  # will grab .gz files
 
         # if user does not provide response directory
         else:
             pha_dir = Path(
-                pha2_file_par
+                pha2_file
             ).parent  # need to get directory where PHA2 file is located
-            resp_list_par = glob.glob(f"{pha_dir}/tg/{pha_root}*.{resp_type_par}")
-            if len(resp_list_par) == 0:
-                resp_list_par = glob.glob(
-                    f"{pha_dir}/tg/{pha_root}*.{resp_type_par}*"  # will grab .gz files
+            resp_list = glob.glob(f"{pha_dir}/tg/{pha_root}*.{resp_type}")
+            if len(resp_list) == 0:
+                resp_list = glob.glob(
+                    f"{pha_dir}/tg/{pha_root}*.{resp_type}*.gz"  # will grab .gz files
                 )
             # TGCAT does not come with a tg directory so check in the pha_dir for response files.
-            if len(resp_list_par) == 0:
-                resp_list_par = glob.glob(
-                    f"{pha_dir}/{pha_root}*.{resp_type_par}"  
+            if len(resp_list) == 0:
+                resp_list = glob.glob(
+                    f"{pha_dir}/{pha_root}*.{resp_type}"  
                 )
-            if len(resp_list_par) == 0:
-                resp_list_par = glob.glob(
-                    f"{pha_dir}/{pha_root}*.{resp_type_par}*"  # will grab .gz files
+            if len(resp_list) == 0:
+                resp_list = glob.glob(
+                    f"{pha_dir}/{pha_root}*.{resp_type}*.gz"  # will grab .gz files
                 )
 
     # if the creator of the PHA2 file is not DS or CIAO then raise error and exit.
@@ -140,47 +141,47 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
         )
 
     # check to make sure at least some files were found
-    if len(resp_list_par) == 0:
+    if len(resp_list) == 0:
         raise ValueError(
             "Could not identify responses. Please load responses manually."
         )
 
 
     # check that the length of the ARF or RMF lists match the number of PHA spec in the PHA2 file
-    if len(resp_list_par) != num_spec_par:
+    if len(resp_list) != num_spec:
         print(
-            f"\nWARNING-- The identified number of {resp_type_par.upper()}s [{len(resp_list_par)}] does not match the number of PHA spectra [{num_spec_par}] in the PHA2 file. Only the responses found will be included.\n"
+            f"\nWARNING-- The identified number of {resp_type.upper()}s [{len(resp_list)}] does not match the number of PHA spectra [{num_spec}] in the PHA2 file. Only the responses found will be included.\n"
         )
 
-    return resp_list_par
+    return resp_list
 
 
-def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=False):
+def match_resp_order(pha2_file, resp_list, resp_type, verbose=False):
     """
     Matches each response to the appropriate spectrum.
 
-    This uses the PHA2 file structure and matches the input response file list/array (resp_list_par) to the appropriate
+    This uses the PHA2 file structure and matches the input response file list/array (resp_list) to the appropriate
     PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
     find_resp_files() and put them in order of the PHA2 spectra.
 
     Parameters
     ----------
 
-    pha2_file_par : PHA2 fits file
-        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
-        running chandra_repro on a chandra HETG obsID.
-    resp_type_par: 'arf' or 'rmf'
+    pha2_file : PHA2 fits file
+        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
+        running chandra_repro on a chandra HETG/LETG obsID.
+    resp_type: 'arf' or 'rmf'
         The type of response files for matchign to PHA spectra
-    resp_dir_par: directory
-        The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
+    resp_dir: directory
+        The directory where the HETG/LETG response files associated with the PHA2 file are located. If none provided, it
         will attempt to search for them.
-    verbose_par: bool, optional
+    verbose: bool, optional
         If 'True' then the matched response files to each spectrum will be printed to the screen. The default is 'False'.
 
     Returns
     ----------
 
-    matched_resp_list_par: array
+    matched_resp_list: array
         Returns an array of ARF or RMF file paths matched to the order (arrangement) of the input PHA2 file. The string
         value 'no match' is returned for elements where there is a spectrum in the PHA2 file but no matching response
         file.
@@ -188,17 +189,17 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=Fa
     """
 
     # check to make sure responses are either arf or rmf
-    if resp_type_par != "arf" and resp_type_par != "rmf":
+    if resp_type != "arf" and resp_type != "rmf":
         raise ValueError("Response type must be either arf or rmf")
 
     # reads in the pha2 file and checks how many spectra (orders) it includes.
-    pha2_dataset = read_pha(pha2_file_par)
-    spec_crate_par = pha2_dataset.get_crate(2)
+    pha2_dataset = read_pha(pha2_file)
+    spec_crate = pha2_dataset.get_crate(2)
 
-    # identify the file arrangement of the HETG orders and HEG/MEG arms via the PHA2 file
-    pha2_tg_m_arr = spec_crate_par.TG_M.values
-    pha2_tg_part_arr = spec_crate_par.TG_PART.values
-    pha2_tg_obsid = get_keyval(spec_crate_par, "OBS_ID")
+    # identify the file arrangement of the HETG/LETG orders and HEG/MEG arms via the PHA2 file
+    pha2_tg_m_arr = spec_crate.TG_M.values
+    pha2_tg_part_arr = spec_crate.TG_PART.values
+    pha2_tg_obsid = get_keyval(spec_crate, "OBS_ID")
 
     # determine the number of spectra in the pha2 file based on the length of one of the tg arrays:
     num_spec_pha2 = len(pha2_tg_m_arr)
@@ -211,15 +212,34 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=Fa
     # start a counter to determine how many response files are missing an OBS_ID header value
     obsid_missing_count = 0
 
+    #NOTE -- The various try and excepts below are due to TGCat provided RMFs not having standard ciao header keywords as 
+    # of 3/23/26. TGCat ACIS HETG RMFs do not have OBS_ID and TGCat HRC LETG RMFs do not have tg_part or tg_m keywords. 
+    # The archive and repro RMFs do not have this problem.
+    
     # read each response file and append appropriate header values
-    for i in resp_list_par:
-        resp_data = read_file(i)
-        resp_m_arr.append(get_keyval(resp_data, "TG_M"))
-        resp_pha2_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
+    for i in resp_list:
 
-        # As of 3/23/26, TGCAT-provided RMFs do not have a 'OBS_ID' header keyword. This attempts to mitigate the issue.
-        # If there is any error reading the OBS_ID header then it assigns the PHA2 obsid value to the array and prints a
-        # warning  so the rest of code will continue. TGCAT RMF data is expected to get OBSID par in near future.
+        #load the response file
+        resp_data = read_file(i)
+        
+        #identify the gratings order
+        try:
+            resp_m_arr.append(get_keyval(resp_data, "TG_M"))
+        except:
+            resp_m_arr.append(get_keyval(resp_data, "ORDER"))
+        
+        #identify the gratings type (HEG, MEG or LEG).
+        try:
+            resp_pha2_tg_part_arr.append(get_keyval(resp_data, "TG_PART"))
+        except:
+            grating_type = get_keyval(resp_data, "GRATING")
+            if grating_type == 'LETG':
+               resp_pha2_tg_part_arr.append(3) #note LEG --> tg_part = 3
+            else:
+                raise ValueError(
+                    f"ERROR-- Could not identify grating type and/or order. Please check load responses manually.")           
+        
+        #identify the obsID
         try:
             resp_obsid_arr.append(get_keyval(resp_data, "OBS_ID"))
         except:
@@ -230,7 +250,7 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=Fa
     # continue though because this requirement is likely to almost never be an issue.
     if obsid_missing_count > 0:
         print(
-            f"\nWARNING -- Header keyword OBS_ID is missing from {obsid_missing_count} {resp_type_par.upper()} file(s). {resp_type_par.upper()}(s) will not be checked against obsID for validity. \n"
+            f"\nWARNING -- Header keyword OBS_ID is missing from {obsid_missing_count} {resp_type.upper()} file(s). {resp_type.upper()}(s) will not be checked against obsID for validity. \n"
         )
 
     # convert obsid lists to numpy arrays for later use with np.where() for obsID checking
@@ -239,7 +259,7 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=Fa
 
     # create an empty object array the same size as the PHA2 file (number of spectra) to hold either 'no match' or the
     # path to the matched response file
-    matched_resp_list_par = np.array([""] * num_spec_pha2, dtype="object")
+    matched_resp_list = np.array([""] * num_spec_pha2, dtype="object")
 
     # for each spectrum in the PHA2 file, use tg_m, tg_part and obsID to match to a single response file. Print appropriate errors.
     for i in range(0, num_spec_pha2):
@@ -249,20 +269,20 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=Fa
             & (resp_obsid_arr == pha2_tg_obsid)
         )[0].tolist()
         if len(match_resp) == 1:
-            matched_resp_list_par[i] = resp_list_par[
+            matched_resp_list[i] = resp_list[
                 match_resp[0]
             ]  # this is the element in the response array that match the i_th element of the PHA2 file.
         elif len(match_resp) > 1:
             raise ValueError(
-                f"ERROR, more than one {resp_type_par.upper()} match found for TG_M={pha2_tg_m_arr[i]}, TG_PART={pha2_tg_part_arr[i]} and obsID={pha2_tg_obsid}. "
+                f"ERROR, more than one {resp_type.upper()} match found for TG_M={pha2_tg_m_arr[i]}, TG_PART={pha2_tg_part_arr[i]} and obsID={pha2_tg_obsid}. "
             )
         elif len(match_resp) == 0:
-            matched_resp_list_par[i] = "no match"
+            matched_resp_list[i] = "no match"
 
-    if verbose_par is True:
+    if verbose is True:
     # report the files matched to the screen in a nice format so it is clear it worked or didn't work
         print(
-            f"\nThe following {resp_type_par.upper()} response files were found for obsID {pha2_tg_obsid}\n"
+            f"\nThe following {resp_type.upper()} response files were found for obsID {pha2_tg_obsid}\n"
         )
 
         # name the arm and order something more readable for output message
@@ -270,49 +290,49 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par, verbose_par=Fa
 
         for i in range(0, num_spec_pha2):
             print(
-                f"{arm[pha2_tg_part_arr[i]]}{pha2_tg_m_arr[i]:+} -- {resp_type_par.upper()}: {matched_resp_list_par[i]}"
+                f"{arm[pha2_tg_part_arr[i]]}{pha2_tg_m_arr[i]:+} -- {resp_type.upper()}: {matched_resp_list[i]}"
             )
         print() #add one extra line to separate load_hetg_resp text from sherpa text
 
     # check if no responses matched and report to user. Most common issue would be the OBSID parameter is wrong
-    if (matched_resp_list_par == "no match").all():
+    if (matched_resp_list == "no match").all():
         print(
-            f"\nWARNING -- No {resp_type_par.upper()} files matched the PHA2 spectra. Check that the ARFS and RMFs are from the same obsID\n"
+            f"\nERROR -- No {resp_type.upper()} files matched the PHA2 spectra. Check that the ARFS and RMFs are from the same obsID. {resp_type.upper()} responses were not loaded.\n"
         )
 
     # returns the array of matched responses in the same order as the PHA2 spectra
-    return matched_resp_list_par
+    return matched_resp_list
 
 
-def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1, use_errors_par=False, verbose=False):
+def load_gratings_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1, use_errors=False, verbose=False):
     """
     Loads the PHA2 spectrum and responses into the sherpa session.
     
-    This function loads an HETG PHA2 file and any associated ARF and RMF response files. If matching responses are
-    found only for a subset of HETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded.
+    This function loads an HETG/LETG PHA2 file and any associated ARF and RMF response files. If matching responses are
+    found only for a subset of HETG/LETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded.
     This works only for PHA2 files and not PHA files. If arf_dir or rmf_dir are not provided then this tool will
     search for the responses in subdirectories where the PHA2 file is located using standard CIAO directory naming
     formats.
 
     Example
     -------
-    >>> load_hetg_pha2(pha2_file="16370/repro/acisf16370_repro_pha2.fits", dataset_id_start=1)
-    >>> load_hetg_pha2("pha2_file=16371/repro/acisf16371_repro_pha2.fits", dataset_id_start=13)
+    >>> load_gratings_pha2(pha2_file="16370/repro/acisf16370_repro_pha2.fits", dataset_id_start=1)
+    >>> load_gratings_pha2("pha2_file=16371/repro/acisf16371_repro_pha2.fits", dataset_id_start=13)
 
     Parameters
     ----------
 
     pha2_file : str
-         PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
-         running chandra_repro on a chandra HETG obsID.
+         PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
+         running chandra_repro on a chandra HETG/LETG obsID.
     arf_dir: str
         The directory that holds the arfs associated with the pha2_file
     rmf_dir: str
         The directory that holds the rmfs associated with the pha2_file
     dataset_id_start: int
-        A sherpa dataset id into which PHA2 spectra will begin loading. A typical HETG PHA2 spectral file contains
+        A sherpa dataset id into which PHA2 spectra will begin loading. A typical HETG/LETG PHA2 spectral file contains
         12 individual spectra so choosing a value 1 (default) will load dataset ids 1-12.
-    use_errors_par: bool, optional
+    use_errors: bool, optional
         If 'True' then the statistical errors are taken from the input data, rather than calculated by Sherpa from 
         the count values. The default is 'False'. 
     verbose: bool, optional
@@ -329,18 +349,18 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
 
     # find and match ARFs
     arf_list = find_resp_files(
-        pha2_file_par=pha2_file, resp_type_par="arf", resp_dir_par=arf_dir
+        pha2_file=pha2_file, resp_type="arf", resp_dir=arf_dir
     )
     arf_list_matched = match_resp_order(
-        pha2_file_par=pha2_file, resp_list_par=arf_list, resp_type_par="arf", verbose_par=verbose
+        pha2_file=pha2_file, resp_list=arf_list, resp_type="arf", verbose=verbose
     )
 
     # find and match RMFs
     rmf_list = find_resp_files(
-        pha2_file_par=pha2_file, resp_type_par="rmf", resp_dir_par=rmf_dir
+        pha2_file=pha2_file, resp_type="rmf", resp_dir=rmf_dir
     )
     rmf_list_matched = match_resp_order(
-        pha2_file_par=pha2_file, resp_list_par=rmf_list, resp_type_par="rmf", verbose_par=verbose
+        pha2_file=pha2_file, resp_list=rmf_list, resp_type="rmf", verbose=verbose
     )
 
     # check for mismatches and unmatched pairs
@@ -359,7 +379,7 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
         dataset_id_start = int(dataset_id_start)
 
     # load data first so responses can be assigned after.
-    load_data(id=dataset_id_start, filename=pha2_file, use_errors=use_errors_par)
+    load_data(id=dataset_id_start, filename=pha2_file, use_errors=use_errors)
 
     # for every identified response (arf), load matching arf and rmf. It should be ok to load RMFs with the arf loop
     # cause an error would be previously thrown if every arf didn't have a matching rmf.

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -13,7 +13,7 @@ def find_resp_files(pha2_file, resp_type, resp_dir=None):
     ----------
 
     pha2_file : str
-        Path to a PHA2 fits file which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
+        Path to a Chandra PHA2 fits file which is typically provided in the Chandra archive of a downloaded HETG/LETG observation or after
         running chandra_repro on a chandra HETG/LETG obsID.
     resp_type: 'arf' or 'rmf'
         The type of response files for matching to PHA spectra
@@ -160,7 +160,7 @@ def match_resp_order(pha2_file, resp_list, resp_type, verbose=False):
     """
     Matches each response to the appropriate spectrum.
 
-    This uses the PHA2 file structure and matches the input response file list/array (resp_list) to the appropriate
+    This uses the Chandra PHA2 file structure and matches the input response file list/array (resp_list) to the appropriate
     PHA2 spectrum using the header keywords tg_m, tg_part and obsid. This function is designed to take the output of
     find_resp_files() and put them in order of the PHA2 spectra.
 
@@ -171,7 +171,7 @@ def match_resp_order(pha2_file, resp_list, resp_type, verbose=False):
         Path to a PHA2 fits file which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
         running chandra_repro on a chandra HETG/LETG obsID.
     resp_type: 'arf' or 'rmf'
-        The type of response files for matchign to PHA spectra
+        The type of response files for matching to PHA spectra
     resp_dir: str
         The path to a directory where the HETG/LETG response files associated with the PHA2 file are located. If none provided, it
         will attempt to search for them.
@@ -308,7 +308,7 @@ def load_gratings_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_st
     """
     Loads the HETG/LETG PHA2 spectrum and responses into the sherpa session.
     
-    This function loads an HETG/LETG PHA2 file and any associated ARF and RMF response files. If matching responses are
+    This function loads a Chandra HETG/LETG PHA2 file and any associated ARF and RMF response files. If matching responses are
     found only for a subset of HETG/LETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded.
     This works only for PHA2 files and not PHA files. If arf_dir or rmf_dir are not provided then this tool will
     search for the responses in subdirectories where the PHA2 file is located using standard CIAO directory naming

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -13,7 +13,7 @@ def find_resp_files(pha2_file, resp_type, resp_dir=None):
     ----------
 
     pha2_file : PHA2 fits file
-        PHA2 spectrum which is typically provided in the chandra archive of a downloaded /LETG observation or after
+        PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG/LETG observation or after
         running chandra_repro on a chandra HETG/LETG obsID.
     resp_type: 'arf' or 'rmf'
         The type of response files for matching to PHA spectra
@@ -306,7 +306,7 @@ def match_resp_order(pha2_file, resp_list, resp_type, verbose=False):
 
 def load_gratings_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=1, use_errors=False, verbose=False):
     """
-    Loads the PHA2 spectrum and responses into the sherpa session.
+    Loads the HETG/LETG PHA2 spectrum and responses into the sherpa session.
     
     This function loads an HETG/LETG PHA2 file and any associated ARF and RMF response files. If matching responses are
     found only for a subset of HETG/LETG orders (e.g., orders +1 and -1) then only those order's responses will be loaded.

--- a/sherpa_contrib/load_hetg_resp.py
+++ b/sherpa_contrib/load_hetg_resp.py
@@ -16,15 +16,15 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
         PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
         running chandra_repro on a chandra HETG obsID.
     resp_type_par: 'arf' or 'rmf'
-        The type of response files for matchign to PHA spectra
+        The type of response files for matching to PHA spectra
     resp_dir_par: directory
         The directory where the HETG response files associated with the PHA2 file are located. If none provided, it
         will attempt to search for them.
 
     Returns
-    ----------
+    --------
     resp_list_par: list
-    Returns a list of ARF or RMF files found.
+        Returns a list of ARF or RMF files found.
 
     """
 
@@ -61,7 +61,7 @@ def find_resp_files(pha2_file_par, resp_type_par, resp_dir_par=None):
         pha_root = pha_name.partition("_pha2.fits")[0]
 
         # uses provided resp_dir to check for files. First check for ARF/RMF.fits and if not found then check compressed.
-        if resp_dir_par != None:  # use provided resp_dir_par
+        if resp_dir_par is not None:  # use provided resp_dir_par
             resp_list_par = glob.glob(
                 f"{resp_dir_par}/{pha_root}*{resp_type_par}*.fits"
             )
@@ -259,10 +259,6 @@ def match_resp_order(pha2_file_par, resp_list_par, resp_type_par):
             )
         elif len(match_resp) == 0:
             matched_resp_list_par[i] = "no match"
-        else:
-            raise ValueError(
-                f"ERROR - Something with wrong identifying {resp_type_par.upper()}s for TG_M={pha2_tg_m_arr[i]}, TG_PART={pha2_tg_part_arr[i]} and obsID={pha2_tg_obsid}"
-            )
 
     # report the files matched to the screen in a nice format so it is clear it worked or didn't work
     print(
@@ -299,13 +295,15 @@ def load_hetg_pha2(pha2_file=None, arf_dir=None, rmf_dir=None, dataset_id_start=
     search for the responses in subdirectories where the PHA2 file is located using standard CIAO directory naming
     formats.
 
-    Example: load_hetg_pha2(pha2_file=16370/repro/acisf16370_repro_pha2.fits, dataset_id_start=1)
-             load_hetg_pha2(pha2_file=16371/repro/acisf16371_repro_pha2.fits, dataset_id_start=13)
+    Example
+    -------
+    >>> load_hetg_pha2(pha2_file="16370/repro/acisf16370_repro_pha2.fits", dataset_id_start=1)
+    >>> load_hetg_pha2("pha2_file=16371/repro/acisf16371_repro_pha2.fits", dataset_id_start=13)
 
     Parameters
     ----------
 
-    pha2_file : PHA2 fits file
+    pha2_file : str
          PHA2 spectrum which is typically provided in the chandra archive of a downloaded HETG observation or after
          running chandra_repro on a chandra HETG obsID.
     arf_dir: str


### PR DESCRIPTION
If users generated or obtained an HETG PHA2 file through relatively standard means (e.g., Chandra archive or running chandra_repro) then this function will load their PHA2 file into sherpa and find/assign the associated ARFs and RMFs.