### PR TITLE
tweak scripts affected by dmhistory changes in colorized CIAO 4.18 build

### DIFF
--- a/bin/blanksky
+++ b/bin/blanksky
@@ -19,7 +19,7 @@
 #
 
 __toolname__ = "blanksky"
-__revision__  = "18 March 2024"
+__revision__  = "18 May 2026"
 
 
 import os
@@ -201,7 +201,13 @@ def check_tool_par(evt,tool,param):
     except OSError as exc:
         raise ValueError(f"{tool} was not used to generate {evt}") from exc
 
-    hist = [t for t in hist.split("\n") if t.startswith(tool)]
+    if "\\\n" in hist:
+        ## support colorized dmhistory where each parameter is
+        ## terminated with a new line, as modified for 4.18
+        hist = [ " ".join( ( s.strip(" ") for s in _h.split("\\\n") ) )
+                for _h in hist[hist.index(tool):].split("\n\n") ]
+    else:
+        hist = [t for t in hist.split("\n") if t.startswith(tool)]
 
     par_instance = []
 
@@ -653,7 +659,7 @@ with valid HRC-I background files.")
         # *      any data on ACIS-4
         # *      CTI-corrected data on ACIS-9
         # *      ACIS-0 data, when ACIS-S is in the focal plane (a SIM_Z limit is exceeded)
-        if stowedbg and not set([4,8,9]).isdisjoint(set(ccds)):
+        if stowedbg and not {4,8,9}.isdisjoint(set(ccds)):
             v1("ACIS-S0, -S4, and/or -S5 will be ignored, as no stowed background files are \
 available for these chips.\n")
 
@@ -675,7 +681,7 @@ available for these chips.\n")
             v1("Ignoring ACIS-S5, as no blank-sky map is available for this chip with CTI corrections applied.\n")
             ccds.remove(9)
 
