### PR TITLE
check_ciao_version: add packages in the LINK list to the packages needing updating in the current env

### DIFF
--- a/ciao_contrib/_tools/versioninfo.py
+++ b/ciao_contrib/_tools/versioninfo.py
@@ -444,7 +444,9 @@ def check_conda_versions(ciao: str) -> bool:
     # filter the names list to only show the CIAO packages
     #
     names = []
-    for name, version in get_names(fetch):
+    all_names = get_names(fetch)
+    all_names.extend(get_names(link))
+    for name, version in all_names:
         if name not in packages:
             v3(f" - skipping {name} {version} from FETCH list")
             continue


### PR DESCRIPTION
This fixes #1045 

`check_ciao_version` is checking the `FETCH` list for packages that need to be updated in the current environment.  But if the package has already been installed in a separate environment and it's still in the cache, then it does not show up in the `FETCH` list; it's in the `LINK` list.  This update combines the packages listed in the `FETCH` and `LINK` lists. 

Not likely to affect most users since they only have one environment so not likely to be in cache already.

