### PR TITLE
Update release month from March to April

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -1,4 +1,4 @@
-## 4.18.1 March 2026
+## 4.18.1 April 2026
 
 Updated Scripts
 

--- a/share/doc/xml/acis_clear_status_bits.xml
+++ b/share/doc/xml/acis_clear_status_bits.xml
@@ -70,7 +70,7 @@
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.18.1 (March 2026) release">
+    <ADESC title="Changes in the scripts 4.18.1 (April 2026) release">
         <PARA>Improved error checking if the input file cannot be modified
         (compressed or lacking file permissions).
         </PARA>

--- a/share/doc/xml/acis_split_evt_by_fptemp.xml
+++ b/share/doc/xml/acis_split_evt_by_fptemp.xml
@@ -255,7 +255,7 @@ ${outroot}_evt.lis
      </PARA>
     </ADESC>
 
-    <ADESC title="Changes in scripts 4.18.1 (March 2026) release">
+    <ADESC title="Changes in scripts 4.18.1 (April 2026) release">
         <PARA>
             Added check on total ONTIME after the event files have been split.
             Issue a warning if the total ONTIME in the output files is different by

--- a/share/doc/xml/chandra_repro.xml
+++ b/share/doc/xml/chandra_repro.xml
@@ -887,7 +887,7 @@ tg_zo_position="5:35:15.7594,-5:23:10.191"
       </PARAM>
     </PARAMLIST>
 
-    <ADESC title="Changes in the scripts 4.18.1 (March 2026) release">
+    <ADESC title="Changes in the scripts 4.18.1 (April 2026) release">
       <PARA>
         Added a new tg_orders parameter that allows the user to choose
         which grating orders, if any, to create responses (ARF and RMF) for.

--- a/share/doc/xml/dax.xml
+++ b/share/doc/xml/dax.xml
@@ -136,7 +136,7 @@ unix% ds9 -analysis $ASCDS_CONTRIB/config/ciao.ds9 ...
 
 </DESC>
 
-<ADESC title="Changes in scripts 4.18.1 (March 2026) release">
+<ADESC title="Changes in scripts 4.18.1 (April 2026) release">
   <PARA>
     Updated to fix the Coords -&gt; Interactive Graating Coordinates
     Vector which broke with internal changes to DS9 8.7b2.

--- a/share/doc/xml/mkrprm.xml
+++ b/share/doc/xml/mkrprm.xml
@@ -374,7 +374,7 @@ ui.fit()
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.18.1 (March 2026) release">
+    <ADESC title="Changes in the scripts 4.18.1 (April 2026) release">
       <PARA>
           With MARX 6, the bug affecting image inputs has been fixed.
           This change allows users to set psfmethod=marx and to allow the

--- a/share/doc/xml/patch_hrc_ssc.xml
+++ b/share/doc/xml/patch_hrc_ssc.xml
@@ -250,7 +250,7 @@ SSC not detected, no action required.
       </PARAM>
    </PARAMLIST>
 
-    <ADESC title="Changes in the scripts 4.18.1 (March 2026) release">
+    <ADESC title="Changes in the scripts 4.18.1 (April 2026) release">
         <PARA>
             An update is made that retains the initial time filtering (GTI)
             due to the HRC high voltage level being out-of-range that can occur

--- a/share/doc/xml/simulate_psf.xml
+++ b/share/doc/xml/simulate_psf.xml
@@ -993,7 +993,7 @@ $ marx @@${outroot}_iNNNN_marx.par
       </PARA>
     </ADESC>
 
-    <ADESC title="Changes in the scripts 4.18.1 (March 2026) release">
+    <ADESC title="Changes in the scripts 4.18.1 (April 2026) release">
         <PARA>
             Updated to support SAOTrace 2.1.0. There is no functional
             difference in the output; only internal setup/configuration.


### PR DESCRIPTION
No functional change.

If we removed the month from the titles then we wouldn't need to do this, but I feel like there's some benefit to know that "4.18.1" was released in April 2026. However, this information can always be got from https://cxc.cfa.harvard.edu/ciao/download/scripts/history.html (although this page is a little hard to find).