-        if [0 in ccds, set([4,5,6,7,8,9]).isdisjoint(set(ccds))] == [True,False]:
+        if [0 in ccds, {4,5,6,7,8,9}.isdisjoint(set(ccds))] == [True,False]:
             # check location of aimpoint with dmcoords using the
             # time-averaged optical-axis coordinates
             ra_pnt = keywords["RA_PNT"]

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -2101,7 +2101,7 @@ def make_fluxed_images(taskrunner, labelconv, preconditions,
     return etask
 
 
-def read_first_row(filename, colname):
+def read_first_row(filename, colname, patch_ssc=False):
     "Return the value of the first row of the given column."
 
     ##############################
@@ -2126,6 +2126,10 @@ def read_first_row(filename, colname):
             else:
                 cc.append(_)
                 ii = i+1
+
+        if patch_ssc:
+            cc = [_c for _c in cc if _c != "\n"]
+            cc = cc[-2:]
 
         with open(filename, mode="w", encoding="utf-8") as hist:
             hist.write(" ".join(cc))
@@ -2286,18 +2290,21 @@ def find_status_filter(infile, obsid, tmpdir="/tmp"):
     status filter it returns the empty string.
     """
 
-    status = tempfile.NamedTemporaryFile(dir=tmpdir,
-                                         suffix=".status")
-    args = ["infile=" + infile,
-            "outfile=" + status.name,
-            "tool=dmcopy",
-            "action=get",
-            "clobber=yes"]
-    run.run("dmhistory", args)
+    with tempfile.NamedTemporaryFile(dir=tmpdir, suffix=".status") as status:
+        args = ["infile=" + infile,
+                "outfile=" + status.name,
+                "tool=dmcopy",
+                "action=get",
+                "clobber=yes"]
+        run.run("dmhistory", args)
 
-    # Need to convert from np.string_ to Python string
-    statbits = str(read_first_row(status.name, "col2"))
-    status.close()
+        kw = fileio.get_keys_from_file(f"{infile}[#row=0]")
+
+        if kw.get("SSC") is not None and kw.get("SSCFIX") is not None:
+            statbits = str(read_first_row(status.name, "col2", patch_ssc=True))
+        else:
+            statbits = str(read_first_row(status.name, "col2"))
+
     v2(f"Finding status bit filter for ObsId {obsid} from: {statbits}")
 
     # I had planned to report this at verbose=2 but that is

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -2104,6 +2104,34 @@ def make_fluxed_images(taskrunner, labelconv, preconditions,
 def read_first_row(filename, colname):
     "Return the value of the first row of the given column."
 
+    ##############################
+
+    # for colorized build, the 4.18 dmhistory output is terminated
+    # by a new line at the end of each parameter causing erroneous
+    # interpretation by pycrates; parse and clean up this syntax
+    # before passing on to pycrates, for regular dmhistory, the
+    # returned string array is not altered.
+    with open(filename, mode="r", encoding="utf-8") as hist:
+        c = hist.readlines()
+
+    if any("\\\n" in _c for _c in c):
+        cc = []
+        ii = 0
+
+        for i,s in enumerate(c):
+            if i == ii:
+                _ = s
+            if _.endswith("\\\n"):
+                _ = _.replace("\\\n", c[i+1].lstrip(" "))
+            else:
+                cc.append(_)
+                ii = i+1
+
+        with open(filename, mode="w", encoding="utf-8") as hist:
+            hist.write(" ".join(cc))
+
+    ##############################
+
     cr = pcr.read_file(filename + "[#row=1]")
     return pcr.copy_colvals(cr, colname)[0]
 

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -2290,38 +2290,45 @@ def find_status_filter(infile, obsid, tmpdir="/tmp"):
     status filter it returns the empty string.
     """
 
-    with tempfile.NamedTemporaryFile(dir=tmpdir, suffix=".status") as status:
-        args = ["infile=" + infile,
-                "outfile=" + status.name,
-                "tool=dmcopy",
-                "action=get",
-                "clobber=yes"]
-        run.run("dmhistory", args)
+    kw = fileio.get_keys_from_file(f"{infile}[#row=0]")
+    statfilt = kw.get("STATFILT") # keyword added by chandra_repro in contrib 4.6.6
 
-        kw = fileio.get_keys_from_file(f"{infile}[#row=0]")
+    if statfilt is None:
+        with tempfile.NamedTemporaryFile(dir=tmpdir, suffix=".status") as status:
+            args = [f"infile={infile}",
+                    f"outfile={status.name}",
+                    "tool=dmcopy",
+                    "action=get",
+                    "clobber=yes"]
+            run.run("dmhistory", args)
 
-        if kw.get("SSC") is not None and kw.get("SSCFIX") is not None:
-            statbits = str(read_first_row(status.name, "col2", patch_ssc=True))
-        else:
-            statbits = str(read_first_row(status.name, "col2"))
+            if kw.get("SSC") is not None and kw.get("SSCFIX") is not None:
+                statbits = str(read_first_row(status.name, "col2", patch_ssc=True))
+            else:
+                statbits = str(read_first_row(status.name, "col2"))
 
-    v2(f"Finding status bit filter for ObsId {obsid} from: {statbits}")
+        v2(f"Finding status bit filter for ObsId {obsid} from: {statbits}")
 
-    # I had planned to report this at verbose=2 but that is
-    # *very* noisy, so adding it to the verbose=1 level,
-    # since it's important to know.
-    spos = statbits.find("[status=")
-    if spos == -1:
-        v1(f"WARNING: no STATUS filter found in {infile} so unable to filter background for obsid {obsid}!")
-        return ""
+        # I had planned to report this at verbose=2 but that is
+        # *very* noisy, so adding it to the verbose=1 level,
+        # since it's important to know.
+        spos = statbits.find("[status=")
+        if spos == -1:
+            v1(f"WARNING: no STATUS filter found in {infile} so unable to filter background for obsid {obsid}!")
+            return ""
 
-    epos = statbits.find("]", spos)
-    if epos == -1:
-        v1(f"WARNING: illegal STATUS filter found in {infile} so unable to filter background for obsid {obsid}!")
-        return ""
+        epos = statbits.find("]", spos)
+        if epos == -1:
+            v1(f"WARNING: illegal STATUS filter found in {infile} so unable to filter background for obsid {obsid}!")
+            return ""
 
-    statbits = statbits[spos:epos + 1]
+        statbits = statbits[spos:epos + 1]
+
+    else:
+        statbits = f"[status={statfilt}]"
+
     v1(f"Background filter (obsid {obsid}): {statbits}")
+
     return statbits
 
 


### PR DESCRIPTION
These updates to `fluximage.py` and `blanksky` addresses regression test failures when using Kenny's custom colorized CIAO 4.18, where the readability of `dmhistory` is improved with terminating each listed argument with a new line.

However, in doing so, these two files use some fragile functionality of parsing the output history to find filters used by some tools during upstream processing; additional parsing is done on the colorized formatting to match the standard formatting that can be used by the scripts.

Coincidentally, a helpdesk ticket, 26176, came in where the user was unable to run `fluximage` with particle background subtraction since the event file was reprocessed with `patch_hrc_ssc`.  This additional correction modified the ordering of the history in the event file causing the existing parsing approach to find the status filter to fail, but a further minor tweak to the introduced parsing modifications resolves this problem.  A less fragile approach to finding the HRC status filter is also introduced to `fluximage.py` so that the parsing approach is used as a fallback if the `STATFILT` keyword is not present in the event file (`chandra_repro` was updated in contrib 4.6.6 to write this keyword to HRC event files).