### PR TITLE
specextract 4.18.2

### DIFF
--- a/bin/specextract
+++ b/bin/specextract
@@ -33,7 +33,7 @@ Script:
 
 __version__ = "CIAO 4.18"
 __toolname__ = "specextract"
-__revision__ = "30 October 2025"
+__revision__ = "5 November 2025"
 
 ##########################################################################
 #
@@ -59,6 +59,7 @@ import paramio
 import caldb4
 import stk
 import region
+import cxcdm
 import pycrates as pcr
 
 import ciao_contrib._tools.specextract as spec
@@ -989,7 +990,53 @@ def group_spectrum(ptype, full_outroot, val, binspec, gtype,
 
 
 
-def edit_header(infile_cr: str|pcr.TABLECrate|pcr.IMAGECrate, key, val, **kwargs) -> None:
+# def edit_headers(verbose, infile, key, val, *args, **kwargs):
+#     """
+#     Update or add the infile header keyword with a specified value.
+#     """
+#
+#     unit = kwargs.get("unit",None) # optional argument
+#     comment = kwargs.get("comment",None)
+#
+#     if verbose == 2:
+#         verbose = 1
+#
+#     dmhedit = make_tool("dmhedit")
+#
+#     dmhedit.punlearn()
+#
+#     dmhedit.infile = infile
+#     dmhedit.filelist = "none"
+#     dmhedit.operation = "add"
+#     dmhedit.key = key
+#     dmhedit.value = str(val)
+#     dmhedit.verbose = verbose
+#
+#     if unit is not None:
+#         dmhedit.unit  = str(unit)
+#
+#     if comment is not None:
+#         dmhedit.comment = str(comment)
+#
+#     dmhedit()
+
+
+
+def _cxcdm_header_info(fn: str, blkno: int|None=None) -> tuple[cxcdm.dmDataset, cxcdm.dmBlock]:
+    dataset = cxcdm.dmDatasetOpen(fn, update=True)
+
+    if blkno is None or blkno < 1:
+        blkno = 2 # first interesting block number
+
+    blkname = cxcdm.dmDatasetGetBlockName(dataset, blkno)
+    blk = cxcdm.dmBlockOpen(blkname, dataset, update=True)
+
+    return dataset, blk
+
+
+
+def edit_header(fn_cr: str|pcr.TABLECrate|pcr.IMAGECrate, key, val,
+                blkno: int|None=None, crate: bool=False, **kwargs) -> None:
     """
     Update or add the infile header keyword with a specified value.
     If 'infile' is a string that points to a file, keywords directly
@@ -997,61 +1044,124 @@ def edit_header(infile_cr: str|pcr.TABLECrate|pcr.IMAGECrate, key, val, **kwargs
     which can then be saved later to a file.
     """
 
-    ## optional argument ##
-    unit = kwargs.get("unit", None)
-    comment = kwargs.get("comment", None)
+    if crate:
+        ## optional argument ##
+        unit = kwargs.get("unit", None)
+        comment = kwargs.get("comment", None)
 
-    crkw = pcr.CrateKey()
-    crkw.name = key
-    crkw.value = val
+        crkw = pcr.CrateKey()
+        crkw.name = key
+        crkw.value = val
 
-    if unit is not None:
-        crkw.unit  = unit
+        if unit is not None:
+            crkw.unit  = unit
 
-    if comment is not None:
-        crkw.desc = comment
+        if comment is not None:
+            crkw.desc = comment
 
-    match infile_cr:
-        case str() if os.path.isfile(infile_cr):
-            cr = pcr.read_dataset(infile_cr)
-            _cr = cr.get_crate(2) # first interesting block
-            _cr.add_key(crkw)
-            cr.write(infile_cr, clobber=True)
+        match fn_cr:
+            case str() if os.path.isfile(fn_cr):
+                cr = pcr.read_dataset(fn_cr)
+                blkno = cr.get_current_crate()
+                _cr = cr.get_crate(blkno) # first interesting block
+                _cr.add_key(crkw)
+                cr.write(fn_cr, clobber=True)
 
-        case pcr.TABLECrate() | pcr.IMAGECrate():
-            infile_cr.add_key(crkw)
+            case pcr.TABLECrate() | pcr.IMAGECrate():
+                fn_cr.add_key(crkw)
 
-        case _:
-            raise IOError("'edit_header' requires a file name string or data crate as input!")
+            case _:
+                raise IOError("'edit_header' requires a file name string or data crate as input!")
+
+    else:
+        ds,blk = _cxcdm_header_info(fn_cr, blkno)
+
+        if "comment" in kwargs:
+            kwargs["desc"] = kwargs.pop("comment")
+
+        try:
+            cxcdm.dmKeyWrite(blk, key, val, **kwargs)
+
+        except KeyError as exc:
+            raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
+keyword and 'val' value, with optional 'unit' and 'comment' dictionary items.") from exc
+
+        cxcdm.dmBlockClose(blk)
+        cxcdm.dmDatasetClose(ds)
 
 
 
-def edit_header_multi_keys(infile, kwdicts: tuple[dict]|list[dict], blkno: int|None=None) -> None:
+def edit_header_multi_keys(fn_cr: str|pcr.TABLECrate|pcr.IMAGECrate, kwdicts: tuple[dict]|list[dict],
+                           blkno: int|None=None, crate: bool=False) -> None:
     """
     Update or add header keywords to a file using a list or
     tuple of dictionaries.
     """
 
-    cr = pcr.read_dataset(infile)
+    if crate:
+        cr = pcr.read_dataset(fn_cr)
 
-    if blkno is None:
-        blkno = cr.get_current_crate() # first interesting block number
+        if blkno is None:
+            blkno = cr.get_current_crate() # first interesting block number
 
-    _cr = cr.get_crate(blkno)
+        _cr = cr.get_crate(blkno)
 
-    for _kwargs in kwdicts:
-        kwargs = _kwargs.copy()
+        for _kwargs in kwdicts:
+            kwargs = _kwargs.copy()
 
-        try:
-            key = kwargs.pop("key")
-            val = kwargs.pop("val")
-        except KeyError as exc:
-            raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
+            try:
+                key = kwargs.pop("key")
+                val = kwargs.pop("val")
+            except KeyError as exc:
+                raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
 keyword and 'val' value, with optional 'unit' and 'comment' dictionary items.") from exc
 
-        edit_header(_cr, key, val, **kwargs)
+            edit_header(_cr, key, val, crate=True, **kwargs)
 
-    cr.write(infile, clobber=True) # cr.write(cr.get_filename(), clobber=True)
+        cr.write(fn_cr, clobber=True) # cr.write(cr.get_filename(), clobber=True)
+
+    else:
+        ds,blk = _cxcdm_header_info(fn_cr, blkno)
+
+        for _kwargs in kwdicts:
+            kwargs = _kwargs.copy()
+
+            if "comment" in kwargs:
+                kwargs["desc"] = kwargs.pop("comment")
+
+            try:
+                key = kwargs.pop("key")
+                val = kwargs.pop("val")
+            except KeyError as exc:
+                raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
+keyword and 'val' value, with optional 'unit' and 'comment' dictionary items.") from exc
+
+            cxcdm.dmKeyWrite(blk, key, val, **kwargs)
+
+        cxcdm.dmBlockClose(blk)
+        cxcdm.dmDatasetClose(ds)
+
+
+
+# import timeit
+#
+# def _edit_header(*args, **kwargs):
+#     infile_cr, key, val = args
+#
+#     t = timeit.Timer(lambda: edit_header(infile_cr, key, val, **kwargs))
+#     try:
+#         _ = t.timeit(number=1)
+#         print(f"cxcdm write {key}={val}: {_} (s)")
+#     except:
+#         t.print_exc()
+
+# def _edit_header_multi_keys(infile, kwdicts, blkno=None):
+#     t = timeit.Timer(lambda: edit_header_multi_keys(infile,kwdicts,blkno))
+#     try:
+#         _ = t.timeit(number=1)
+#         print(f"cxcdm write multi-keys: {_} (s)")
+#     except:
+#         t.print_exc()
 
 
 

--- a/bin/specextract
+++ b/bin/specextract
@@ -31,9 +31,9 @@ Script:
 	command line, within the CIAO environment.
 """
 
-__version__ = "CIAO 4.17"
+__version__ = "CIAO 4.18"
 __toolname__ = "specextract"
-__revision__ = "4 September 2025"
+__revision__ = "30 October 2025"
 
 ##########################################################################
 #
@@ -47,6 +47,7 @@ __revision__ = "4 September 2025"
 # Load the necessary libraries.
 
 import os
+import resource
 import sys
 import shutil
 import tempfile
@@ -85,7 +86,8 @@ vprogress = spec._set_verbose_progressbar(sys.argv,toolname=__toolname__)
 
 
 def make_combined_outroot(outroot: str, label: str) -> str:
-    """create the outroot for combined data.
+    """
+    Create the outroot for combined data.
 
     Do we really need to send in label or can we assume
     it is always "src1"?
@@ -278,17 +280,21 @@ def readout_streak_spec(specfile,infile,src_x,src_y):
 
     del cr_ccd
 
-    streak_exposure = nframes * nrows * xfer_time
+    streak_exposure = f"{nframes * nrows * xfer_time:.12}"
 
     v1(f"The readout streak extraction region encompasses {nrows} pixel \
 rows of ACIS-{ccd_id[0]} with an effective exposure time of \
-{streak_exposure:.12} [s].")
+{streak_exposure} [s].")
 
-    edit_headers(0, specfile, "EXPOSURE", f"{streak_exposure:.12}", unit="s",
-                 comment="effective readout streak exposure time")
+    hdr_items = ( {"key" : "EXPOSURE",
+                   "val" : float(streak_exposure),
+                   "unit" : "s",
+                   "comment" : "effective readout streak exposure time"},
+                  {"key" : "NROW_STRK",
+                   "val" : nrows,
+                   "comment" : "number of ACIS rows from readout streak extraction"} )
 
-    edit_headers(0,specfile,"NROW_STRK",nrows,
-                 comment="number of ACIS rows from readout streak extraction")
+    edit_header_multi_keys(specfile, hdr_items)
 
 
 
@@ -691,11 +697,13 @@ reprocess the dataset or re-download the observation from the archive.")
     shutil.copyfile(rmf,rmffile)
 
     # establish detsubsys
-    if instrument == "HRC":
-        if chip_id == "0":
+    match instrument:
+        case "HRC" if chip_id == "0":
             detname = "HRC-I"
-        else:
+        case "HRC":
             detname = f"HRC-S{chip_id}"
+        case _:
+            raise RuntimeError(f"Function argument {instrument=}! This function should only be used with HRC data.")
 
     # determine matrix block name since it can either be "SPECRESP MATRIX" or "MATRIX"
     blnames = [bl[0].lower() for bl in get_info_from_file(f"{rmffile}[#row=0]")]
@@ -981,35 +989,69 @@ def group_spectrum(ptype, full_outroot, val, binspec, gtype,
 
 
 
-def edit_headers(verbose, infile, key, val, *args, **kwargs):
+def edit_header(infile_cr: str|pcr.TABLECrate|pcr.IMAGECrate, key, val, **kwargs) -> None:
     """
     Update or add the infile header keyword with a specified value.
+    If 'infile' is a string that points to a file, keywords directly
+    written, if it is a data Crate, the crate header is modified,
+    which can then be saved later to a file.
     """
 
-    unit = kwargs.get("unit",None) # optional argument
-    comment = kwargs.get("comment",None)
+    ## optional argument ##
+    unit = kwargs.get("unit", None)
+    comment = kwargs.get("comment", None)
 
-    if verbose == 2:
-        verbose = 1
-
-    dmhedit = make_tool("dmhedit")
-
-    dmhedit.punlearn()
-
-    dmhedit.infile = infile
-    dmhedit.filelist = "none"
-    dmhedit.operation = "add"
-    dmhedit.key = key
-    dmhedit.value = str(val)
-    dmhedit.verbose = verbose
+    crkw = pcr.CrateKey()
+    crkw.name = key
+    crkw.value = val
 
     if unit is not None:
-        dmhedit.unit  = str(unit)
+        crkw.unit  = unit
 
     if comment is not None:
-        dmhedit.comment = str(comment)
+        crkw.desc = comment
 
-    dmhedit()
+    match infile_cr:
+        case str() if os.path.isfile(infile_cr):
+            cr = pcr.read_dataset(infile_cr)
+            _cr = cr.get_crate(2) # first interesting block
+            _cr.add_key(crkw)
+            cr.write(infile_cr, clobber=True)
+
+        case pcr.TABLECrate() | pcr.IMAGECrate():
+            infile_cr.add_key(crkw)
+
+        case _:
+            raise IOError("'edit_header' requires a file name string or data crate as input!")
+
+
+
+def edit_header_multi_keys(infile, kwdicts: tuple[dict]|list[dict], blkno: int|None=None) -> None:
+    """
+    Update or add header keywords to a file using a list or
+    tuple of dictionaries.
+    """
+
+    cr = pcr.read_dataset(infile)
+
+    if blkno is None:
+        blkno = cr.get_current_crate() # first interesting block number
+
+    _cr = cr.get_crate(blkno)
+
+    for _kwargs in kwdicts:
+        kwargs = _kwargs.copy()
+
+        try:
+            key = kwargs.pop("key")
+            val = kwargs.pop("val")
+        except KeyError as exc:
+            raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
+keyword and 'val' value, with optional 'unit' and 'comment' dictionary items.") from exc
+
+        edit_header(_cr, key, val, **kwargs)
+
+    cr.write(infile, clobber=True) # cr.write(cr.get_filename(), clobber=True)
 
 
 
@@ -1115,23 +1157,11 @@ def build_acis_arf(args):
     iteminfostr = args["iteminfostr"]
 
     weight = args["weight"]
-
     tdetwmap = args["tdetwmap"]
 
-    try:
-        bpix = args["bpix"]
-    except KeyError:
-        bpix = None
-
-    try:
-        da = args["da"]
-    except KeyError:
-        da = None
-
-    try:
-        msk = args["msk"]
-    except KeyError:
-        msk = None
+    bpix = args.get("bpix")
+    da = args.get("da")
+    msk = args.get("msk")
 
     ###########################
     #
@@ -1218,10 +1248,7 @@ def build_acis_rmf(args):
     verbose = args["verbose"]
     iteminfostr = args["iteminfostr"]
 
-    try:
-        bpix = args["bpix"]
-    except KeyError:
-        bpix = None
+    bpix = args.get("bpix")
 
     tdetwmap = args["tdetwmap"]
     feffile = args["feffile"]
@@ -1244,23 +1271,19 @@ def build_acis_rmf(args):
         try:
             if any([srcbkg == "src", srcbkg == "bkg" and dobkgresp]):
                 if all([weight == "yes",weight_rmf == "yes"]):
-                    respfile = build_rmf_ext(rmftool,ptype,full_outroot,
-                                             ebin,rmfbin,clobber,verbose,
-                                             phafile,weightfile,wmap_clip,
-                                             tdetwmap, infostr)
+                    return build_rmf_ext(rmftool,ptype,full_outroot,
+                                         ebin,rmfbin,clobber,verbose,
+                                         phafile,weightfile,wmap_clip,
+                                         tdetwmap, infostr)
 
-                else:
-                    respfile = build_rmf_ps(rmftool,filename,ptype,full_outroot,
-                                            ebin,rmfbin,clobber,verbose,phafile,feffile,
-                                            ccd_id,chipx,chipy,infostr)
+                return build_rmf_ps(rmftool,filename,ptype,full_outroot,
+                                    ebin,rmfbin,clobber,verbose,phafile,feffile,
+                                    ccd_id,chipx,chipy,infostr)
+
+            return None # `if srcbkg == "bkg" and not dobkgresp`
 
         except Exception as exc:
             raise IOError(f"Failed to create RMF for {fullfile}") from exc
-
-    if srcbkg == "bkg" and not dobkgresp:
-        return None
-
-    return respfile
 
 
 
@@ -1300,20 +1323,12 @@ def spectra(args):
 
     outreg = args["outreg"]
 
-    try:
-        bpix = args["bpix"]
-    except KeyError:
-        bpix = None
+    bpix = args.get("bpix")
 
-    try:
-        nrao_nh = args["nrao_nh"]
-    except KeyError:
-        nrao_nh = None
+    nrao_nh = args.get("nrao_nh")
+    bell_nh = args.get("bell_nh")
 
-    try:
-        bell_nh = args["bell_nh"]
-    except KeyError:
-        bell_nh = None
+    pardict = {}
 
     with new_pfiles_environment(ardlib=True,copyuser=False):
         ###################################
@@ -1343,13 +1358,13 @@ for this file, which is required input for this step.\n")
 
                     correct = "no"
 
-                    pardict = {key_id : {"correct" : correct}}
+                    pardict[key_id] = {"correct" : correct}
 
                 else:
                     v3(f"Converting source region to physical coordinates {iteminfostr}")
 
                     fullfile = convert_region(fullfile,filename,outreg,True,verbose)
-                    pardict = {key_id : {"fullfile" : fullfile}}
+                    pardict[key_id] = {"fullfile" : fullfile}
 
         ###########################
         #
@@ -1391,23 +1406,23 @@ parameter of dmextract will be set to use DET coordinates instead.\n")
 
         try:
             pardict[key_id].update({"phafile" : phafile})
-        except NameError:
-            pardict = {key_id : {"phafile" : phafile}}
+        except (KeyError,NameError):
+            pardict[key_id] = {"phafile" : phafile}
 
         ## add nH values to phafile header ##
         if nrao_nh is not None:
             # Galactic neutral hydrogen column density at the source position using
             # the NRAO all-sky interpolation, via COLDEN.
 
-            edit_headers(verbose,phafile,"NRAO_nH",float(f"{nrao_nh:.6}"),unit="10**22 cm**-2",
-                         comment="galactic HI column density")
+            edit_header(phafile, "NRAO_nH", float(f"{nrao_nh:.6}"), unit="10**22 cm**-2",
+                        comment="galactic HI column density")
 
         if bell_nh is not None:
             # Galactic neutral hydrogen column density at the source position using
             # the Bell Labs survey, via COLDEN.
 
-            edit_headers(verbose,phafile,"Bell_nH",float(f"{bell_nh:.6}"),unit="10**22 cm**-2",
-                         comment="galactic HI column density")
+            edit_header(phafile, "Bell_nH", float(f"{bell_nh:.6}"), unit="10**22 cm**-2",
+                        comment="galactic HI column density")
 
 
         ############################################################
@@ -1443,8 +1458,8 @@ parameter of dmextract will be set to use DET coordinates instead.\n")
 
                 bkgscale = fileio.get_keys_from_file(fullfile)[f"BKGSCAL{ccdid}"]
 
-                edit_headers(verbose, phafile, "AREASCAL", 1/bkgscale,
-                             comment=f"1/BKGSCAL{ccdid} using the 'blanksky' scaling factor") #, set to 1.0 if subtracting background")
+                edit_header(phafile, "AREASCAL", 1/bkgscale,
+                            comment=f"1/BKGSCAL{ccdid} using the 'blanksky' scaling factor") #, set to 1.0 if subtracting background")
 
                 v1(f"{phafile} AREASCAL keyword set to the inverse of \
 the 'blanksky' BKGSCAL{ccdid} value for automated background spectrum \
@@ -1479,15 +1494,8 @@ def _resps_preprocess_wrapper(args_dict):
         asphist = args_dict["asphist"]
         asolstat = False
 
-    try:
-        bpix = args_dict["bpix"]
-    except KeyError:
-        bpix = None
-
-    try:
-        dtf = args_dict["dtf"]
-    except KeyError:
-        dtf = None
+    bpix = args_dict.get("bpix")
+    dtf = args_dict.get("dtf")
 
     kdict = {}
 
@@ -1560,11 +1568,7 @@ def _build_resps(args):
     verbose = args["verbose"]
     iteminfostr = args["iteminfostr"]
 
-    try:
-        bpix = args["bpix"]
-
-    except KeyError:
-        bpix = None
+    bpix = args.get("bpix")
 
     # try:
     #     dtf = args["dtf"]
@@ -1644,11 +1648,12 @@ def _build_resps(args):
                         raise IOError(f"Failed to create RMF for {fullfile}") from exc
 
             else:
-                if mkresp == "ARF":
-                    ancrfile = build_acis_arf(args)
+                match mkresp:
+                    case "ARF":
+                        ancrfile = build_acis_arf(args)
 
-                if mkresp == "RMF":
-                    respfile = build_acis_rmf(args)
+                    case "RMF":
+                        respfile = build_acis_rmf(args)
 
         else:
             ##########################################
@@ -1683,11 +1688,12 @@ def _build_resps(args):
     if srcbkg == "bkg" and not dobkgresp:
         return None
 
-    if mkresp == "ARF":
-        return {key_id : {"ARF" : ancrfile}}
+    match mkresp:
+        case "ARF":
+            return {key_id : {"ARF" : ancrfile}}
 
-    if mkresp == "RMF":
-        return {key_id : {"RMF" : respfile}}
+        case "RMF":
+            return {key_id : {"RMF" : respfile}}
 
     assert mkresp == "ARF+RMF", f"Unknown 'mkresp={mkresp}'"
 
@@ -1779,45 +1785,28 @@ def groupspec(args):
     phafile = args["phafile"]
     ptype = args["ptype"]
 
-    try:
-        gtype = args["gtype"]
-    except KeyError:
-        gtype = None
-    try:
-        gval = args["gval"]
-    except KeyError:
-        gval = None
-    try:
-        binspec = args["binspec"]
-    except KeyError:
-        binspec = None
+    gtype = args.get("gtype")
+    gval = args.get("gval")
+    binspec = args.get("binspec")
 
-    try:
-        bggtype = args["bggtype"]
-    except KeyError:
-        bggtype = None
-    try:
-        bggval = args["bggval"]
-    except KeyError:
-        bggval = None
-    try:
-        bgbinspec = args["bgbinspec"]
-    except KeyError:
-        bgbinspec = None
+    bggtype = args.get("bggtype")
+    bggval = args.get("bggval")
+    bgbinspec = args.get("bgbinspec")
 
     try:
         v3(f"Grouping {srcbkg} spectrum {iteminfostr}")
         grpfile = None
 
-        if all([srcbkg == "src", dogroup]):
-            grpfile = group_spectrum(ptype,full_outroot,
-                                     gval,binspec,gtype,
-                                     clobber,verbose,phafile)
+        match srcbkg:
+            case "src" if dogroup:
+                grpfile = group_spectrum(ptype,full_outroot,
+                                        gval,binspec,gtype,
+                                        clobber,verbose,phafile)
 
-        if all([srcbkg == "bkg", bgdogroup]):
-            grpfile = group_spectrum(ptype,full_outroot,
-                                     bggval,bgbinspec,bggtype,
-                                     clobber,verbose,phafile)
+            case "bkg" if bgdogroup:
+                grpfile = group_spectrum(ptype,full_outroot,
+                                         bggval,bgbinspec,bggtype,
+                                         clobber,verbose,phafile)
 
     except OSError as exc:
         raise IOError(f"Failed to group spectrum for {phafile}") from exc
@@ -1829,13 +1818,17 @@ def groupspec(args):
 def add_history_scriptver(fn,toolname,params,toolversion,modname,modversion):
     add_tool_history(fn, toolname, params, toolversion=toolversion)
 
+    hdr_items = [ {"key" : "SCRPTVER",
+                   "val" : f"{toolname} - {toolversion}"},
+                  {"key" : "SCRPTMOD",
+                   "val" : f"{modname} - {modversion}"} ]
+
     if isinstance(fn,str):
-        edit_headers(0, fn, "SCRPTVER", f"{toolname} - {toolversion}")
-        edit_headers(0, fn, "SCRPTMOD", f"{modname} - {modversion}")
+        edit_header_multi_keys(fn, hdr_items)
+
     else:
         for f in fn:
-            edit_headers(0, f, "SCRPTVER", f"{toolname} - {toolversion}")
-            edit_headers(0, f, "SCRPTMOD", f"{modname} - {modversion}")
+            edit_header_multi_keys(f, hdr_items)
 
 
 
@@ -1854,26 +1847,13 @@ def add_header_keys(args):
     dogroup = args["dogroup"]
     bgdogroup = args["bgdogroup"]
 
-    verbose = args["verbose"]
-
     pars = args["pars_specextract"]
 
     bkgresp = pars["bkgresp"]
 
-    try:
-        ancrfile = args["ARF"]
-    except KeyError:
-        ancrfile = None
-
-    try:
-        respfile = args["RMF"]
-    except KeyError:
-        respfile = None
-
-    try:
-        grpfile = args["grpfile"]
-    except KeyError:
-        grpfile = None
+    ancrfile = args.get("ARF")
+    respfile = args.get("RMF")
+    grpfile = args.get("grpfile")
 
     ####################################
     #
@@ -1891,22 +1871,29 @@ def add_header_keys(args):
                     respfile = args["specdicts"][key_id.replace("bkg","src")]["RMF"]
                     ancrfile = args["specdicts"][key_id.replace("bkg","src")]["ARF"]
 
-                    edit_headers(verbose, fn, "RESPFILE", os.path.basename(respfile))
-                    edit_headers(verbose, fn, "ANCRFILE", os.path.basename(ancrfile))
+                    hdr_items = ( {"key" : "RESPFILE",
+                                   "val" : os.path.basename(respfile)},
+                                  {"key" : "ANCRFILE",
+                                   "val" : os.path.basename(ancrfile)} )
+
+                    edit_header_multi_keys(fn, hdr_items)
 
             else:
                 v2(f"Updating header of {fn} with RESPFILE and ANCRFILE keywords.\n")
 
-                edit_headers(verbose, fn, "RESPFILE", os.path.basename(respfile))
-                edit_headers(verbose, fn, "ANCRFILE", os.path.basename(ancrfile))
+                hdr_items = [ {"key" : "RESPFILE",
+                               "val" : os.path.basename(respfile)},
+                              {"key" : "ANCRFILE",
+                               "val" : os.path.basename(ancrfile)} ]
+
+                edit_header_multi_keys(fn, hdr_items)
 
                 # If the source or background spectrum was grouped, add the respfile
                 # and ancrfile keys there, too.
                 if all([srcbkg == "src", dogroup]) or all([srcbkg == "bkg", bgdogroup]):
                     v2(f"Updating header of {grpfile} with RESPFILE and ANCRFILE keywords.\n")
 
-                    edit_headers(verbose, grpfile, "RESPFILE", os.path.basename(respfile))
-                    edit_headers(verbose, grpfile, "ANCRFILE", os.path.basename(ancrfile))
+                    edit_header_multi_keys(grpfile, hdr_items)
 
         except Exception as exc:
             print(exc)
@@ -1921,7 +1908,7 @@ def add_header_keys(args):
                 backpha = args["specdicts"][key_id.replace("src","bkg")]["phafile"]
 
                 v2(f"Updating header of {fn} with BACKFILE keyword.\n")
-                edit_headers(verbose, fn, "BACKFILE", os.path.basename(backpha))
+                edit_header(fn, "BACKFILE", os.path.basename(backpha))
 
                 # If the source spectrum was grouped, add the
                 # backfile key to the grouped source spectrum.
@@ -1936,7 +1923,7 @@ def add_header_keys(args):
                         backpha = args["specdicts"][key_id.replace("src","bkg")]["grpfile"]
 
                     v2(f"Updating header of {grpfile} with BACKFILE keyword.\n")
-                    edit_headers(verbose, grpfile, "BACKFILE", os.path.basename(backpha))
+                    edit_header(grpfile, "BACKFILE", os.path.basename(backpha))
 
         except Exception as exc:
             print(exc)
@@ -2180,7 +2167,7 @@ def get_par(args):
         if out_root.endswith("/"):
             raise ValueError("outroot path must include a file root name and cannot be just a directory.")
 
-        outdir,outhead = utils.split_outroot(out_root)
+        outdir,_outhead = utils.split_outroot(out_root)
 
         if outdir != "":
             fileio.validate_outdir(outdir)
@@ -2228,6 +2215,32 @@ def update_param_args_and_dict(dict_update,dict_orig,args_list,cmd_pars_history)
                 for key in dict_orig.keys()]
 
     return args_list
+
+
+
+def _check_open_file_limits(nfiles: int, Ntemp: int = 4, Npad: int = 20) -> None:
+    """
+    Check number of open files the working shell supports; opening too many
+    temporary files exceeding the suported value will throw an OSError.
+
+    This would be the equivalent of using:
+
+    bash:
+    'ulimit -n' and 'ulimit -Sn <softlim>'
+
+    csh:
+    'limit descriptors' and 'limit descriptors <softlim>'
+
+    from within Python.
+    """
+
+    open_file_lim = resource.RLIMIT_NOFILE
+    softlim, hardlim = resource.getrlimit(open_file_lim)
+
+    N_open_file = Ntemp * nfiles + Npad
+
+    if softlim < N_open_file:
+        resource.setrlimit(open_file_lim, (N_open_file, hardlim))
 
 
 
@@ -2329,6 +2342,8 @@ cannot contain any spaces")
             def parallelize(func,args,numcores=nproc,progress=None,prefix=None):
                 return [func(arg) for arg in args]
 
+    ## check open file limits on the system ##
+    _check_open_file_limits(len(specextract_args))
 
     ###########################
     #
@@ -2346,7 +2361,6 @@ cannot contain any spaces")
 
     # update parameters dictionary if necessary, and the list passed to parallelization
     specextract_args = update_param_args_and_dict(pardict_update_spectra,specdicts,specextract_args,pars)
-
 
     ###########################
     #
@@ -2377,10 +2391,12 @@ cannot contain any spaces")
     #
     ###########################
 
-    dobg = specdicts["src1"]["dobg"]
-    dobkgresp = specdicts["src1"]["dobkgresp"]
-    dogroup = specdicts["src1"]["dogroup"]
-    bgdogroup = specdicts["src1"]["bgdogroup"]
+    _srcno,_specdict = next(iter(specdicts.items()))
+
+    dobg = _specdict["dobg"]
+    dobkgresp = _specdict["dobkgresp"]
+    dogroup = _specdict["dogroup"]
+    bgdogroup = _specdict["bgdogroup"]
 
     sdvals = specdicts.values()
 
@@ -2460,7 +2476,7 @@ cannot contain any spaces")
     ###########################
 
     if combine == "yes":
-        combine_outroot = make_combined_outroot(specdicts["src1"]["full_outroot"],"src1")
+        combine_outroot = make_combined_outroot(_specdict["full_outroot"],_srcno)
 
         coadd(combine_outroot,
               src_spec,bkg_spec,

--- a/bin/specextract
+++ b/bin/specextract
@@ -33,7 +33,7 @@ Script:
 
 __version__ = "CIAO 4.18"
 __toolname__ = "specextract"
-__revision__ = "5 November 2025"
+__revision__ = "21 May 2026"
 
 ##########################################################################
 #
@@ -47,7 +47,6 @@ __revision__ = "5 November 2025"
 # Load the necessary libraries.
 
 import os
-import resource
 import sys
 import shutil
 import tempfile
@@ -63,7 +62,7 @@ import cxcdm
 import pycrates as pcr
 
 import ciao_contrib._tools.specextract as spec
-from ciao_contrib._tools import fileio, utils
+from ciao_contrib._tools import fileio, utils, merging
 from ciao_contrib.param_wrapper import open_param_file
 from ciao_contrib.cxcdm_wrapper import get_info_from_file
 from ciao_contrib.runtool import make_tool, new_pfiles_environment, add_tool_history
@@ -1035,6 +1034,12 @@ def _cxcdm_header_info(fn: str, blkno: int|None=None) -> tuple[cxcdm.dmDataset, 
 
 
 
+def _cxcdm_header_close(ds: cxcdm.dmDataset, blk: cxcdm.dmBlock) -> None:
+    cxcdm.dmBlockClose(blk)
+    cxcdm.dmDatasetClose(ds)
+
+
+
 def edit_header(fn_cr: str|pcr.TABLECrate|pcr.IMAGECrate, key, val,
                 blkno: int|None=None, crate: bool=False, **kwargs) -> None:
     """
@@ -1065,29 +1070,28 @@ def edit_header(fn_cr: str|pcr.TABLECrate|pcr.IMAGECrate, key, val,
                 blkno = cr.get_current_crate()
                 _cr = cr.get_crate(blkno) # first interesting block
                 _cr.add_key(crkw)
-                cr.write(fn_cr, clobber=True)
+                return cr.write(fn_cr, clobber=True)
 
             case pcr.TABLECrate() | pcr.IMAGECrate():
-                fn_cr.add_key(crkw)
+                return fn_cr.add_key(crkw)
 
             case _:
                 raise IOError("'edit_header' requires a file name string or data crate as input!")
 
-    else:
-        ds,blk = _cxcdm_header_info(fn_cr, blkno)
+    # use cxcdm to write header keyword
+    ds,blk = _cxcdm_header_info(fn_cr, blkno)
 
-        if "comment" in kwargs:
-            kwargs["desc"] = kwargs.pop("comment")
+    if "comment" in kwargs:
+        kwargs["desc"] = kwargs.pop("comment")
 
-        try:
-            cxcdm.dmKeyWrite(blk, key, val, **kwargs)
+    try:
+        cxcdm.dmKeyWrite(blk, key, val, **kwargs)
 
-        except KeyError as exc:
-            raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
+    except KeyError as exc:
+        raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
 keyword and 'val' value, with optional 'unit' and 'comment' dictionary items.") from exc
 
-        cxcdm.dmBlockClose(blk)
-        cxcdm.dmDatasetClose(ds)
+    return _cxcdm_header_close(ds, blk)
 
 
 
@@ -1118,28 +1122,27 @@ keyword and 'val' value, with optional 'unit' and 'comment' dictionary items.") 
 
             edit_header(_cr, key, val, crate=True, **kwargs)
 
-        cr.write(fn_cr, clobber=True) # cr.write(cr.get_filename(), clobber=True)
+        return cr.write(fn_cr, clobber=True) # cr.write(cr.get_filename(), clobber=True)
 
-    else:
-        ds,blk = _cxcdm_header_info(fn_cr, blkno)
+    # use cxcdm to write header keywords
+    ds,blk = _cxcdm_header_info(fn_cr, blkno)
 
-        for _kwargs in kwdicts:
-            kwargs = _kwargs.copy()
+    for _kwargs in kwdicts:
+        kwargs = _kwargs.copy()
 
-            if "comment" in kwargs:
-                kwargs["desc"] = kwargs.pop("comment")
+        if "comment" in kwargs:
+            kwargs["desc"] = kwargs.pop("comment")
 
-            try:
-                key = kwargs.pop("key")
-                val = kwargs.pop("val")
-            except KeyError as exc:
-                raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
+        try:
+            key = kwargs.pop("key")
+            val = kwargs.pop("val")
+        except KeyError as exc:
+            raise RuntimeError(f"{exc}\nRequired: list or tuple of dictionaries with 'key' \
 keyword and 'val' value, with optional 'unit' and 'comment' dictionary items.") from exc
 
-            cxcdm.dmKeyWrite(blk, key, val, **kwargs)
+        cxcdm.dmKeyWrite(blk, key, val, **kwargs)
 
-        cxcdm.dmBlockClose(blk)
-        cxcdm.dmDatasetClose(ds)
+    return _cxcdm_header_close(ds, blk)
 
 
 
@@ -1184,6 +1187,7 @@ def resp_setup(args,asphist,rmftool):
     ccd_id = args["chip_id"]
     chipx = args["chipx"]
     chipy = args["chipy"]
+    resp_pos = args["resp_pos"]
 
     tmpdir = args["tmpdir"]
     verbose = args["verbose"]
@@ -1193,32 +1197,61 @@ def resp_setup(args,asphist,rmftool):
     with new_pfiles_environment(ardlib=False,copyuser=False):
         acis_fef_lookup = make_tool("acis_fef_lookup")
         sky2tdet = make_tool("sky2tdet")
+        dmimgfilt = make_tool("dmimgfilt")
+
+        if verbose == 2:
+            verbose = 1
 
         if all([srcbkg == "src", weight == "yes"]) or all([srcbkg == "bkg", dobkgresp]):
-            try:
-                if verbose == 2:
-                    verbose = 1
+            if resp_pos.upper() == "REGION" and args.get("zero_counts"):
+                # c.f. cxcsds/ciao-contrib/issues/1005:
+                #
+                # Without any counts, for weighted responses we do not know how to
+                # weight individual pixels, so all pixels should have the same,
+                # non-zero weight. One option is create a unit image (i.e. pixel
+                # values of 1s) that respect the image subspace, so pixels outside
+                # the region are 0/NaN/Null-values.
+                #
+                # There are a couple ways to do this but dmimgfilt can be used in
+                # a single-shot, which will create an image bound the extraction
+                # region.  Pixels outside the region will be NaN and pixels inside
+                # will have the number of pixels encompassed by the point mask,
+                # which will be 1.
 
-                sky2tdet.punlearn()
+                dmimgfilt.punlearn()
 
-                sky2tdet.infile = f"{infile}[energy={ewmap_param}][bin sky]" # include extraction region
-                                                                             # plus same energy filter
+                dmimgfilt.infile = infile
+                dmimgfilt.outfile = f"{tdetwmap}[wmap]"
+                dmimgfilt.function = "count"
+                dmimgfilt.mask = "point(0,0)"
+                dmimgfilt.clobber = True
+                dmimgfilt.verbose = verbose
 
-                # used for dmextract wmap input to mkacisrmf
-                sky2tdet.bin = bintwmap_param
-                sky2tdet.asphistfile = asp_param
-                sky2tdet.outfile = f"{tdetwmap}[wmap]"
-                sky2tdet.clobber = True
-                sky2tdet.verbose = verbose
+                dmimgfilt()
 
-                sky2tdet()
+            else:
+                try:
+                    sky2tdet.punlearn()
 
-                # generate clipped WMAP to speed up response generation
-                if wmap_clip:
-                    clip_wmap(tdetwmap,wmap_thresh,tmpdir)
+                    sky2tdet.infile = f"{infile}[energy={ewmap_param}][bin sky]" # include extraction region
+                                                                                 # plus same energy filter
 
-            except OSError as exc:
-                raise IOError("Error generating WMAP w/sky2tdet!") from exc
+                    # used for dmextract wmap input to mkacisrmf
+                    sky2tdet.bin = bintwmap_param
+                    sky2tdet.asphistfile = asp_param
+                    sky2tdet.outfile = f"{tdetwmap}[wmap]"
+                    sky2tdet.clobber = True
+                    sky2tdet.verbose = verbose
+
+                    sky2tdet()
+
+                    # generate clipped WMAP to speed up response generation
+                    if wmap_clip:
+                        clip_wmap(tdetwmap,wmap_thresh,tmpdir)
+
+                except OSError as exc:
+                    raise IOError("Error generating WMAP w/sky2tdet!") from exc
+
         else:
             tdetwmap = None
 
@@ -2328,32 +2361,6 @@ def update_param_args_and_dict(dict_update,dict_orig,args_list,cmd_pars_history)
 
 
 
-def _check_open_file_limits(nfiles: int, Ntemp: int = 4, Npad: int = 20) -> None:
-    """
-    Check number of open files the working shell supports; opening too many
-    temporary files exceeding the suported value will throw an OSError.
-
-    This would be the equivalent of using:
-
-    bash:
-    'ulimit -n' and 'ulimit -Sn <softlim>'
-
-    csh:
-    'limit descriptors' and 'limit descriptors <softlim>'
-
-    from within Python.
-    """
-
-    open_file_lim = resource.RLIMIT_NOFILE
-    softlim, hardlim = resource.getrlimit(open_file_lim)
-
-    N_open_file = Ntemp * nfiles + Npad
-
-    if softlim < N_open_file:
-        resource.setrlimit(open_file_lim, (N_open_file, hardlim))
-
-
-
 #######################################################################
 #######################################################################
 #####
@@ -2453,7 +2460,7 @@ cannot contain any spaces")
                 return [func(arg) for arg in args]
 
     ## check open file limits on the system ##
-    _check_open_file_limits(len(specextract_args))
+    merging._check_open_file_limits(len(specextract_args))
 
     ###########################
     #

--- a/bin/specextract
+++ b/bin/specextract
@@ -33,7 +33,7 @@ Script:
 
 __version__ = "CIAO 4.18"
 __toolname__ = "specextract"
-__revision__ = "4 June 2026"
+__revision__ = "8 June 2026"
 
 ##########################################################################
 #
@@ -336,7 +336,7 @@ def create_arf_ps(full_outroot, evt_filename, asp_param, ebin,
     mkarf.asphistfile = asp_param
     mkarf.sourcepixelx = skyx
     mkarf.sourcepixely = skyy
-    mkarf.grating = fileio.get_keys_from_file(evt_filename)["GRATING"]
+    mkarf.grating = fileio.get_keys_from_file(f"{evt_filename}[#row=0]")["GRATING"]
     mkarf.obsfile = evt_filename
     mkarf.dafile = dafile
     mkarf.maskfile = mskfile
@@ -393,6 +393,9 @@ def create_arf_ext(full_outroot, ebin, verbose, dafile, mskfile,
             mkwarf.infile = f"{tdetwmap}[wmap]"
 
         mkwarf()
+
+        ## the FEFFILE keyword unnecessarily provides an absolute path ##
+        edit_header(arffile, "FEFFILE", os.path.basename(fileio.get_keys_from_file(f"{arffile}[#row=0]")["FEFFILE"]))
 
     except Exception as exc:
         raise IOError(f"Failure to create weighted ARF.  Possible causes \
@@ -612,7 +615,7 @@ def build_rmf_ps(rmftool, evt_filename, ptype, full_outroot,
 
 
 def build_rmf_ext(rmftool, ptype, full_outroot, ebin, rmfbin, clobber, verbose,
-                  specfile, weightfile, wmap_clip, wmap_sky2tdet, infostr):
+                  specfile, weightfile, wmap_clip, wmap_sky2tdet, infostr, force_tdetwmap : bool=False):
     """
     Run either mkrmf or mkacisrmf depending on input conditions.
     For mkrmf: input CALDB and weight file and return RMF name.
@@ -646,9 +649,14 @@ def build_rmf_ext(rmftool, ptype, full_outroot, ebin, rmfbin, clobber, verbose,
             # ## (since ACIS RMF originally calibrated by splitting each CCD into 32x32 sections)
             # mkacisrmf.wmap = f"{specfile}[WMAP]"
 
+            if force_tdetwmap:
+                detwmap = wmap_sky2tdet
+            else:
+                detwmap = f"{specfile}[WMAP]"
+
             run_mkacisrmf(infile="CALDB",outfile=rmffile,
                           energy=ebin,channel=channel[0],chantype=ptype.upper(),
-                          obsfile="",wmap=f"{specfile}[WMAP]",
+                          obsfile="",wmap=detwmap,
                           clobber=clobber,verbose=verbose)
 
         return rmffile
@@ -731,7 +739,7 @@ reprocess the dataset or re-download the observation from the archive.")
         mkarf.asphistfile = asp_param
         mkarf.sourcepixelx = skyx
         mkarf.sourcepixely = skyy
-        mkarf.grating = fileio.get_keys_from_file(specfile)["GRATING"]
+        mkarf.grating = fileio.get_keys_from_file(f"{specfile}[#row=0]")["GRATING"]
         mkarf.obsfile = specfile
         mkarf.maskfile = mskfile
         mkarf.verbose = verbose
@@ -777,7 +785,7 @@ def set_badpix(evtfile, bpixfile, instrument, verbose, dobpix):
                 raise IOError(f"Failed to set {bpixfile} bad pixel file in ardlib.par for {evtfile}.") from exc
 
         else:
-            detnam = fileio.get_keys_from_file(evtfile)["DETNAM"].replace("-","_")
+            detnam = fileio.get_keys_from_file(f"{evtfile}[#row=0]")["DETNAM"].replace("-","_")
             bpixpar = f"AXAF_{detnam}_BADPIX_FILE"
             bpix = f"{bpixfile}[BADPIX]"
 
@@ -1193,6 +1201,7 @@ def resp_setup(args,asphist,rmftool):
     verbose = args["verbose"]
 
     tdetwmap = args["tdetwmap"]
+    zero_counts = args.get("zero_counts")
 
     with new_pfiles_environment(ardlib=False,copyuser=False):
         acis_fef_lookup = make_tool("acis_fef_lookup")
@@ -1203,57 +1212,70 @@ def resp_setup(args,asphist,rmftool):
             verbose = 1
 
         if all([srcbkg == "src", weight == "yes"]) or all([srcbkg == "bkg", dobkgresp]):
-            if resp_pos.upper() == "REGION" and args.get("zero_counts"):
-                # c.f. cxcsds/ciao-contrib/issues/1005:
-                #
-                # Without any counts, for weighted responses we do not know how to
-                # weight individual pixels, so all pixels should have the same,
-                # non-zero weight. One option is create a unit image (i.e. pixel
-                # values of 1s) that respect the image subspace, so pixels outside
-                # the region are 0/NaN/Null-values.
-                #
-                # There are a couple ways to do this but dmimgfilt can be used in
-                # a single-shot, which will create an image bound the extraction
-                # region.  Pixels outside the region will be NaN and pixels inside
-                # will have the number of pixels encompassed by the point mask,
-                # which will be 1.
+            try:
+                sky2tdet.punlearn()
 
-                dmimgfilt.punlearn()
+                sky2tdet.bin = bintwmap_param
+                sky2tdet.asphistfile = asp_param
+                sky2tdet.outfile = f"{tdetwmap}[wmap]"
+                sky2tdet.clobber = True
+                sky2tdet.verbose = verbose
 
-                dmimgfilt.infile = infile
-                dmimgfilt.outfile = f"{tdetwmap}[wmap]"
-                dmimgfilt.function = "count"
-                dmimgfilt.mask = "point(0,0)"
-                dmimgfilt.clobber = True
-                dmimgfilt.verbose = verbose
+                if resp_pos.upper() == "REGION" and zero_counts:
+                    # c.f. cxcsds/ciao-contrib/issues/1005:
+                    #
+                    # Without any counts, for weighted responses we do not know how to
+                    # weigh individual pixels, so all pixels should have the same,
+                    # non-zero weight. One option is create a unit image (i.e. pixel
+                    # values of 1s) that respect the image subspace, so pixels outside
+                    # the region are 0/NaN/Null-values.
+                    #
+                    # There are a couple ways to do this but dmimgfilt can be used in
+                    # a single-shot, which will create an image bound the extraction
+                    # region.  Pixels outside the region will be NaN and pixels inside
+                    # will have the number of pixels encompassed by the point mask,
+                    # which will be 1.
 
-                dmimgfilt()
+                    v1(f"There are zero counts available to create a weights map to generate \
+weighted responses for the extraction region {infile}.  Since 'resp_pos=REGION', proceeding by \
+assuming a uniformly weighted extraction region...")
 
-            else:
-                try:
-                    sky2tdet.punlearn()
+                    with tempfile.NamedTemporaryFile(suffix=".wmsk",dir=tmpdir) as weightmask:
+                        dmimgfilt.punlearn()
 
+                        dmimgfilt.infile = infile
+                        dmimgfilt.outfile = weightmask.name
+                        dmimgfilt.function = "count"
+                        dmimgfilt.mask = "point(0,0)"
+                        dmimgfilt.clobber = True
+                        dmimgfilt.verbose = verbose
+
+                        dmimgfilt()
+
+                        sky2tdet.infile = weightmask.name
+                        sky2tdet()
+
+                        zero_counts_tdetwmap = True
+
+                else:
                     sky2tdet.infile = f"{infile}[energy={ewmap_param}][bin sky]" # include extraction region
                                                                                  # plus same energy filter
-
-                    # used for dmextract wmap input to mkacisrmf
-                    sky2tdet.bin = bintwmap_param
-                    sky2tdet.asphistfile = asp_param
-                    sky2tdet.outfile = f"{tdetwmap}[wmap]"
-                    sky2tdet.clobber = True
-                    sky2tdet.verbose = verbose
-
+                                                                                 # used for dmextract wmap
+                                                                                 # input to mkacisrmf
                     sky2tdet()
 
-                    # generate clipped WMAP to speed up response generation
-                    if wmap_clip:
-                        clip_wmap(tdetwmap,wmap_thresh,tmpdir)
+                    zero_counts_tdetwmap = False
 
-                except OSError as exc:
-                    raise IOError("Error generating WMAP w/sky2tdet!") from exc
+                # generate clipped WMAP to speed up response generation
+                if wmap_clip:
+                    clip_wmap(tdetwmap,wmap_thresh,tmpdir)
+
+            except OSError as exc:
+                raise IOError("Error generating WMAP w/sky2tdet!") from exc
 
         else:
             tdetwmap = None
+            zero_counts_tdetwmap = True
 
         if all([weight_rmf == "no",rmftool == "mkrmf"]) and any([srcbkg == "src", srcbkg == "bkg" and dobkgresp]):
             acis_fef_lookup.punlearn()
@@ -1270,7 +1292,7 @@ def resp_setup(args,asphist,rmftool):
         else:
             feffile = None
 
-    return tdetwmap, feffile
+    return tdetwmap, feffile, zero_counts_tdetwmap
 
 
 
@@ -1396,6 +1418,7 @@ def build_acis_rmf(args):
     tdetwmap = args["tdetwmap"]
     feffile = args["feffile"]
     weightfile = None
+    force_tdetwmap = args.get("zero_counts_tdetwmap")
 
     ###########################
     #
@@ -1417,7 +1440,7 @@ def build_acis_rmf(args):
                     return build_rmf_ext(rmftool,ptype,full_outroot,
                                          ebin,rmfbin,clobber,verbose,
                                          phafile,weightfile,wmap_clip,
-                                         tdetwmap, infostr)
+                                         tdetwmap,infostr,force_tdetwmap)
 
                 return build_rmf_ps(rmftool,filename,ptype,full_outroot,
                                     ebin,rmfbin,clobber,verbose,phafile,feffile,
@@ -1599,7 +1622,7 @@ parameter of dmextract will be set to use DET coordinates instead.\n")
 
                 ccdid = ccds[ccd_counts.tolist().index(max(ccd_counts))]
 
-                bkgscale = fileio.get_keys_from_file(fullfile)[f"BKGSCAL{ccdid}"]
+                bkgscale = fileio.get_keys_from_file(f"{fullfile}[#row=0]")[f"BKGSCAL{ccdid}"]
 
                 edit_header(phafile, "AREASCAL", 1/bkgscale,
                             comment=f"1/BKGSCAL{ccdid} using the 'blanksky' scaling factor") #, set to 1.0 if subtracting background")
@@ -1669,7 +1692,7 @@ def _resps_preprocess_wrapper(args_dict):
         if instrument == "ACIS":
             rmftool = args_dict["rmftool"]
 
-            kdict["tdetwmap"], kdict["feffile"] = resp_setup(args_dict,asphist,rmftool)
+            kdict["tdetwmap"], kdict["feffile"], kdict["zero_counts_tdetwmap"] = resp_setup(args_dict,asphist,rmftool)
 
     return {key_id : kdict}
 
@@ -1798,35 +1821,34 @@ def _build_resps(args):
                     case "RMF":
                         respfile = build_acis_rmf(args)
 
-        else:
+        elif instrument == "HRC" and not all([srcbkg == "bkg", not dobkgresp]):
             ##########################################
             #
             # make HRC ARF and copy RMF from CalDB
             #
             ##########################################
 
-            if not all([srcbkg == "bkg", not dobkgresp]):
-                infostr = f"Creating {srcbkg} ARF {iteminfostr}"
+            infostr = f"Creating {srcbkg} ARF {iteminfostr}"
 
-                try:
-                    ancrfile, respfile = create_hrc_resp(phafile,rmffile,full_outroot,
-                                                         asphist,clobber,verbose,msk,
-                                                         skyx,skyy,instrument,chip_id,infostr)
+            try:
+                ancrfile, respfile = create_hrc_resp(phafile,rmffile,full_outroot,
+                                                     asphist,clobber,verbose,msk,
+                                                     skyx,skyy,instrument,chip_id,infostr)
 
-                    if all([srcbkg == "src",correct == "yes"]):
-                        try:
-                            if verbose == 1:
-                                vprogress("Calculating aperture correction")
-                            else:
-                                v2(f"Calculating aperture correction for {srcbkg} ARF {iteminfostr}")
+                if all([srcbkg == "src",correct == "yes"]):
+                    try:
+                        if verbose == 1:
+                            vprogress("Calculating aperture correction")
+                        else:
+                            v2(f"Calculating aperture correction for {srcbkg} ARF {iteminfostr}")
 
-                            ancrfile = correct_arf(full_outroot,fullfile,filename,
-                                                   ancrfile,skyx,skyy,binarfcorr)
-                        except OSError as exc:
-                            raise IOError(f"Failed to PSF correct the ARF: {ancrfile}") from exc
+                        ancrfile = correct_arf(full_outroot,fullfile,filename,
+                                               ancrfile,skyx,skyy,binarfcorr)
+                    except OSError as exc:
+                        raise IOError(f"Failed to PSF correct the ARF: {ancrfile}") from exc
 
-                except OSError as exc:
-                    raise IOError(f"Failed to create ARF for {fullfile}") from exc
+            except OSError as exc:
+                raise IOError(f"Failed to create ARF for {fullfile}") from exc
 
     if srcbkg == "bkg" and not dobkgresp:
         return None
@@ -1902,9 +1924,9 @@ def resps(args,specdicts,specextract_args,pars,parallelize):
                                        progress=True,
                                        prefix="Generating ARFs & RMFs:")
 
-    for key in asphists.keys():
-        if asphists[key] is not None:
-            asphists[key].close()
+    for key,ahist_val in asphists.items():
+        if ahist_val is not None:
+            ahist_val.close()
 
         if tdetwmap[key] is not None:
             tdetwmap[key].close()
@@ -2096,7 +2118,7 @@ in the 'infile' parameter; the 'combine=yes' setting will be ignored.\n")
     #
     #################################################
 
-    nsrcs = set([len(spec_src_stk), len(arf_src_stk), len(rmf_src_stk)])
+    nsrcs = { len(spec_src_stk), len(arf_src_stk), len(rmf_src_stk) }
     if len(nsrcs) > 1:
         v1("Output spectra and responses were not combined \
 because spectra and/or responses were not created for every \
@@ -2449,16 +2471,16 @@ cannot contain any spaces")
 
                 return status
 
-    else:
-        if verbose == 1 and _check_tty():
-            def parallelize(func,args,numcores=nproc,progress=True,prefix=""):
-                if progress:
-                    return [func(arg) for arg in progressbar_iter(args,use_unicode=_use_unicode(),prefix=prefix)]
+    elif parallel == "no" and verbose == 1 and _check_tty():
+        def parallelize(func,args,numcores=nproc,progress=True,prefix=""):
+            if progress:
+                return [func(arg) for arg in progressbar_iter(args,use_unicode=_use_unicode(),prefix=prefix)]
 
-                return [func(arg) for arg in args]
-        else:
-            def parallelize(func,args,numcores=nproc,progress=None,prefix=None):
-                return [func(arg) for arg in args]
+            return [func(arg) for arg in args]
+
+    else:
+        def parallelize(func,args,numcores=nproc,progress=None,prefix=None):
+            return [func(arg) for arg in args]
 
     ## check open file limits on the system ##
     open_file_lim = merging._check_open_file_limits(len(specextract_args))
@@ -2466,9 +2488,10 @@ cannot contain any spaces")
     if open_file_lim:
         v3("Increasing system open file limit for this and child Python instance.")
 
-    if regtest:
-        assert not open_file_lim, f"The system open file limit was increased for this instance, as expected for this test."
-        assert open_file_lim, f"The system open file limit was not increased for this instance, which is not expected for this test!"
+    if regtest and all([len(specextract_args) == 520,
+                        params["outroot"] == f"{os.getenv('PWD')}/too-many-open-files"]):
+        assert not open_file_lim, "The system open file limit was increased for this instance, as expected for this test."
+        assert open_file_lim, "The system open file limit was not increased for this instance, which is not expected for this test!"
 
     ###########################
     #
@@ -2497,8 +2520,8 @@ cannot contain any spaces")
     specextract_args = update_param_args_and_dict(pardict_update_resps,specdicts,specextract_args,pars)
 
     ## clean up converted region stack ##
-    for key in outreg_tmp.keys():
-        outreg_tmp[key].close()
+    for regtemp in outreg_tmp.values():
+        regtemp.close()
     del outreg_name
 
     ###########################

--- a/bin/specextract
+++ b/bin/specextract
@@ -33,7 +33,7 @@ Script:
 
 __version__ = "CIAO 4.18"
 __toolname__ = "specextract"
-__revision__ = "21 May 2026"
+__revision__ = "4 June 2026"
 
 ##########################################################################
 #
@@ -2250,6 +2250,7 @@ def get_par(args):
 
     pinfo = open_param_file(args, toolname=__toolname__)
     pfile = pinfo["fp"]
+    regtest = pinfo["regtest_short-circuit"]
 
     # Parameters:
     params = {}
@@ -2336,7 +2337,7 @@ def get_par(args):
 
     paramio.paramclose(pfile)
 
-    return params,pars
+    return params,pars,regtest
 
 
 
@@ -2376,7 +2377,7 @@ def run_specextract(args):
     # Retrieve parameter values from specextract parameter file.
     #-----------------------------------------------------------
 
-    params,pars = get_par(args)
+    params, pars, regtest = get_par(args)
 
     #--------------------------------------------------
     # Check the input values and do some initial setup.
@@ -2460,7 +2461,14 @@ cannot contain any spaces")
                 return [func(arg) for arg in args]
 
     ## check open file limits on the system ##
-    merging._check_open_file_limits(len(specextract_args))
+    open_file_lim = merging._check_open_file_limits(len(specextract_args))
+
+    if open_file_lim:
+        v3("Increasing system open file limit for this and child Python instance.")
+
+    if regtest:
+        assert not open_file_lim, f"The system open file limit was increased for this instance, as expected for this test."
+        assert open_file_lim, f"The system open file limit was not increased for this instance, which is not expected for this test!"
 
     ###########################
     #

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -24,6 +24,7 @@ Routines used when merging and combining data.
 
 import os
 import tempfile
+import resource
 
 import numpy as np
 
@@ -42,11 +43,11 @@ import ciao_contrib.runtool as rt
 import coords.format
 import coords.utils
 
-import ciao_contrib._tools.fileio as fileio
-import ciao_contrib._tools.fluximage as fi
+from ciao_contrib._tools import fileio
+from ciao_contrib._tools import fluximage as fi
 from ciao_contrib._tools.obsinfo import ObsInfo
-import ciao_contrib._tools.run as run
-import ciao_contrib._tools.utils as utils
+from ciao_contrib._tools import run
+from ciao_contrib._tools import utils
 
 from ciao_contrib._tools.headers import HeaderMerge
 from ciao_contrib.stacklib import TemporaryStack
@@ -1165,10 +1166,10 @@ def validate_obsinfo(infiles, colcheck=True):
                 except TypeError:
                     continue
 
-        for obsid in obs_cycle.keys():
+        for obsid,val in obs_cycle.items():
             # if ObsID has both cycle=P and cycle=S files, then remove it
             # from the multi-obi list
-            if obs_cycle[obsid] in ["PS", "SP"]:
+            if val in ["PS", "SP"]:
                 v3(f"ObsID {obsid} is an interleaved observation")
                 multis.remove(obsid)
 
@@ -2475,7 +2476,7 @@ def which_obsids_overlap(obsinfos,
 
 def merge_files(imgfiles, expmap_files, imgfile, expmap, fluxmap,
                 lookupTable, toolname, pars, toolversion,
-                verbose=1, clobber=False, tmpdir="/tmp/"):
+                verbose=1, clobber=False, tmpdir="/tmp/", nchunk=100):
     """Combine the images"""
 
     run.dmimgcalc_add(imgfiles,
@@ -2483,14 +2484,18 @@ def merge_files(imgfiles, expmap_files, imgfile, expmap, fluxmap,
                       verbose=verbose,
                       clobber=clobber,
                       lookupTab=lookupTable,
-                      tmpdir=tmpdir)
+                      tmpdir=tmpdir,
+                      nchunk=nchunk,
+                      bigN_smallNchunk_bypass=True)
 
     run.dmimgcalc_add(expmap_files,
                       expmap + '[EXPMAP]',
                       verbose=verbose,
                       clobber=clobber,
                       lookupTab=lookupTable,
-                      tmpdir=tmpdir)
+                      tmpdir=tmpdir,
+                      nchunk=nchunk,
+                      bigN_smallNchunk_bypass=True)
 
     run.fix_bunit(expmap_files[0], expmap, verbose=verbose)
 
@@ -2856,7 +2861,7 @@ def expmap_weight(infiles, expmaps, outfile, lookupTable,
 
 def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
                   lookupTable, toolname, pars, toolversion,
-                  verbose=1, clobber=False, tmpdir="/tmp/"):
+                  verbose=1, clobber=False, tmpdir="/tmp", nchunk=None):
     """Combine the PSF maps.
 
     It is assumed that the PSF maps have no spatial subspace filters
@@ -2867,30 +2872,79 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
     dmfilttypes = ['min', 'max', 'mean', 'median', 'mid']
     clstr = "yes" if clobber else "no"
 
-    outfile = "{}[PSFMAP]".format(psfmap)
-    if mergetype in dmfilttypes:
+    outfile = f"{psfmap}[PSFMAP]"
 
-        with TemporaryStack(psfmap_files, dir=tmpdir) as tmp_stk:
-            run.punlearn("dmimgfilt")
-            args = ["infile=@{}".format(tmp_stk.name),
-                    "outfile={}".format(outfile),
-                    "function={}".format(mergetype),
-                    "mask=point(0,0)",
-                    "lookupTab={}".format(lookupTable),
-                    "clobber={}".format(clstr),
-                    "verbose={}".format(verbose)]
-            run.run("dmimgfilt", args)
 
-    elif mergetype == 'exptime':
+    def dmfilt_stk(stk, out, merge_type, lut=lookupTable, clob=clstr, verb=verbose):
+        with rt.new_pfiles_environment(ardlib=False):
+            with TemporaryStack(stk, dir=tmpdir) as tmp_stk:
+                run.punlearn("dmimgfilt")
 
-        exposure_weight(psfmap_files, outfile, lookupTable)
+                args = [f"infile=@{tmp_stk.name}",
+                        f"outfile={out}",
+                        f"function={merge_type}",
+                        "mask=point(0,0)",
+                        f"lookupTab={lut}",
+                        f"clobber={clob}",
+                        f"verbose={verb}"]
 
-    elif mergetype == 'expmap':
+                run.run("dmimgfilt", args)
 
-        expmap_weight(psfmap_files, expmap_files, outfile, lookupTable)
+
+    def combine_psfmap(pmap_files=psfmap_files, emap_files=expmap_files, out=outfile,
+                       mergetype=mergetype, lut=lookupTable):
+        if mergetype in dmfilttypes:
+            dmfilt_stk(pmap_files, out, mergetype)
+
+        elif mergetype == 'exptime':
+            exposure_weight(pmap_files, out, lut)
+
+        elif mergetype == 'expmap':
+            expmap_weight(pmap_files, emap_files, out, lut)
+
+        else:
+            raise ValueError("Unexpected mergetype={} for combining PSF maps".format(mergetype))
+
+
+    if nchunk is None or mergetype in ["exptime", "expmap"]:
+        combine_psfmap(psfmap_files, expmap_files, outfile, mergetype, lookupTable)
 
     else:
-        raise ValueError("Unexpected mergetype={} for combining PSF maps".format(mergetype))
+        chunks = int(np.ceil( len(psfmap_files)/nchunk ))
+        datachunks = [ list(zip(*[psfmap_files,expmap_files]))[i::chunks] for i in range(chunks) ]
+        tmplist = []
+
+        for d in datachunks:
+            pmaps, emaps = zip(*d)
+
+            tmplist.append( _tmp := tempfile.NamedTemporaryFile(dir=tmpdir) )
+
+            combine_psfmap(pmaps, emaps, f"{_tmp.name}[PSFMAP]", mergetype, lookupTable)
+
+        tmp_fn = [t.name for t in tmplist]
+        _iter = 0
+
+        while chunks > nchunk:
+            chunks = int(np.ceil( chunks/nchunk ))
+            _datachunks = [ tmplist[i::chunks] for i in range(chunks) ]
+            _tmplist = []
+
+            for d in _datachunks:
+                _tmplist.append( _tmp := tempfile.NamedTemporaryFile(dir=tmpdir) )
+
+                dmfilt_stk([_d.name for _d in d], f"{_tmp.name}[PSFMAP]", mergetype)
+
+                for _d in d: _d.close()
+
+            _iter += 1
+            tmplist = _tmplist
+
+        if _iter > 0:
+            tmp_fn = [t.name for t in _tmplist]
+
+        dmfilt_stk(tmp_fn, outfile, mergetype)
+
+        for t in tmplist: t.close()
 
     run.fix_bunit(psfmap_files[0], psfmap, verbose=verbose)
 
@@ -2910,7 +2964,9 @@ def merge(process,
           threshold=False,
           clobber=False,
           pathfrom=None,
-          tmpdir="/tmp/"):
+          tmpdir="/tmp/",
+          counts_nchunk : int|None=100,
+          psfmap_nchunk : int|None=None):
     """Combine the fluximage outputs into single images.
     outfiles is the output of setup_output_names().
 
@@ -2990,7 +3046,8 @@ def merge(process,
         merge_files(images[eband], expmaps[eband],
                     imgfile, expmap, fluxmap,
                     ltable, toolname, pars, toolversion,
-                    verbose=verbose, clobber=clobber, tmpdir=tmpdir)
+                    verbose=verbose, clobber=clobber,
+                    tmpdir=tmpdir, nchunk=counts_nchunk)
 
     if psfmerge is not None:
         psfmaps = outfiles['psfmaps']
@@ -2998,7 +3055,8 @@ def merge(process,
 
             merge_psfmaps(psfmerge, psfmap, psfmaps[eband], expmaps[eband],
                           ltable, toolname, pars, toolversion,
-                          verbose=verbose, clobber=clobber, tmpdir=tmpdir)
+                          verbose=verbose, clobber=clobber,
+                          tmpdir=tmpdir, nchunk=psfmap_nchunk)
 
     try:
         rt.add_tool_history(outfiles['mergedevtfile'], toolname, pars,
@@ -3144,5 +3202,32 @@ def handle_xygrid(pfile, instrument, pars, params):
         params['sizes'] = sizes
 
     params['xygrid'] = xygrid
+
+
+def _check_open_file_limits(nfiles: int, Ntemp: int = 4, Npad: int = 20) -> None:
+    """
+    Check number of open files the working shell supports; opening too many
+    temporary files exceeding the suported value will throw an OSError.
+
+    This would be the equivalent of using:
+
+    bash:
+    'ulimit -n' and 'ulimit -Sn <softlim>'
+
+    csh:
+    'limit descriptors' and 'limit descriptors <softlim>'
+
+    from within Python.  This is only applied for the Python process instance
+    executing this resource usage.
+    """
+
+    open_file_lim = resource.RLIMIT_NOFILE
+    softlim, hardlim = resource.getrlimit(open_file_lim)
+
+    N_open_file = Ntemp * nfiles + Npad
+
+    if softlim < N_open_file:
+        resource.setrlimit(open_file_lim, (N_open_file, hardlim))
+
 
 # End

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2025
+#  Copyright (C) 2012 - 2026
 #  Smithsonian Astrophysical Observatory
 #
 #
@@ -97,8 +97,7 @@ def match_obsid(obsinfos, infiles, label):
             cycle = obsid.cycle
         if utils.is_multi_obi_obsid(obsid.obsid):
             return (obsid.obsid, cycle, obsid.obi)
-        else:
-            return (obsid.obsid, cycle)
+        return (obsid.obsid, cycle)
 
     cache = {}
     for infile in infiles:
@@ -201,8 +200,7 @@ def match_obsid_asol(obsinfos, asolfiles):
     def make_key(obsid):
         if utils.is_multi_obi_obsid(obsid.obsid):
             return (obsid.obsid, obsid.obi)
-        else:
-            return obsid.obsid
+        return obsid.obsid
 
     aobsids = {}
     for asolfile in asolfiles:
@@ -213,7 +211,7 @@ def match_obsid_asol(obsinfos, asolfiles):
         try:
             aobsids[key].add(asolfile)
         except KeyError:
-            aobsids[key] = set([asolfile])
+            aobsids[key] = { asolfile }
 
     out = []
     keys = []
@@ -691,10 +689,10 @@ def adjust_rule(key, rule, obsinfos):
 
     if rule.startswith('Merge-'):
         return adjust_merge_rule(key, rule, obsinfos)
-    elif rule.startswith('WarnOmit-'):
+    if rule.startswith('WarnOmit-'):
         return adjust_warnomit_rule(key, rule, obsinfos)
-    else:
-        return (key, rule)
+
+    return (key, rule)
 
 
 def adjust_warnomit_rule(key, rule, obsinfos):
@@ -987,16 +985,17 @@ def validate_obsinfo(infiles, colcheck=True):
 
     sinfiles = fileio.expand_evtfiles_stack(infiles)
     norig = len(sinfiles)
-    if norig == 0:
-        raise IOError("No valid event files were found.")
-    elif norig == 1:
-        # TODO: does it make sense to allow only one observation here?
-        v1("Verifying one observation.")
-    else:
-        v1(f"Verifying {norig} observations.")
+    match norig:
+        case 0:
+            raise IOError("No valid event files were found.")
+        case 1:
+            # TODO: does it make sense to allow only one observation here?
+            v1("Verifying one observation.")
+        case _:
+            v1(f"Verifying {norig} observations.")
 
-    acols = set(['TIME', 'CHIP', 'DET', 'SKY', 'CCD_ID', 'ENERGY'])
-    hcols = set(['TIME', 'CHIP', 'DET', 'SKY', 'CHIP_ID'])
+    acols = {'TIME', 'CHIP', 'DET', 'SKY', 'CCD_ID', 'ENERGY'}
+    hcols = {'TIME', 'CHIP', 'DET', 'SKY', 'CHIP_ID'}
     req_columns = {'ACIS': acols, 'HRC': hcols}
 
     obsinfos = []
@@ -1245,7 +1244,7 @@ def obsinfo_checks(obsinfos):
         return None
 
     pi_ranges = [get_pi_range(obs.get_columns()) for obs in obsinfos]
-    v4("PI ranges={}".format(pi_ranges))
+    v4(f"PI ranges={pi_ranges}")
     pi_ranges = [pir for pir in pi_ranges if pir is not None]
     if pi_ranges != []:
         pi_flags = [pir != pi_ranges[0] for pir in pi_ranges]
@@ -1302,11 +1301,11 @@ def find_hrci_backgrounds(obsinfos, bgndmap=None, tmpdir=None):
         return None
 
     if nmissing == 1:
-        v1("Skipping {} as it has no matching HRC-I background file.".format(missing[0]))
+        v1(f"Skipping {missing[0]} as it has no matching HRC-I background file.")
         v1("Set background=none to turn off the background subtraction and include this file.")
         return bgfiles
 
-    elif nmissing > 1:
+    if nmissing > 1:
         v1("Skipping the following as they have no matching HRC-I background file.")
         for mfile in missing:
             v1("    " + mfile)
@@ -1395,7 +1394,7 @@ def merge_event_files(infiles,
     else:
         v1("Merging reprojected events files to " + outfile)
 
-    v3(" ... using lookup table: {}".format(lookupTab))
+    v3(f" ... using lookup table: {lookupTab}")
 
     # We can reduce the history record (and the argument length to
     # dmmerge) if we know the instrument type: at present we only
@@ -1406,7 +1405,7 @@ def merge_event_files(infiles,
         if inst not in ['ACIS', 'HRC']:
             raise TypeError("Hack to break out of the loop")
 
-        v4(" ... using instrument = {} to specialize subspace rules".format(inst))
+        v4(f" ... using instrument = {inst} to specialize subspace rules")
 
     except TypeError:
         v4("No obs info included, so can not specialize subspace rules when merging.")
@@ -1418,15 +1417,15 @@ def merge_event_files(infiles,
     hrc_pi_case = False
 
     if inst is None or inst == 'ACIS':
-        excl_cols = set(["phas"])
+        excl_cols = { "phas" }
     else:
         excl_cols = set()
 
     if colfilter and obsinfos is not None:
         v3(" ... checking the columns match")
 
-        cols = dict([(ci.name, ci) for ci in obsinfos[0].get_columns()])
-        cmatch = dict([(ci.name, 1) for ci in obsinfos[0].get_columns()])
+        cols = { ci.name : ci for ci in obsinfos[0].get_columns() }
+        cmatch = { ci.name : 1 for ci in obsinfos[0].get_columns() }
 
         for obs in obsinfos[1:]:
             for ci in obs.get_columns():
@@ -1449,8 +1448,7 @@ def merge_event_files(infiles,
                    not hrc_pi_case and ci.range != ci0.range:
                     v1("WARNING: dropping the PI column from the merged " +
                        "event file.")
-                    v2("         PI ranges = " +
-                       "{} vs {}".format(ci0.range, ci.range))
+                    v2(f"{'':>9}PI ranges = {ci0.range} vs {ci.range}")
                     hrc_pi_case = True
                     excl_cols.add(ci.name)
                     continue
@@ -1461,7 +1459,7 @@ def merge_event_files(infiles,
             if nfound != nfiles:
                 excl_cols.add(cname)
 
-        v3(" ... and removing {}".format([' '.join([exc for exc in excl_cols])]))
+        v3(f" ... and removing {[' '.join(exc for exc in excl_cols)]}")
 
         # dmmerge needs the same column order in all the files, so use
         # the ordering of the first file.
@@ -1479,7 +1477,7 @@ def merge_event_files(infiles,
         # the same in all the files. This is a little bit messy to get right,
         # so leave as is for the moment.
         #
-        colfilter = "[cols {}]".format(','.join(colfilter))
+        colfilter = f"[cols {','.join(colfilter)}]"
 
     elif inst == 'ACIS':
         colfilter = "[cols -phas]"
@@ -1501,7 +1499,7 @@ def merge_event_files(infiles,
     else:
         excl_subspace = excl_subspace_acis + excl_subspace_hrc
 
-    v4("  ... excluding subspace: {}".format(excl_subspace))
+    v4(f"  ... excluding subspace: {excl_subspace}")
     for colname in excl_subspace:
         excl_cols.add(colname)
 
@@ -1514,8 +1512,8 @@ def merge_event_files(infiles,
     else:
         ltab = lookupTab
 
-    v3("Column filter for merge: {}".format(colfilter))
-    v3("Subspace filter for merge: {}".format(subspacefilter))
+    v3(f"Column filter for merge: {colfilter}")
+    v3(f"Subspace filter for merge: {subspacefilter}")
 
     # If we are removing the PI column from HRC data then the
     # merge is to a temporary file so that we can then have a
@@ -1530,16 +1528,14 @@ def merge_event_files(infiles,
                                                          suffix=".merged")
         merge_outfile = merge_outfile_temp.name
         clobber_merge = True
-        v3("Merge to temporary file: {}".format(merge_outfile))
+        v3(f"Merge to temporary file: {merge_outfile}")
     else:
         merge_outfile = outfile
         clobber_merge = clobber
 
     stkfile = make_stackfile(infiles, dir=tmpdir, suffix=".merge")
     try:
-        run.dmmerge("@{}{}[subspace {}]".format(stkfile.name,
-                                                colfilter,
-                                                subspacefilter),
+        run.dmmerge(f"@{stkfile.name}{colfilter}[subspace {subspacefilter}]",
                     merge_outfile,
                     clobber=clobber_merge,
                     verbose=verbose,
@@ -1576,9 +1572,9 @@ def merge_event_files(infiles,
         # but not really worth it
 
         if val.find('/') != -1:
-            val = "'{}'".format(val)
+            val = f"'{val}'"
 
-        action = "{} = {}".format(name, val)
+        action = f"{name} = {val}"
         edits.append(action)
 
     add_edit("ASOLFILE", asolfile)
@@ -1587,10 +1583,10 @@ def merge_event_files(infiles,
     add_edit("MASKFILE", maskfile)
 
     if edits == []:
-        v3("No ancillary file keywords to edit in {}".format(outfile))
+        v3(f"No ancillary file keywords to edit in {outfile}")
         return
 
-    v3("Editing ancillary file keywords in {}".format(outfile))
+    v3(f"Editing ancillary file keywords in {outfile}")
     tfile = tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+',
                                         suffix=".dmhedit")
     tfile.write('#add\n')
@@ -1620,16 +1616,15 @@ def process_reference_position(refpos, obsinfos):
                                                             list(decs))
 
     elif rpos[2] is not None:
-        v1("Tangent point is taken from the file {}".format(rpos[2]))
+        v1(f"Tangent point is taken from the file {rpos[2]}")
         try:
             (ra, dec) = fileio.get_tangent_point(rpos[2])
 
         except IOError as ioe:
             # could look for RA_NOM/DEC_NOM as a fall back but doubt it is
             # worth it.
-            v2("Error is: {}".format(ioe))
-            raise ValueError("Unable to find a tangent position in " +
-                             "{}".format(rpos[2]))
+            v2(f"Error is: {ioe}")
+            raise ValueError(f"Unable to find a tangent position in {rpos[2]}")
 
         rval = rpos[2]
 
@@ -1647,7 +1642,7 @@ def process_reference_position(refpos, obsinfos):
     v1(f"New tangent point: RA={rastr} Dec={decstr}")
 
     if rval is None:
-        rval = "{0} {1}".format(ra, dec)
+        rval = f"{ra} {dec}"
 
     return (rval, ra, dec)
 
@@ -1690,7 +1685,7 @@ def list_observations(instrume, ranom, decnom, obsinfos):
         suffix = ''
     else:
         suffix = 's'
-    v1("\nObservation{} to be reprojected:\n".format(suffix))
+    v1(f"\nObservation{suffix} to be reprojected:\n")
 
     # Check for any multi-obi datasets, as this increases the ObsId field
     # width. For ACIS datasets this can get further increased if there
@@ -1710,7 +1705,7 @@ def list_observations(instrume, ranom, decnom, obsinfos):
     if instrume == "ACIS":
         # Do we need to allocate more space for interleaved-mode data?
         obsids = [obs.obsid for obs in obsinfos]
-        if not all([obsid.cycle is None for obsid in obsids]):
+        if not all(obsid.cycle is None for obsid in obsids):
             olen += 2
 
         fmt = "{:" + str(nchar) + "} {:^" + str(olen) + \
@@ -1834,7 +1829,7 @@ def list_observations(instrume, ranom, decnom, obsinfos):
             v1(fmt.format(*fmtargs))
 
         except KeyError as ke:
-            raise ValueError("ObsId {} ({}) is missing the {} keyword.".format(obsid, obs.get_evtfile(), ke))
+            raise ValueError(f"ObsId {obsid} ({obs.get_evtfile()}) is missing the {ke} keyword.")
 
     v1("")
 
@@ -1845,7 +1840,7 @@ def list_observations(instrume, ranom, decnom, obsinfos):
         if len(values) < 2:
             continue
 
-        v1("WARNING - {} values differ:".format(keyname))
+        v1(f"WARNING - {keyname} values differ:")
         out = [(len(value), key, value)
                for (key, value) in values.items()]
         out.sort(reverse=True)
@@ -1856,25 +1851,25 @@ def list_observations(instrume, ranom, decnom, obsinfos):
             nlarger = larger[0]
 
             if nlarger == 1:
-                lbl = "{} has".format(larger[2][0])
+                lbl = f"{larger[2][0]} has"
             else:
                 lbl = "the rest have"
 
             if nsmaller == 1:
-                v1("  Obsid {} has {}={} and {} {}".format(smaller[2][0], keyname, smaller[1], lbl, larger[1]))
+                v1(f"  Obsid {smaller[2][0]} has {keyname}={smaller[1]} and {lbl} {larger[1]}")
             elif nsmaller < 6:
-                v1("  Obsids {} have {}={} and {} {}".format(" ".join([str(s) for s in smaller[2]]), keyname, smaller[1], lbl, larger[1]))
+                v1(f"  Obsids {' '.join([str(s) for s in smaller[2]])} have {keyname}={smaller[1]} and {lbl} {larger[1]}")
             else:
-                v1("  {} Obsids have {}={} and {} {}".format(nsmaller, keyname, smaller[1], lbl, larger[1]))
+                v1(f"  {nsmaller} Obsids have {keyname}={smaller[1]} and {lbl} {larger[1]}")
 
         else:
             for (nobsids, val, obsids) in out:
                 if nobsids == 1:
-                    v1("  ObsId {} has {}={}".format(obsids[0], keyname, val))
+                    v1(f"  ObsId {obsids[0]} has {keyname}={val}")
                 elif nobsids < 6:
-                    v1("  ObsIds {} have {}={}".format(" ".join([str(o) for o in obsids]), keyname, val))
+                    v1(f"  ObsIds {" ".join([str(o) for o in obsids])} have {keyname}={val}")
                 else:
-                    v1("  {} ObsIds have {}={}".format(nobsids, keyname, val))
+                    v1(f"  {nobsids} ObsIds have {keyname}={val}")
 
         v1("")
 
@@ -1979,7 +1974,7 @@ def display_merging_warnings(warnings, evtfile, obsinfos):
             #
             ndp = number_decimal_places(mdiff)
             if ndp > 0:
-                fmt = "{{:.{}f}}".format(ndp)
+                fmt = f"{{:.{ndp}f}}"
                 diff = fmt.format(diff)
 
             msg = f"{spacer}the {key} keyword varies by {diff} " + \
@@ -2000,7 +1995,7 @@ def display_merging_warnings(warnings, evtfile, obsinfos):
             v1(f"{spacer}[internal error] unrecognized warning {warnvals}")
 
     if len(aimpoints) > 1:
-        v1("{}the aim points fall on CCDs: {}".format(spacer, ' '.join([str(a) for a in aimpoints])))
+        v1(f"{spacer}the aim points fall on CCDs: {' '.join([str(a) for a in aimpoints])}")
         v1(f"{spacer}  which means that the ONTIME/LIVETIME/EXPOSURE keywords")
         v1(f"{spacer}  do not reflect the full observation length.")
 
@@ -2024,12 +2019,11 @@ def setup_obsid_asol(obsinfos, asolfiles):
 
         nmissing = len(missing)
         if nmissing == 1:
-            raise IOError("Missing the asol file(s) for " +
-                          "{}.".format(missing[0]))
+            raise IOError(f"Missing the asol file(s) for {missing[0]}.")
 
-        elif nmissing > 1:
+        if nmissing > 1:
             indent = "\n    "
-            raise IOError("Missing the asol files for {} observations:{}{}".format(nmissing, indent, indent.join(missing)))
+            raise IOError(f"Missing the asol files for {nmissing} observations:{indent}{indent.join(missing)}")
 
     else:
         asol = stk.build(asolfiles)
@@ -2070,11 +2064,11 @@ def setup_obsid_bpix(obsinfos, badpixfiles):
                 obs.set_ancillary('bpix', 'CALDB')
 
         elif nmissing == 1:
-            raise IOError("Missing the bad-pixel file for {}.".format(missing[0]))
+            raise IOError(f"Missing the bad-pixel file for {missing[0]}.")
 
         elif nmissing > 1:
             indent = "\n    "
-            raise IOError("Missing bad-pixel files for {} observations:{}{}".format(nmissing, indent, indent.join(missing)))
+            raise IOError(f"Missing bad-pixel files for {nmissing} observations:{indent}{indent.join(missing)}")
 
     else:
         badpix = stk.build(badpixfiles)
@@ -2090,7 +2084,7 @@ def setup_obsid_bpix(obsinfos, badpixfiles):
             if not os.path.isfile(bpixfile):
                 bpixfile += ".gz"
                 if not os.path.isfile(bpixfile):
-                    raise IOError("Unable to find bad pixel file={} (or .gz version)".format(bpixfile[:-3]))
+                    raise IOError(f"Unable to find bad pixel file={bpixfile[:-3]} (or .gz version)")
 
                 v3(f"Found .gz version of badpixfile={bpixfile}")
 
@@ -2099,7 +2093,7 @@ def setup_obsid_bpix(obsinfos, badpixfiles):
         badpix = match_obsid(obsinfos, out, 'bad-pixel')
         nbpix = len(badpix)
         if nbpix != nobs:
-            raise ValueError("The number of bad-pixel files ({}) does not match the number of input files ({})".format(nbpix, nobs))
+            raise ValueError(f"The number of bad-pixel files ({nbpix}) does not match the number of input files ({nobs})")
 
         for (obs, bpix) in zip(obsinfos, badpix):
             obs.set_ancillary('bpix', bpix)
@@ -2135,23 +2129,23 @@ def setup_obsid_ancillary(obsinfos, userinput, anctype, warnmsg):
 
         nmissing = len(missing)
         if nmissing == nobs:
-            v1("WARNING - no {0} files were found, setting {0}files=NONE. {1}".format(anctype, warnmsg))
+            v1(f"WARNING - no {anctype} files were found, setting {anctype}files=NONE. {warnmsg}")
             for obs in obsinfos:
                 obs.set_ancillary(anctype, 'NONE')
 
         elif nmissing == 1:
-            raise IOError("Missing the {} file for {}.".format(anctype, missing[0]))
+            raise IOError(f"Missing the {anctype} file for {missing[0]}.")
 
         elif nmissing > 1:
             indent = "\n    "
-            raise IOError("Missing {} files for {} observations:{}{}".format(anctype, nmissing, indent, indent.join(missing)))
+            raise IOError(f"Missing {anctype} files for {nmissing} observations:{indent}{indent.join(missing)}")
 
     else:
         files = stk.build(userinput)
         files = match_obsid(obsinfos, files, anctype)
         nfiles = len(files)
         if nfiles != nobs:
-            raise ValueError("The number of {} files ({}) does not match the number of input files ({})".format(anctype, nfiles, nobs))
+            raise ValueError(f"The number of {anctype} files ({nfiles}) does not match the number of input files ({nobs})")
 
         for (obs, filename) in zip(obsinfos, files):
             obs.set_ancillary(anctype, filename)
@@ -2421,7 +2415,7 @@ def which_obsids_overlap(obsinfos,
     The return raises a ValueError if no observations overlap.
     """
 
-    user_filter = "RECT({},{},{},{})".format(xlo, ylo, xhi, yhi)
+    user_filter = f"RECT({xlo},{ylo},{xhi},{yhi})"
     keep = []
     chipslist = []
     skipped_obsids = []
@@ -2433,12 +2427,11 @@ def which_obsids_overlap(obsinfos,
 
     for obs in obsinfos:
         infile = obs.get_evtfile()
-        fname = "{}[sky={}]".format(infile, user_filter)
+        fname = f"{infile}[sky={user_filter}]"
         chips = getfunc(fname)
 
         if chips is None:
-            v3("Skipping Obsid {} as it does not ".format(obs.obsid) +
-               "overlap the requested grid.")
+            v3(f"Skipping Obsid {obs.obsid} as it does not overlap the requested grid.")
             keep.append(False)
             chipslist.append([])
             skipped_obsids.append(str(obs.obsid))
@@ -2453,12 +2446,12 @@ def which_obsids_overlap(obsinfos,
     nobs = len(obsinfos)
     nskip = len(skipped_obsids)
     if nskip == nobs:
-        raise ValueError("No observations overlap the requested grid: x={}:{} y={}:{}".format(xlo, xhi, ylo, yhi))
+        raise ValueError(f"No observations overlap the requested grid: x={xlo}:{xhi} y={ylo}:{yhi}")
 
-    elif nskip == (nobs - 1):
+    if nskip == (nobs - 1):
         obsid = [obs.obsid
                  for (flag, obs) in zip(keep, obsinfos) if flag]
-        raise ValueError("Only one observation left ({}) that overlaps the requested grid: x={}:{} y={}:{}".format(obsid[0], xlo, xhi, ylo, yhi))
+        raise ValueError(f"Only one observation left ({obsid[0]}) that overlaps the requested grid: x={xlo}:{xhi} y={ylo}:{yhi}")
 
     if nskip != 0:
         if nskip == 1:
@@ -2468,8 +2461,8 @@ def which_obsids_overlap(obsinfos,
             lbl1 = "s"
             lbl2 = "they do"
 
-        v1("\nRemoved {} observation{} as {} not overlap the requested grid.".format(nskip, lbl1, lbl2))
-        v1("   ObsId{}: {}".format(lbl1, " ".join(skipped_obsids)))
+        v1(f"\nRemoved {nskip} observation{lbl1} as {lbl2} not overlap the requested grid.")
+        v1(f"   ObsId{lbl1}: {' '.join(skipped_obsids)}")
 
     return (keep, chipslist)
 
@@ -2655,15 +2648,14 @@ def exposure_weight(infiles, outfile, lookupTable,
     for infile in infiles:
         cr = pycrates.read_file(infile)
         if not isinstance(cr, pycrates.IMAGECrate):
-            raise ValueError("Not an image: {}".format(infile))
+            raise ValueError(f"Not an image: {infile}")
 
         exp = cr.get_key_value('EXPOSURE')
         if exp is None:
-            raise ValueError("No EXPOSURE keyword in {}".format(infile))
+            raise ValueError(f"No EXPOSURE keyword in {infile}")
 
         if exp <= 0.0:
-            raise ValueError("EXPOSURE keyword = {} in {}".format(exp,
-                                                                  infile))
+            raise ValueError(f"EXPOSURE keyword = {exp} in {infile}")
 
         # NOTE: using NaN as an indicator that the pixel is outside the
         #       filtered data; really should also check the subspace
@@ -2681,7 +2673,7 @@ def exposure_weight(infiles, outfile, lookupTable,
             if numerator.shape != pixvals.shape:
                 shape = shape_to_string(numerator.shape)
                 got = shape_to_string(pixvals.shape)
-                raise ValueError("Expected {} but found {} in {}".format(shape, got, infile))
+                raise ValueError(f"Expected {shape} but found {got} in {infile}")
 
             numerator += pixvals
             denominator += expvals
@@ -2793,11 +2785,11 @@ def expmap_weight(infiles, expmaps, outfile, lookupTable,
     for infile, expmap in zip(infiles, expmaps):
         cr = pycrates.read_file(infile)
         if not isinstance(cr, pycrates.IMAGECrate):
-            raise ValueError("Not an image: {}".format(infile))
+            raise ValueError(f"Not an image: {infile}")
 
         ecr = pycrates.read_file(expmap)
         if not isinstance(cr, pycrates.IMAGECrate):
-            raise ValueError("Not an image: {}".format(expmap))
+            raise ValueError(f"Not an image: {expmap}")
 
         # NOTE: using NaN as an indicator that the pixel is outside the
         #       filtered data; really should also check the subspace
@@ -2808,7 +2800,7 @@ def expmap_weight(infiles, expmaps, outfile, lookupTable,
         ivals = cr.get_image().values
 
         if ivals.shape != evals.shape:
-            raise ValueError("Shapes do not match: {} and {}".format(infile, expmap))
+            raise ValueError(f"Shapes do not match: {infile} and {expmap}")
 
         expvals = np.nan_to_num(evals)
         pixvals = expvals * np.nan_to_num(ivals)
@@ -2820,7 +2812,7 @@ def expmap_weight(infiles, expmaps, outfile, lookupTable,
             if numerator.shape != pixvals.shape:
                 shape = shape_to_string(numerator.shape)
                 got = shape_to_string(pixvals.shape)
-                raise ValueError("Expected {} but found {} in {}".format(shape, got, infile))
+                raise ValueError(f"Expected {shape} but found {got} in {infile}")
 
             numerator += pixvals
             denominator += expvals
@@ -2903,7 +2895,7 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
             expmap_weight(pmap_files, emap_files, out, lut)
 
         else:
-            raise ValueError("Unexpected mergetype={} for combining PSF maps".format(mergetype))
+            raise ValueError(f"Unexpected mergetype={mergetype} for combining PSF maps")
 
 
     if nchunk is None or mergetype in ["exptime", "expmap"]:
@@ -2934,7 +2926,8 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
 
                 dmfilt_stk([_d.name for _d in d], f"{_tmp.name}[PSFMAP]", mergetype)
 
-                for _d in d: _d.close()
+                for _d in d:
+                    _d.close()
 
             _iter += 1
             tmplist = _tmplist
@@ -2944,7 +2937,8 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
 
         dmfilt_stk(tmp_fn, outfile, mergetype)
 
-        for t in tmplist: t.close()
+        for t in tmplist:
+            t.close()
 
     run.fix_bunit(psfmap_files[0], psfmap, verbose=verbose)
 
@@ -3074,9 +3068,9 @@ def merge(process,
     spacer = '     '
 
     def display(typestr, filenames):
-        v1("{}{}".format(typestr, lbl))
+        v1(f"{typestr}{lbl}")
         fnames = ('\n' + spacer).join(filenames)
-        v1("{}{}\n".format(spacer, fnames))
+        v1(f"{spacer}{fnames}\n")
 
     v1("\nThe following files were created:\n")
     if threshold:

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -3223,5 +3223,8 @@ def _check_open_file_limits(nfiles: int, Ntemp: int = 4, Npad: int = 20) -> None
     if softlim < N_open_file:
         resource.setrlimit(open_file_lim, (N_open_file, hardlim))
 
+        return True
+
+    return False
 
 # End

--- a/ciao_contrib/_tools/specextract.py
+++ b/ciao_contrib/_tools/specextract.py
@@ -27,7 +27,7 @@ Routines to support the specextract tool.
 
 __modulename__ = "_tools.specextract"
 __toolname__ = "specextract"
-__revision__ = "31 October 2025"
+__revision__ = "3 June 2026"
 
 import os
 import sys
@@ -273,7 +273,7 @@ aspect solution files. Try entering aspect histogram files into \
 
                 regstk = stk.build(regfile)
 
-                fn_stk = [f"{fi}[{regcoord}={region}]" for region in regstk]
+                fn_stk = [f"{fi}[{regcoord}={region.split('/')[-1]}]" for region in regstk]
 
                 del fi, regfile, regfilter, regcoord, regstk
 
@@ -447,7 +447,7 @@ data with chandra_repro or add the keywords to the event file(s) with r4_header_
                 if refcoord_check.lower() in ["","none","indef"]:
                     if isinstance(resp_pos_type,str) and resp_pos_type.upper() == "REGION":
                         v1(f"{file} has zero counts. Using the region defined position for reference.")
-                        return True
+                        return True, int(counts)
 
                     raise IOError(f"{file} has zero counts. Check that the region formatting is correct \
 (e.g. wrong region, coordinates not in sky pixels or degrees) or use the 'refcoord' parameter.")
@@ -467,7 +467,7 @@ data with chandra_repro or add the keywords to the event file(s) with r4_header_
 
             return False
 
-        return True
+        return True, int(counts)
 
 
     def _event_stats(self,file,colname,args=None):
@@ -795,8 +795,8 @@ source files. Exiting.")
             else:
                 ## parse infile region ##
                 if self._get_region(infile) == infile:
-                    raise IOError("No region filter with the event file, nor a refcoord \
-value, provided to produce response files.")
+                    raise IOError("No region filter, nor a refcoord \
+value, is provided with the event file to produce response files.")
 
                 if resp_pos.lower() in ["centroid","max"]:
                     dmstat = make_tool("dmstat")
@@ -931,8 +931,8 @@ when 'resp_pos' is set to 'MAX' or 'CENTROID'.") from exc
 
                 fef = acis_fef_lookup.outfile
 
-            cr_fef = pcr.read_file(fef)
-            fef_energy = cr_fef.get_column("ENERGY").values
+            cr_fef = pcr.read_file(f"{fef}[cols ENERGY]")
+            fef_energy = cr_fef.ENERGY.values
             del cr_fef
 
             fef_emin = min(fef_energy)
@@ -1760,14 +1760,27 @@ block corresponding to the source region location will be used.\n")
 
                 ### check that 'chip_id' determined by dmcoords is actually present in the event file ###
                 if not self._check_dmcoords_chip(filename, instrument, int(chip_id)):
-                    raise IOError(f"The region 'chip_id' ({chip_id}) determined by 'dmcoords' is \
-not found in the provided event file ({filename})!")
+                    raise IOError(f"The response location, sky=({skyx}, {skyy}), will fall on \
+'chip_id'={chip_id}, as determined by 'dmcoords', which is not present in the provided event file ({filename})!")
 
                 arg_dict["skyx"] = skyx
                 arg_dict["skyy"] = skyy
                 arg_dict["chip_id"] = chip_id
                 arg_dict["chipx"] = chipx
                 arg_dict["chipy"] = chipy
+
+                ### Check that if there are zero-counts in extraction region for weighted
+                ### responses while 'resp_pos=region' so that a unit image may be
+                ### generated as a weights map.
+                if weight == "yes" and resp_pos.lower() == "region":
+                    _, cts = self._check_event_stats(fullfile, refcoord_check=False,
+                                                     weights_check=False, ewmap_range_check=None,
+                                                     resp_pos_type=resp_pos)
+
+                    if cts > 0:
+                        arg_dict["zero_counts"] = False
+                    else:
+                        arg_dict["zero_counts"] = True
 
                 # determine hydrogen column density based on extraction region centroid
                 # or refcoord to add to PI header in units of 1e-22 cm**-2

--- a/ciao_contrib/_tools/specextract.py
+++ b/ciao_contrib/_tools/specextract.py
@@ -27,7 +27,7 @@ Routines to support the specextract tool.
 
 __modulename__ = "_tools.specextract"
 __toolname__ = "specextract"
-__revision__ = "3 June 2026"
+__revision__ = "5 June 2026"
 
 import os
 import sys
@@ -458,12 +458,15 @@ data with chandra_repro or add the keywords to the event file(s) with r4_header_
                     v1("WARNING: Using 'refcoord' position to produce response files.\n")
 
             except AttributeError as exc:
-                if ewmap_range_check is not None:
+                if ewmap_range_check is not None and isinstance(resp_pos_type,str) and resp_pos_type.upper() != "REGION":
                     ## do we want to error out if the number of counts is
                     ## smaller than some magic count, instead of just zero?
 
                     raise IOError(f"{file} has zero counts in the \
 'energy_wmap={ewmap_range_check}' eV range needed to generate a weights map.") from exc
+
+                if isinstance(resp_pos_type,str) and resp_pos_type.upper() == "REGION" and all([not refcoord_check, not weights_check, ewmap_range_check is None]):
+                    return True, 0
 
             return False
 
@@ -1403,7 +1406,8 @@ and/or background files. Assuming source and background file lists have a matchi
 
                 if ewmap_range_check is not None and fileio.get_keys_from_file(f"{file}[#row=0]")["INSTRUME"] == "ACIS":
                     return self._check_event_stats(file,
-                                                   ewmap_range_check=ewmap_range_check)
+                                                   ewmap_range_check=ewmap_range_check,
+                                                   resp_pos_type=resp_pos)
                 return None
 
             except Exception as E:

--- a/ciao_contrib/param_wrapper.py
+++ b/ciao_contrib/param_wrapper.py
@@ -98,6 +98,12 @@ def open_param_file(argv, toolname=None):
         logger.verbose = 5
         args.remove("--paramdebug")
 
+    if "--regtestonly" in args:
+        args.remove("--regtestonly")
+        regtest = True
+    else:
+        regtest = False
+
     args = lw.preprocess_arglist(args)
 
     v5("Tool name = {0}".format(progname))
@@ -136,4 +142,4 @@ def open_param_file(argv, toolname=None):
     except Exception:
         raise IOError("There was a problem with the command-line parameter settings.")
 
-    return {"progname": progname, "parname": parname, "fp": fp, "mode": mode}
+    return {"progname": progname, "parname": parname, "fp": fp, "mode": mode, "regtest_short-circuit" : regtest}

--- a/ciao_contrib/param_wrapper.py
+++ b/ciao_contrib/param_wrapper.py
@@ -93,6 +93,7 @@ def open_param_file(argv, toolname=None):
     #
     #  --paramdebug      sets verbosity of this module's logger to 5
     #  --tracebackdebug  turns on traceback in error reporting by lw.handle_ciao_error
+    #  --regtestonly     provide flag to allow chunks of code to only be used when invoked
     #
     if "--paramdebug" in args:
         logger.verbose = 5

--- a/share/doc/xml/specextract.xml
+++ b/share/doc/xml/specextract.xml
@@ -1955,7 +1955,35 @@ unix% cat output.lis
 	revert to using the default CalDB bad pixel file.
       </PARA>
     </ADESC>
-    
+
+    <ADESC title="Changes in the scripts 4.18.2 release">      
+      <PARA>
+	Several minor enhancements and improved error messaging
+	provided with the changes being transparent in regular usage.
+	The most notable changes include:
+      </PARA>
+      
+      <LIST>
+        <ITEM>
+	  Better handling of large stacks in excess of 500+ source
+	  extraction regions by checking for the system's open file limit
+	  and adjusting it for the Python instance if necessary.
+	</ITEM>
+
+	<ITEM>
+          Added support to create weighted responses with a putative
+	  uniformly weighted map when 'resp_pos=REGION' and there are
+	  zero counts in the extraction region without erroring out.
+	</ITEM>
+
+	<ITEM>
+	  Re-worked how header keywords are written to the output
+	  files since the prior approach would pollute
+	  the the file history with excessive 'dmhedit' records.
+	</ITEM>
+      </LIST>      
+    </ADESC>
+
     <BUGS>
       <PARA title="Caveat: Exposure Variations">
 	The mkwarf tool is designed to represent the weighted ARF


### PR DESCRIPTION
This includes multiple updates to `specextract`.

- Better handling of large stacks in excess of 500+ source extraction regions by checking for the system's open file limit and adjusting it for the Python instance if necessary. Since this functionality is also shared with recent `flux_obs` work, moved this to `ciao_contrib/_tools/merging.py` and the feature is pulled from that working branch.
- Added `--regtestonly` flag to `ciao_contrib/param_wrapper.py` a frontloaded check can be run during regression testing without unnecessarily running the entire script.
- Added support to create weighted responses with a putative uniformly weighted map when `resp_pose=REGION` and there are no counts in the extraction region without erroring out.
- Re-worked how header keywords are written to output file.  The previous approach made use of `dmhedit`, but with the number keywords written, the file history would be polluted with `dmhedit` records.  Using `pycrates` to do this would eliminate the excessive history records, but is very slow.  While this approach is retained as an option in the function, using a `cxcdm` approach, while messier, provides identical results but is almost just as quick as using `dmhedit`.  
- linted and refactored functions.

