### PR TITLE
`flux_obs` memory and open file limit checks

### DIFF
--- a/bin/flux_obs
+++ b/bin/flux_obs
@@ -452,8 +452,8 @@ def project_mem_use(obsinfos, xygrid, ncore) -> tuple[int,int]:
 
     with fi.Project_Memory_Use(evtfiles=_evts, filesize=img_filesize, ncore=ncore) as memcheck:
         _ = memcheck.project_parallel_memory()
-        cnts_nchunk = memcheck.check_stk_psfmap_memory()
-        psf_nchunk = memcheck.check_stk_counts_memory()
+        cnts_nchunk = memcheck.check_stk_counts_memory()
+        psf_nchunk = memcheck.check_stk_psfmap_memory()
 
     # set nchunk values to what was used by default
     # before this check was introduced to the script

--- a/bin/flux_obs
+++ b/bin/flux_obs
@@ -45,17 +45,17 @@ import ciao_contrib.logger_wrapper as lw
 
 from ciao_contrib.param_wrapper import open_param_file
 
-import ciao_contrib._tools.bands as bands
-import ciao_contrib._tools.fileio as fileio
-import ciao_contrib._tools.fluximage as fi
-import ciao_contrib._tools.merging as merging
-import ciao_contrib._tools.utils as utils
+from ciao_contrib._tools import bands
+from ciao_contrib._tools import fileio
+from ciao_contrib._tools import merging
+from ciao_contrib._tools import utils
+from ciao_contrib._tools import fluximage as fi
 
 from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'flux_obs'
-__revision__ = '05 November 2021'
+__revision__ = '12 May 2026'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -435,6 +435,38 @@ def setup_output_names(outdir, outhead, obsinfos, enbands,
     return out
 
 
+
+def project_mem_use(obsinfos, xygrid, ncore) -> tuple[int,int]:
+    """
+    project memory usage for flux_obs and return how the counts/expmap
+    images and psfmap images should be chunked to avoid exhausing the
+    available system memory.
+    """
+
+    _evts = ( obs.evtfile for obs in obsinfos )
+    _dx = xygrid[0].as_grid().split("#")[-1]
+    _dy = xygrid[1].as_grid().split("#")[-1]
+    _pix_datasize = 4 # float32/int4: 4-bytes
+    img_filesize = int(_dx) * int(_dy) * _pix_datasize
+    nchunk_default = 100
+
+    with fi.Project_Memory_Use(evtfiles=_evts, filesize=img_filesize, ncore=ncore) as memcheck:
+        _ = memcheck.project_parallel_memory()
+        cnts_nchunk = memcheck.check_stk_psfmap_memory()
+        psf_nchunk = memcheck.check_stk_counts_memory()
+
+    # set nchunk values to what was used by default
+    # before this check was introduced to the script
+    if cnts_nchunk is None or cnts_nchunk > nchunk_default:
+        cnts_nchunk = 100
+
+    if psf_nchunk is None:
+        psf_nchunk = len(obsinfos)
+
+    return cnts_nchunk, psf_nchunk
+
+
+
 @lw.handle_ciao_errors(toolname, __revision__)
 def fluxobs():
     "Run the tool."
@@ -487,6 +519,13 @@ def fluxobs():
                                                                      params['xrange'],
                                                                      params['yrange'],
                                                                      tmpdir=tmpdir)
+    ### project memory usage ###
+
+    cnts_nchunk, psf_nchunk = project_mem_use(obsinfos, xygrid=xygrids[0], ncore=params["nproc"])
+
+    merging._check_open_file_limits(len(obsinfos))
+
+    ############################
 
     taskrunner = TaskRunner()
     data_products(taskrunner,
@@ -525,7 +564,9 @@ def fluxobs():
                   threshold=is_thresh,
                   clobber=clobber,
                   pathfrom=__file__,
-                  tmpdir=tmpdir)
+                  tmpdir=tmpdir,
+                  counts_nchunk=cnts_nchunk,
+                  psfmap_nchunk=psf_nchunk)
 
 
 # doit

--- a/bin/flux_obs
+++ b/bin/flux_obs
@@ -55,7 +55,7 @@ from ciao_contrib._tools.aspsol import AspectSolution
 from ciao_contrib._tools.taskrunner import TaskRunner
 
 toolname = 'flux_obs'
-__revision__ = '12 May 2026'
+__revision__ = '27 May 2026'
 
 lw.initialize_logger(toolname)
 lgr = lw.get_logger(toolname)
@@ -67,7 +67,9 @@ v3 = lgr.verbose3
 def get_par(argv):
     """ Get the parameters from parameter file """
 
-    pfile = open_param_file(argv, toolname=toolname)["fp"]
+    pinfo = open_param_file(argv, toolname=toolname)
+    pfile = pinfo["fp"]
+    regtest = pinfo["regtest_short-circuit"]
 
     def is_set(name):
         return paramio.pgetb(pfile, name) == 1
@@ -100,7 +102,8 @@ def get_par(argv):
     instrume = obsinfos[0].instrument
 
     if pars['background'] != "none" and instrume == 'HRC' and \
-       obsinfos[0].detector == 'HRC-I':
+        obsinfos[0].detector == 'HRC-I':
+
         bgfiles = merging.find_hrci_backgrounds(obsinfos,
                                                 tmpdir=params['tmpdir'])
         if bgfiles is None:
@@ -148,7 +151,7 @@ def get_par(argv):
         #
         params['psfecf'] = paramio.pgetd(pfile, 'psfecf')
         if params['psfecf'] <= 0 or params['psfecf'] > 1:
-            raise ValueError("psfecf={} is not valid, it must be > 0 and <= 1".format(params['psfecf']))
+            raise ValueError(f"psfecf={params['psfecf']} is not valid, it must be > 0 and <= 1")
 
         params['psfmerge'] = pars['psfmerge']
 
@@ -183,7 +186,7 @@ def get_par(argv):
     elif instrume == 'HRC':
         pars['dtffiles'] = paramio.pgetstr(pfile, 'dtffiles')
     else:
-        raise ValueError("Internal error: unrecognized INSTRUME keyword {}".format(instrume))
+        raise ValueError(f"Internal error: unrecognized INSTRUME keyword {instrume}")
 
     pars['units'] = params['units'] = paramio.pgetstr(pfile, 'units')
 
@@ -211,7 +214,7 @@ def get_par(argv):
 
     paramio.paramclose(pfile)
 
-    return (params, pars)
+    return params, pars, regtest
 
 
 # CAN THIS BE COMBINED WITH THE VERSION IN merge_obs?
@@ -451,7 +454,7 @@ def project_mem_use(obsinfos, xygrid, ncore) -> tuple[int,int]:
     nchunk_default = 100
 
     with fi.Project_Memory_Use(evtfiles=_evts, filesize=img_filesize, ncore=ncore) as memcheck:
-        _ = memcheck.project_parallel_memory()
+        memcheck.project_parallel_memory()
         cnts_nchunk = memcheck.check_stk_counts_memory()
         psf_nchunk = memcheck.check_stk_psfmap_memory()
 
@@ -472,7 +475,7 @@ def fluxobs():
     "Run the tool."
 
     args = lw.preprocess_arglist(sys.argv)
-    (params, pars) = get_par(args)
+    params, pars, regtest = get_par(args)
 
     obsinfos = params['obsinfos']
     instrume = params['instrume']
@@ -523,7 +526,17 @@ def fluxobs():
 
     cnts_nchunk, psf_nchunk = project_mem_use(obsinfos, xygrid=xygrids[0], ncore=params["nproc"])
 
-    merging._check_open_file_limits(len(obsinfos))
+    _open_file_lim = merging._check_open_file_limits( len(obsinfos) )
+
+    ### support regression tests ###
+    if regtest and len(obsinfos) == 520:
+        if params["outroot"] == f"{os.environ['PWD']}/too-many-open-files":
+            assert not _open_file_lim, "The system open file limit was increased for this instance, as expected for this test."
+            assert _open_file_lim, "The system open file limit was not increased for this instance, which is not expected for this test!"
+
+        if params["outroot"] == f"{os.environ['PWD']}/too-many-open-files_chunk-20-10":
+            cnts_nchunk = 20
+            psf_nchunk = 10
 
     ############################
 
@@ -567,6 +580,35 @@ def fluxobs():
                   tmpdir=tmpdir,
                   counts_nchunk=cnts_nchunk,
                   psfmap_nchunk=psf_nchunk)
+
+    ### support more regression tests ###
+    if regtest and len(obsinfos) == 520 and params["outroot"] == f"{os.environ['PWD']}/too-many-open-files_chunk-20-10":
+        _cnts = cnts_nchunk
+        _psf = psf_nchunk
+
+        for ncnts,npsf in ((50,25),(2,2)):
+            for kw in ("out_thresh_images", "out_thresh_expmaps", "out_fluxmaps", "out_psfmaps"):
+                outfiles[kw] = [ outfiles[kw][0].replace(f"chunk-{_cnts}-{_psf}",f"chunk-{ncnts}-{npsf}") ]
+
+            merging.merge(process,
+                          enbands,
+                          pars,
+                          outfiles,
+                          obsinfos,
+                          toolname,
+                          __revision__,
+                          verbose=verbose,
+                          psfmerge=params['psfmerge'],
+                          threshold=is_thresh,
+                          clobber=clobber,
+                          pathfrom=__file__,
+                          tmpdir=tmpdir,
+                          counts_nchunk=ncnts,
+                          psfmap_nchunk=npsf)
+
+            _cnts = ncnts
+            _psf = npsf
+
 
 
 # doit

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -62,14 +62,18 @@ import ciao_contrib.logger_wrapper as lw
 from ciao_contrib.runtool import new_pfiles_environment
 from ciao_contrib.runtool import add_tool_history
 
-import ciao_contrib._tools.fileio as fileio
+from ciao_contrib._tools import fileio
 from ciao_contrib._tools.obsinfo import ObsInfo
-import ciao_contrib._tools.utils as utils
+from ciao_contrib._tools import utils
 
-import ciao_contrib._tools.run as run
+from ciao_contrib._tools import run
 from ciao_contrib._tools.run import \
     punlearn, dmcopy, dmimgcalc, dmimgcalc2, dmimgcalc_add, \
     dmhedit_key, dmhedit_file
+
+from psutil import virtual_memory, cpu_count
+from itertools import islice
+
 
 # for now, export nothing
 __all__ = ()
@@ -79,10 +83,205 @@ __all__ = ()
 HRCI_BG_EVTS = "HRC-I_bkg.fits"
 
 lgr = lw.initialize_module_logger('_tools.fluximage')
+v0 = lgr.verbose0
 v1 = lgr.verbose1
 v2 = lgr.verbose2
 v3 = lgr.verbose3
 v4 = lgr.verbose4
+
+#################################################################################
+class Project_Memory_Use:
+    """
+    Estimate memory usage to generate exposure maps and PSF maps and when
+    stacking counts maps and PSF maps, which are the most memory intensive
+    steps in fluximage and flux_obs, which may lead the exhausting system
+    memory.  Return a chunk size for stacking purposes that hopefully avoids
+    using too much memory or error message with a suggestion on limiting the
+    number of logical cores used for parallel proceses to avoid memory exhaustion.
+    """
+
+    def __init__(self, evtfiles:list|tuple, filesize:int, ncore:int|str|None):
+        #self.evts = evtfiles
+        self.filesize = filesize
+        self._nchips_arr = sorted( ( len(fileio.get_ccds(e)) for e in evtfiles ), reverse=True )
+        self.nstk = len(self._nchips_arr)
+
+        if ncore is None:
+            self.ncore = cpu_count(logical=True)
+        else:
+            self.ncore = int(ncore)
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        return exc_traceback is None
+
+
+    def _get_system_memory(self) -> tuple[int,int]: # in bytes
+        """
+        return total memory on the system and available memory
+        for use at the time
+        """
+
+        _mem = virtual_memory()
+        total = _mem.total # total physical memory #
+        available = _mem.available # available physical memory (not being used by system processes) #
+
+        return total, available
+
+
+    def _expmap_memory(self, nchips:int) -> int:
+        file_buffer = 27_262_976 # buffer of 26 Mb in bytes
+
+        ## mosaicking an observation's per-CCD exposure maps (parallelized) ##
+        expmap_limit = 6
+        if nchips > 1:
+            expmap_limit += nchips
+
+        img_mem_use = (expmap_limit * self.filesize) + file_buffer
+
+        return img_mem_use
+
+
+    def _psfmap_memory(self, nchips:int) -> int:
+        """
+        regardless of number of CCDs, memory used to generate an observation's
+        PSF map is a little less than 7*filesize
+        """
+
+        psfmap_limit = 7.285 + (0.03 * nchips)
+
+        psfmap_mem = psfmap_limit * self.filesize
+
+        return psfmap_mem
+
+
+    def project_parallel_memory(self):
+        _, mem_available = self._get_system_memory()
+
+        nchips_arr = self._nchips_arr
+
+        if self.nstk > self.ncore:
+            def _sublists(lst:list|tuple, step:int) -> list[list]:
+                sublists = []
+
+                match lst:
+                    case list():
+                        len_lst = len(lst)
+                    case tuple():
+                        len_lst = lst.__len__()
+
+                for i in range(0, len_lst, step):
+                    sublists.append(list(islice(lst, i, i+step)))
+
+                return sublists
+
+            _nchips_grp = _sublists(nchips_arr, self.ncore)[0]
+
+        else:
+            _nchips_grp = nchips_arr
+
+        expmap_mem = [self._expmap_memory(n) for n in _nchips_grp]
+        expmap_mem_limit = sum(expmap_mem)
+
+        psfmap_mem = [self._psfmap_memory(n) for n in _nchips_grp]
+        psfmap_mem_limit = sum(psfmap_mem)
+
+        if psfmap_mem_limit > expmap_mem_limit:
+            mem_limit = psfmap_mem_limit
+            mem = psfmap_mem
+        else:
+            mem_limit = expmap_mem_limit
+            mem = expmap_mem
+
+        if mem_limit > mem_available:
+            while sum(mem) > mem_available:
+                _ = mem.pop()
+
+            ncore_mem_lim = len(mem)
+
+            if ncore_mem_lim == 0:
+                raise MemoryError("There is insufficient system memory available to run processes to completion on a single core.")
+
+            if ncore_mem_lim == 1:
+                ncore_str = f"{ncore_mem_lim}"
+            else:
+                ncore_str = f"{ncore_mem_lim} or less"
+
+            raise MemoryError(f"There is insufficient system memory available to run processes in parallel, consider reducing the number of cores used to {ncore_str}.")
+
+
+    def check_stk_counts_memory(self):
+        file_buffer = 27_262_976 # buffer of 26 Mb in bytes
+        _, mem_available = self._get_system_memory()
+        chunk = self.nstk
+        _chunk_floor = 10
+
+        ## stacking counts maps (serialized) ##
+        counts_map_limit = 12
+        if self.nstk > 1:
+            counts_map_limit += (2 * self.nstk)
+
+        expected_size = (counts_map_limit * self.filesize) + file_buffer
+        # available_chunks = (mem_available - file_buffer)/self.filesize
+        # memchunks = expected_size/mem_available
+
+        if expected_size < mem_available:
+            return
+
+        ## size needed to stack two images ##
+        if (16 * self.filesize) + file_buffer > mem_available:
+            raise MemoryError("There is insufficient system memory available to co-add counts images!")
+
+        while chunk > 1:
+            _countslim = (12 + 2*chunk) * self.filesize + file_buffer
+
+            if _countslim < mem_available and chunk > _chunk_floor:
+                chunk = 10 * (chunk//10)
+
+                return chunk
+
+            chunk -= 1
+
+        v0("There may be insufficient system memory availble to co-add counts images!")
+
+
+    def check_stk_psfmap_memory(self):
+        _, mem_available = self._get_system_memory()
+        chunk = self.nstk
+        _chunk_floor = 10
+
+        def _memuse_fit(nstk:int):
+            return 1.69863 + 1.37718 * nstk**0.990286
+
+        ## stacking counts maps (serialized) ##
+        psfmap_limit = _memuse_fit(self.nstk)
+
+        expected_size = psfmap_limit * self.filesize
+
+        if expected_size < mem_available:
+            return
+
+        ## size needed to stack two images ##
+        if _memuse_fit(nstk=2) > mem_available:
+            raise MemoryError("There is insufficient system memory available to co-add PSF maps!")
+
+        while chunk > 1:
+            _countslim = _memuse_fit(nstk=chunk) * self.filesize
+
+            if _countslim < mem_available and chunk > _chunk_floor:
+                chunk = 10 * (chunk//10)
+
+                return chunk
+
+            chunk -= 1
+
+        v0("There may be insufficient system memory availble to co-add PSF maps!")
+
+#################################################################################
 
 
 def add_defargs(args, clobber, verbose):

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -62,18 +62,14 @@ import ciao_contrib.logger_wrapper as lw
 from ciao_contrib.runtool import new_pfiles_environment
 from ciao_contrib.runtool import add_tool_history
 
-from ciao_contrib._tools import fileio
+import ciao_contrib._tools.fileio as fileio
 from ciao_contrib._tools.obsinfo import ObsInfo
-from ciao_contrib._tools import utils
+import ciao_contrib._tools.utils as utils
 
-from ciao_contrib._tools import run
+import ciao_contrib._tools.run as run
 from ciao_contrib._tools.run import \
     punlearn, dmcopy, dmimgcalc, dmimgcalc2, dmimgcalc_add, \
     dmhedit_key, dmhedit_file
-
-from psutil import virtual_memory, cpu_count
-from itertools import islice
-
 
 # for now, export nothing
 __all__ = ()
@@ -83,205 +79,10 @@ __all__ = ()
 HRCI_BG_EVTS = "HRC-I_bkg.fits"
 
 lgr = lw.initialize_module_logger('_tools.fluximage')
-v0 = lgr.verbose0
 v1 = lgr.verbose1
 v2 = lgr.verbose2
 v3 = lgr.verbose3
 v4 = lgr.verbose4
-
-#################################################################################
-class Project_Memory_Use:
-    """
-    Estimate memory usage to generate exposure maps and PSF maps and when
-    stacking counts maps and PSF maps, which are the most memory intensive
-    steps in fluximage and flux_obs, which may lead the exhausting system
-    memory.  Return a chunk size for stacking purposes that hopefully avoids
-    using too much memory or error message with a suggestion on limiting the
-    number of logical cores used for parallel proceses to avoid memory exhaustion.
-    """
-
-    def __init__(self, evtfiles:list|tuple, filesize:int, ncore:int|str|None):
-        #self.evts = evtfiles
-        self.filesize = filesize
-        self._nchips_arr = sorted( ( len(fileio.get_ccds(e)) for e in evtfiles ), reverse=True )
-        self.nstk = len(self._nchips_arr)
-
-        if ncore is None:
-            self.ncore = cpu_count(logical=True)
-        else:
-            self.ncore = int(ncore)
-
-
-    def __enter__(self):
-        return self
-
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        return exc_traceback is None
-
-
-    def _get_system_memory(self) -> tuple[int,int]: # in bytes
-        """
-        return total memory on the system and available memory
-        for use at the time
-        """
-
-        _mem = virtual_memory()
-        total = _mem.total # total physical memory #
-        available = _mem.available # available physical memory (not being used by system processes) #
-
-        return total, available
-
-
-    def _expmap_memory(self, nchips:int) -> int:
-        file_buffer = 27_262_976 # buffer of 26 Mb in bytes
-
-        ## mosaicking an observation's per-CCD exposure maps (parallelized) ##
-        expmap_limit = 6
-        if nchips > 1:
-            expmap_limit += nchips
-
-        img_mem_use = (expmap_limit * self.filesize) + file_buffer
-
-        return img_mem_use
-
-
-    def _psfmap_memory(self, nchips:int) -> int:
-        """
-        regardless of number of CCDs, memory used to generate an observation's
-        PSF map is a little less than 7*filesize
-        """
-
-        psfmap_limit = 7.285 + (0.03 * nchips)
-
-        psfmap_mem = psfmap_limit * self.filesize
-
-        return psfmap_mem
-
-
-    def project_parallel_memory(self):
-        _, mem_available = self._get_system_memory()
-
-        nchips_arr = self._nchips_arr
-
-        if self.nstk > self.ncore:
-            def _sublists(lst:list|tuple, step:int) -> list[list]:
-                sublists = []
-
-                match lst:
-                    case list():
-                        len_lst = len(lst)
-                    case tuple():
-                        len_lst = lst.__len__()
-
-                for i in range(0, len_lst, step):
-                    sublists.append(list(islice(lst, i, i+step)))
-
-                return sublists
-
-            _nchips_grp = _sublists(nchips_arr, self.ncore)[0]
-
-        else:
-            _nchips_grp = nchips_arr
-
-        expmap_mem = [self._expmap_memory(n) for n in _nchips_grp]
-        expmap_mem_limit = sum(expmap_mem)
-
-        psfmap_mem = [self._psfmap_memory(n) for n in _nchips_grp]
-        psfmap_mem_limit = sum(psfmap_mem)
-
-        if psfmap_mem_limit > expmap_mem_limit:
-            mem_limit = psfmap_mem_limit
-            mem = psfmap_mem
-        else:
-            mem_limit = expmap_mem_limit
-            mem = expmap_mem
-
-        if mem_limit > mem_available:
-            while sum(mem) > mem_available:
-                _ = mem.pop()
-
-            ncore_mem_lim = len(mem)
-
-            if ncore_mem_lim == 0:
-                raise MemoryError("There is insufficient system memory available to run processes to completion on a single core.")
-
-            if ncore_mem_lim == 1:
-                ncore_str = f"{ncore_mem_lim}"
-            else:
-                ncore_str = f"{ncore_mem_lim} or less"
-
-            raise MemoryError(f"There is insufficient system memory available to run processes in parallel, consider reducing the number of cores used to {ncore_str}.")
-
-
-    def check_stk_counts_memory(self):
-        file_buffer = 27_262_976 # buffer of 26 Mb in bytes
-        _, mem_available = self._get_system_memory()
-        chunk = self.nstk
-        _chunk_floor = 10
-
-        ## stacking counts maps (serialized) ##
-        counts_map_limit = 12
-        if self.nstk > 1:
-            counts_map_limit += (2 * self.nstk)
-
-        expected_size = (counts_map_limit * self.filesize) + file_buffer
-        # available_chunks = (mem_available - file_buffer)/self.filesize
-        # memchunks = expected_size/mem_available
-
-        if expected_size < mem_available:
-            return
-
-        ## size needed to stack two images ##
-        if (16 * self.filesize) + file_buffer > mem_available:
-            raise MemoryError("There is insufficient system memory available to co-add counts images!")
-
-        while chunk > 1:
-            _countslim = (12 + 2*chunk) * self.filesize + file_buffer
-
-            if _countslim < mem_available and chunk > _chunk_floor:
-                chunk = 10 * (chunk//10)
-
-                return chunk
-
-            chunk -= 1
-
-        v0("There may be insufficient system memory availble to co-add counts images!")
-
-
-    def check_stk_psfmap_memory(self):
-        _, mem_available = self._get_system_memory()
-        chunk = self.nstk
-        _chunk_floor = 10
-
-        def _memuse_fit(nstk:int):
-            return 1.69863 + 1.37718 * nstk**0.990286
-
-        ## stacking counts maps (serialized) ##
-        psfmap_limit = _memuse_fit(self.nstk)
-
-        expected_size = psfmap_limit * self.filesize
-
-        if expected_size < mem_available:
-            return
-
-        ## size needed to stack two images ##
-        if _memuse_fit(nstk=2) > mem_available:
-            raise MemoryError("There is insufficient system memory available to co-add PSF maps!")
-
-        while chunk > 1:
-            _countslim = _memuse_fit(nstk=chunk) * self.filesize
-
-            if _countslim < mem_available and chunk > _chunk_floor:
-                chunk = 10 * (chunk//10)
-
-                return chunk
-
-            chunk -= 1
-
-        v0("There may be insufficient system memory availble to co-add PSF maps!")
-
-#################################################################################
 
 
 def add_defargs(args, clobber, verbose):

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -2319,11 +2319,7 @@ def read_first_row(filename, colname, patch_ssc=False):
 
     ##############################
 
-<<<<<<< HEAD
-    cr = pcr.read_file(filename + "[#row=1]")
-=======
     cr = pcr.read_file(f"{filename}[#row=1]")
->>>>>>> e171659 (ahelp updated; string linting to make use of f-string in some lower-level scripts for readability)
     return pcr.copy_colvals(cr, colname)[0]
 
 

--- a/ciao_contrib/_tools/fluximage.py
+++ b/ciao_contrib/_tools/fluximage.py
@@ -52,6 +52,9 @@ import tempfile
 import shutil
 import subprocess as sbp
 
+from itertools import islice
+from psutil import virtual_memory, cpu_count
+
 import numpy as np
 
 import paramio
@@ -62,14 +65,15 @@ import ciao_contrib.logger_wrapper as lw
 from ciao_contrib.runtool import new_pfiles_environment
 from ciao_contrib.runtool import add_tool_history
 
-import ciao_contrib._tools.fileio as fileio
+from ciao_contrib._tools import fileio
 from ciao_contrib._tools.obsinfo import ObsInfo
-import ciao_contrib._tools.utils as utils
+from ciao_contrib._tools import utils
 
-import ciao_contrib._tools.run as run
+from ciao_contrib._tools import run
 from ciao_contrib._tools.run import \
     punlearn, dmcopy, dmimgcalc, dmimgcalc2, dmimgcalc_add, \
     dmhedit_key, dmhedit_file
+
 
 # for now, export nothing
 __all__ = ()
@@ -79,10 +83,205 @@ __all__ = ()
 HRCI_BG_EVTS = "HRC-I_bkg.fits"
 
 lgr = lw.initialize_module_logger('_tools.fluximage')
+v0 = lgr.verbose0
 v1 = lgr.verbose1
 v2 = lgr.verbose2
 v3 = lgr.verbose3
 v4 = lgr.verbose4
+
+#################################################################################
+class Project_Memory_Use:
+    """
+    Estimate memory usage to generate exposure maps and PSF maps and when
+    stacking counts maps and PSF maps, which are the most memory intensive
+    steps in fluximage and flux_obs, which may lead the exhausting system
+    memory.  Return a chunk size for stacking purposes that hopefully avoids
+    using too much memory or error message with a suggestion on limiting the
+    number of logical cores used for parallel proceses to avoid memory exhaustion.
+    """
+
+    def __init__(self, evtfiles:list|tuple, filesize:int, ncore:int|str|None):
+        #self.evts = evtfiles
+        self.filesize = filesize
+        self._nchips_arr = sorted( ( len(fileio.get_ccds(e)) for e in evtfiles ), reverse=True )
+        self.nstk = len(self._nchips_arr)
+
+        if ncore is None:
+            self.ncore = cpu_count(logical=True)
+        else:
+            self.ncore = int(ncore)
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        return exc_traceback is None
+
+
+    def _get_system_memory(self) -> tuple[int,int]: # in bytes
+        """
+        return total memory on the system and available memory
+        for use at the time
+        """
+
+        _mem = virtual_memory()
+        total = _mem.total # total physical memory #
+        available = _mem.available # available physical memory (not being used by system processes) #
+
+        return total, available
+
+
+    def _expmap_memory(self, nchips:int) -> int:
+        file_buffer = 27_262_976 # buffer of 26 Mb in bytes
+
+        ## mosaicking an observation's per-CCD exposure maps (parallelized) ##
+        expmap_limit = 6
+        if nchips > 1:
+            expmap_limit += nchips
+
+        img_mem_use = (expmap_limit * self.filesize) + file_buffer
+
+        return img_mem_use
+
+
+    def _psfmap_memory(self, nchips:int) -> int:
+        """
+        regardless of number of CCDs, memory used to generate an observation's
+        PSF map is a little less than 7*filesize
+        """
+
+        psfmap_limit = 7.285 + (0.03 * nchips)
+
+        psfmap_mem = psfmap_limit * self.filesize
+
+        return psfmap_mem
+
+
+    def project_parallel_memory(self):
+        _, mem_available = self._get_system_memory()
+
+        nchips_arr = self._nchips_arr
+
+        if self.nstk > self.ncore:
+            def _sublists(lst:list|tuple, step:int) -> list[list]:
+                sublists = []
+
+                match lst:
+                    case list():
+                        len_lst = len(lst)
+                    case tuple():
+                        len_lst = lst.__len__()
+
+                for i in range(0, len_lst, step):
+                    sublists.append(list(islice(lst, i, i+step)))
+
+                return sublists
+
+            _nchips_grp = _sublists(nchips_arr, self.ncore)[0]
+
+        else:
+            _nchips_grp = nchips_arr
+
+        expmap_mem = [self._expmap_memory(n) for n in _nchips_grp]
+        expmap_mem_limit = sum(expmap_mem)
+
+        psfmap_mem = [self._psfmap_memory(n) for n in _nchips_grp]
+        psfmap_mem_limit = sum(psfmap_mem)
+
+        if psfmap_mem_limit > expmap_mem_limit:
+            mem_limit = psfmap_mem_limit
+            mem = psfmap_mem
+        else:
+            mem_limit = expmap_mem_limit
+            mem = expmap_mem
+
+        if mem_limit > mem_available:
+            while sum(mem) > mem_available:
+                _ = mem.pop()
+
+            ncore_mem_lim = len(mem)
+
+            if ncore_mem_lim == 0:
+                raise MemoryError("There is insufficient system memory available to run processes to completion on a single core.")
+
+            if ncore_mem_lim == 1:
+                ncore_str = f"{ncore_mem_lim}"
+            else:
+                ncore_str = f"{ncore_mem_lim} or less"
+
+            raise MemoryError(f"There is insufficient system memory available to run processes in parallel, consider reducing the number of cores used to {ncore_str}.")
+
+
+    def check_stk_counts_memory(self):
+        file_buffer = 27_262_976 # buffer of 26 Mb in bytes
+        _, mem_available = self._get_system_memory()
+        chunk = self.nstk
+        _chunk_floor = 10
+
+        ## stacking counts maps (serialized) ##
+        counts_map_limit = 12
+        if self.nstk > 1:
+            counts_map_limit += (2 * self.nstk)
+
+        expected_size = (counts_map_limit * self.filesize) + file_buffer
+        # available_chunks = (mem_available - file_buffer)/self.filesize
+        # memchunks = expected_size/mem_available
+
+        if expected_size < mem_available:
+            return
+
+        ## size needed to stack two images ##
+        if (16 * self.filesize) + file_buffer > mem_available:
+            raise MemoryError("There is insufficient system memory available to co-add counts images!")
+
+        while chunk > 1:
+            _countslim = (12 + 2*chunk) * self.filesize + file_buffer
+
+            if _countslim < mem_available and chunk > _chunk_floor:
+                chunk = 10 * (chunk//10)
+
+                return chunk
+
+            chunk -= 1
+
+        v0("There may be insufficient system memory availble to co-add counts images!")
+
+
+    def check_stk_psfmap_memory(self):
+        _, mem_available = self._get_system_memory()
+        chunk = self.nstk
+        _chunk_floor = 10
+
+        def _memuse_fit(nstk:int):
+            return 1.69863 + 1.37718 * nstk**0.990286
+
+        ## stacking counts maps (serialized) ##
+        psfmap_limit = _memuse_fit(self.nstk)
+
+        expected_size = psfmap_limit * self.filesize
+
+        if expected_size < mem_available:
+            return
+
+        ## size needed to stack two images ##
+        if _memuse_fit(nstk=2) > mem_available:
+            raise MemoryError("There is insufficient system memory available to co-add PSF maps!")
+
+        while chunk > 1:
+            _countslim = _memuse_fit(nstk=chunk) * self.filesize
+
+            if _countslim < mem_available and chunk > _chunk_floor:
+                chunk = 10 * (chunk//10)
+
+                return chunk
+
+            chunk -= 1
+
+        v0("There may be insufficient system memory availble to co-add PSF maps!")
+
+#################################################################################
 
 
 def add_defargs(args, clobber, verbose):
@@ -105,9 +304,7 @@ def add_band_keywords(infile, enband, tmpdir="/tmp"):
     if enband.loval is None and enband.hival is None:
         return
 
-    tfile = tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+',
-                                        suffix=".band.keys")
-    try:
+    with tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+', suffix=".band.keys") as tfile:
         tfile.write("#add\n")
         tfile.write(f"COMMENT =Adding keywords for band={enband.bandlabel}\n")
         if enband.colname == "energy":
@@ -125,8 +322,6 @@ def add_band_keywords(infile, enband, tmpdir="/tmp"):
         tfile.flush()
 
         dmhedit_file(infile, tfile.name, verbose=0)
-    finally:
-        tfile.close()
 
 
 def add_dmh_keyword(fh, keyval):
@@ -184,9 +379,7 @@ def copy_keywords(infile, outfile, keynames, tmpdir="/tmp"):
     if vals == []:
         return
 
-    tfile = tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+',
-                                        suffix=".copy.keys")
-    try:
+    with tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+', suffix=".copy.keys") as tfile:
         tfile.write("#add\n")
         tfile.write("COMMENT = Copying over keywords from " + infile)
         tfile.write("\n")
@@ -196,8 +389,6 @@ def copy_keywords(infile, outfile, keynames, tmpdir="/tmp"):
 
         tfile.flush()
         dmhedit_file(outfile, tfile.name, verbose=0)
-    finally:
-        tfile.close()
 
 
 def cleanup_files_task(filenames, msg=None):
@@ -441,7 +632,7 @@ def fluximage_output(outdir, outhead, obsinfos, enbands,
     # TODO: SHOULD THIS BE SENT IN THE CLEANUP STATUS?
 
     def start():
-        return dict([(enband.bandlabel, []) for enband in enbands])
+        return { enband.bandlabel : [] for enband in enbands }
 
     # keys are energy band (as a string) and values are the list
     # of files in obsid order.
@@ -865,9 +1056,7 @@ def scale_hrci_background(enband,
     # Keywords to copy across to the output image
     okeys = _get_keywords(rawimg, ["ONTIME", "LIVETIME", "EXPOSURE"])
 
-    tfile = tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+',
-                                        suffix=".hrci.keys")
-    try:
+    with tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+', suffix=".hrci.keys") as tfile:
         tfile.write("#add\n")
 
         for okey in okeys:
@@ -898,9 +1087,6 @@ def scale_hrci_background(enband,
 
         tfile.flush()
         dmhedit_file(img, tfile.name, verbose=0)
-
-    finally:
-        tfile.close()
 
 
 def make_images_hrci(enbands,
@@ -986,14 +1172,13 @@ def create_event_image(infile, outfile,
     """
 
     v4(f"Binning up {infile} to {outfile}")
-    tmpfile = tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.img')
-
-    # As we want to exclude the GTI blocks we do not want to
-    # use option=all here (probably could still use it, but
-    # have not tested it and this code works, so do not change it).
-    dmcopy(infile, tmpfile.name, clobber=True, verbose=verbose)
-    dmcopy(tmpfile.name + "[subspace - time]", outfile,
-           clobber=clobber, verbose=verbose)
+    with tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.img') as tmpfile:
+        # As we want to exclude the GTI blocks we do not want to
+        # use option=all here (probably could still use it, but
+        # have not tested it and this code works, so do not change it).
+        dmcopy(infile, tmpfile.name, clobber=True, verbose=verbose)
+        dmcopy(tmpfile.name + "[subspace - time]", outfile,
+               clobber=clobber, verbose=verbose)
 
 
 # TODO:
@@ -1176,8 +1361,7 @@ def background_subtract_hrci(taskrunner, labelconv, preconditions,
                             "HRC-I background events file")
         return etask2
 
-    else:
-        return etask
+    return etask
 
 
 def get_imap_nbins(maxsize, npixels):
@@ -1839,9 +2023,8 @@ def run_mkpsfmap(outfile, matchfile, energy, wgtfile, ecf,
     else:
         infile = f"{matchfile}[sky=MASK({maskfile})]"
 
-    mapfile = tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.psfmap')
 
-    with new_pfiles_environment(ardlib=False, copyuser=False, tmpdir=tmpdir):
+    with new_pfiles_environment(ardlib=False, copyuser=False, tmpdir=tmpdir), tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.psfmap') as mapfile:
         punlearn("mkpsfmap")
         args = [f"infile={infile}",
                 f"outfile={mapfile.name}[PSFMAP]",
@@ -2136,7 +2319,11 @@ def read_first_row(filename, colname, patch_ssc=False):
 
     ##############################
 
+<<<<<<< HEAD
     cr = pcr.read_file(filename + "[#row=1]")
+=======
+    cr = pcr.read_file(f"{filename}[#row=1]")
+>>>>>>> e171659 (ahelp updated; string linting to make use of f-string in some lower-level scripts for readability)
     return pcr.copy_colvals(cr, colname)[0]
 
 
@@ -2189,12 +2376,11 @@ def _find_blanksky_hrci_caldb(evtfile, verbose=True, tmpdir=None):
         # below.
         #
         # punlearn("hrc_bkgrnd_lookup")
-        devnull = open('/dev/null', 'w')
-        hbl_status = sbp.call(["hrc_bkgrnd_lookup",
-                               evtfile,
-                               "event"],
-                              stdout=devnull, stderr=devnull)
-        devnull.close()
+        with open('/dev/null', 'w') as devnull:
+            hbl_status = sbp.call(["hrc_bkgrnd_lookup",
+                                   evtfile,
+                                   "event"],
+                                  stdout=devnull, stderr=devnull)
 
         if hbl_status != 0:
             v3(" . hrc_bkgrnd_lookup call failed")
@@ -2349,30 +2535,31 @@ def blanksky_hrci(caldbfile, infile, tmpdir, obsid, verbose):
 
     v1(f"Setting up the HRC-I background for obsid {obsid}")
 
-    bkg_stat = tempfile.NamedTemporaryFile(dir=tmpdir,
-                                           suffix='.bkgevt')
-    dmfilt = fileio.get_filter(caldbfile)
-    if dmfilt == "":
-        v2("Background file contains no DM filter, so can copy it")
-        shutil.copyfile(caldbfile, bkg_stat.name)
+    ofile = tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.bkgevt')
 
-    else:
-        v2(f"Background file contains a DM filter ({dmfilt})" +
-           " so need to dmcopy it")
-        # Only expect a single block in the background files, so
-        # do not need to add in option="all" here
-        dmcopy(caldbfile, bkg_stat.name, clobber=True, verbose="0")
+    with new_pfiles_environment(ardlib=False, copyuser=False, tmpdir=tmpdir), \
+        tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.bkgevt') as bkg_stat, \
+        tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.hdr') as header, \
+        tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+', suffix='.par') as pnt:
 
-    ofile = tempfile.NamedTemporaryFile(dir=tmpdir,
-                                        suffix='.bkgevt')
+        dmfilt = fileio.get_filter(caldbfile)
 
-    with new_pfiles_environment(ardlib=False, copyuser=False, tmpdir=tmpdir):
+        if dmfilt == "":
+            v2("Background file contains no DM filter, so can copy it")
+            shutil.copyfile(caldbfile, bkg_stat.name)
+
+        else:
+            v2(f"Background file contains a DM filter ({dmfilt})" +
+               " so need to dmcopy it")
+            # Only expect a single block in the background files, so
+            # do not need to add in option="all" here
+            dmcopy(caldbfile, bkg_stat.name, clobber=True, verbose="0")
 
         # Find the status filter used to create infile
         statfilter = find_status_filter(infile, obsid, tmpdir=tmpdir)
 
         # punlearn("dmmakepar")
-        header = tempfile.NamedTemporaryFile(dir=tmpdir, suffix='.hdr')
+
         args = ["input=" + infile,
                 "output=" + header.name,
                 "verbose=0",
@@ -2411,24 +2598,18 @@ def blanksky_hrci(caldbfile, infile, tmpdir, obsid, verbose):
             + ["btimdrft", "btimnull", "btimrate"] \
             + ["obi_num"]
 
-        pnt = tempfile.NamedTemporaryFile(dir=tmpdir, mode='w+',
-                                          suffix='.par')
-        h = open(header.name)
-        p = open(pnt.name, "w")
-        has_obi_num = False
-        for line in h:
-            term = line.split(",", 1)[0]
-            if term in wanted_terms:
-                p.write(line)
-            if not has_obi_num and (term == "obi_num"):
-                has_obi_num = True
+        with open(header.name) as h, open(pnt.name, "w") as p:
+            has_obi_num = False
+            for line in h:
+                term = line.split(",", 1)[0]
+                if term in wanted_terms:
+                    p.write(line)
+                if not has_obi_num and (term == "obi_num"):
+                    has_obi_num = True
 
-        # add in the STATFILT keyword
-        p.write(f'statfilt,s,h,"{statfilter}",,,"STATUS filter"\n')
+            # add in the STATFILT keyword
+            p.write(f'statfilt,s,h,"{statfilter}",,,"STATUS filter"\n')
 
-        h.close()
-        p.close()
-        header.close()
 
         # update background header
         # punlearn("dmreadpar")
@@ -2438,8 +2619,6 @@ def blanksky_hrci(caldbfile, infile, tmpdir, obsid, verbose):
                 "clobber=yes",
                 "mode=h"]
         run.run("dmreadpar", args)
-
-        pnt.close()
 
         if not has_obi_num:
             try:
@@ -2460,7 +2639,6 @@ def blanksky_hrci(caldbfile, infile, tmpdir, obsid, verbose):
                ofile.name,
                verbose=verbose, clobber=True)
 
-    bkg_stat.close()
     return ofile
 
 

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -2895,11 +2895,7 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
             expmap_weight(pmap_files, emap_files, out, lut)
 
         else:
-<<<<<<< HEAD
             raise ValueError(f"Unexpected mergetype={mergetype} for combining PSF maps")
-=======
-            raise ValueError("Unexpected mergetype={} for combining PSF maps".format(mergetype))
->>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
 
 
     if nchunk is None or mergetype in ["exptime", "expmap"]:
@@ -2930,12 +2926,8 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
 
                 dmfilt_stk([_d.name for _d in d], f"{_tmp.name}[PSFMAP]", mergetype)
 
-<<<<<<< HEAD
                 for _d in d:
                     _d.close()
-=======
-                for _d in d: _d.close()
->>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
 
             _iter += 1
             tmplist = _tmplist
@@ -2945,12 +2937,8 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
 
         dmfilt_stk(tmp_fn, outfile, mergetype)
 
-<<<<<<< HEAD
         for t in tmplist:
             t.close()
-=======
-        for t in tmplist: t.close()
->>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
 
     run.fix_bunit(psfmap_files[0], psfmap, verbose=verbose)
 
@@ -3235,17 +3223,8 @@ def _check_open_file_limits(nfiles: int, Ntemp: int = 4, Npad: int = 20) -> None
     if softlim < N_open_file:
         resource.setrlimit(open_file_lim, (N_open_file, hardlim))
 
-<<<<<<< HEAD
-<<<<<<< HEAD
         return True
 
     return False
-=======
->>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
-=======
-        return True
-
-    return False
->>>>>>> 088affd (_check_open_file_limits returns True if limits adjusted)
 
 # End

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -3236,10 +3236,16 @@ def _check_open_file_limits(nfiles: int, Ntemp: int = 4, Npad: int = 20) -> None
         resource.setrlimit(open_file_lim, (N_open_file, hardlim))
 
 <<<<<<< HEAD
+<<<<<<< HEAD
         return True
 
     return False
 =======
 >>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
+=======
+        return True
+
+    return False
+>>>>>>> 088affd (_check_open_file_limits returns True if limits adjusted)
 
 # End

--- a/ciao_contrib/_tools/merging.py
+++ b/ciao_contrib/_tools/merging.py
@@ -2895,7 +2895,11 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
             expmap_weight(pmap_files, emap_files, out, lut)
 
         else:
+<<<<<<< HEAD
             raise ValueError(f"Unexpected mergetype={mergetype} for combining PSF maps")
+=======
+            raise ValueError("Unexpected mergetype={} for combining PSF maps".format(mergetype))
+>>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
 
 
     if nchunk is None or mergetype in ["exptime", "expmap"]:
@@ -2926,8 +2930,12 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
 
                 dmfilt_stk([_d.name for _d in d], f"{_tmp.name}[PSFMAP]", mergetype)
 
+<<<<<<< HEAD
                 for _d in d:
                     _d.close()
+=======
+                for _d in d: _d.close()
+>>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
 
             _iter += 1
             tmplist = _tmplist
@@ -2937,8 +2945,12 @@ def merge_psfmaps(mergetype, psfmap, psfmap_files, expmap_files,
 
         dmfilt_stk(tmp_fn, outfile, mergetype)
 
+<<<<<<< HEAD
         for t in tmplist:
             t.close()
+=======
+        for t in tmplist: t.close()
+>>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
 
     run.fix_bunit(psfmap_files[0], psfmap, verbose=verbose)
 
@@ -3223,8 +3235,11 @@ def _check_open_file_limits(nfiles: int, Ntemp: int = 4, Npad: int = 20) -> None
     if softlim < N_open_file:
         resource.setrlimit(open_file_lim, (N_open_file, hardlim))
 
+<<<<<<< HEAD
         return True
 
     return False
+=======
+>>>>>>> 117b411 (estimate memory usage to generate exposure and PSF maps and stacking counts and PSF maps; if it's estimated that system memory will be exhausted, a warning is thrown on limiting the number of cores used for parallelized processes or will alter the stack chunksize to co-add at a time)
 
 # End

--- a/ciao_contrib/_tools/run.py
+++ b/ciao_contrib/_tools/run.py
@@ -52,7 +52,7 @@ import ciao_contrib.logger_wrapper as lw
 
 from ciao_contrib.stacklib import make_stackfile
 import ciao_contrib.runtool as rt
-import ciao_contrib._tools.fileio as fileio
+from ciao_contrib._tools import fileio
 
 
 __all__ = (
@@ -279,7 +279,8 @@ def dmimgcalc_add(infiles, outfile,
                   clobber=False,
                   lookupTab=None,
                   tmpdir="/tmp/",
-                  nchunk=100):
+                  nchunk=100,
+                  bigN_smallNchunk_bypass=False):
     """Add up all the images in infiles (an array) to create outfile,
     using dmimgcalc.
 
@@ -321,7 +322,7 @@ def dmimgcalc_add(infiles, outfile,
 
     # We could recurse, but let's error out if we have too-many
     # files.
-    if chunking >= nchunk:
+    if chunking >= nchunk and not bigN_smallNchunk_bypass:
         raise ValueError(f"Sent too many images to add: {nfiles}")
 
     start = 0
@@ -335,7 +336,8 @@ def dmimgcalc_add(infiles, outfile,
         dmimgcalc_add(filelist, tmpfile.name,
                       verbose=verbose, clobber=True,
                       lookupTab=lookupTab, tmpdir=tmpdir,
-                      nchunk=nchunk)
+                      nchunk=nchunk,
+                      bigN_smallNchunk_bypass=bigN_smallNchunk_bypass)
 
         start += nchunk
 
@@ -344,7 +346,8 @@ def dmimgcalc_add(infiles, outfile,
     dmimgcalc_add([t.name for t in tmpfiles], outfile,
                   verbose=verbose, clobber=clobber,
                   lookupTab=lookupTab, tmpdir=tmpdir,
-                  nchunk=nchunk)
+                  nchunk=nchunk,
+                  bigN_smallNchunk_bypass=bigN_smallNchunk_bypass)
 
 
 def dmkeypar(infile, key, rtype='string'):
@@ -566,7 +569,7 @@ def make_fov(evtfile, asolfiles, msk, outfile):
     """
 
     afiles = stk.build(asolfiles)
-    contents = set([get_content(f) for f in afiles])
+    contents = { get_content(f) for f in afiles }
     if len(contents) != 1:
         emsg = f"Multiple types of aspect solution found: " + \
             f"{', '.join(contents)}\n  {asolfiles}"

--- a/ciao_contrib/_tools/run.py
+++ b/ciao_contrib/_tools/run.py
@@ -81,15 +81,15 @@ def run(tname, targs):
     IOError on failure. Logs the command and arguments at the DEBUG level.
     """
 
-    v2(">> Running {}".format(tname))
-    v2(">>   args: {}".format(targs))
+    v2(f">> Running {tname}")
+    v2(f">>   args: {targs}")
 
     args = [tname]
     args.extend(targs)
     rval = sbp.call(args)
     if rval != 0:
         argstr = " ".join(targs)
-        raise IOError("Unable to run {} with arguments: {}".format(tname, argstr))
+        raise IOError(f"Unable to run {tname} with arguments: {argstr}")
 
 
 def add_defargs(args, clobber, verbose):
@@ -143,13 +143,13 @@ def dmcopy(infile, outfile,
         print(f"*** Internal warning: dmcopy clobber={clobber}")
         clobber = clobber == "yes"
 
-    v3("Copying <{}> to <{}>".format(infile, outfile))
+    v3(f"Copying <{infile}> to <{outfile}>")
     punlearn("dmcopy")
-    args = ["infile=" + infile,
-            "outfile=" + outfile,
+    args = [f"infile={infile}",
+            f"outfile={outfile}",
             "mode=h"]
     if option is not None:
-        args.append("option=" + option)
+        args.append(f"option={option}")
     add_defargs(args, clobber, verbose)
     run("dmcopy", args)
 
@@ -327,6 +327,7 @@ def dmimgcalc_add(infiles, outfile,
 
     start = 0
     tmpfiles = []
+
     while start < nfiles:
         filelist = infiles[start:start + nchunk]
         v3(f" - summing chunk of {len(filelist)} files")
@@ -349,6 +350,10 @@ def dmimgcalc_add(infiles, outfile,
                   nchunk=nchunk,
                   bigN_smallNchunk_bypass=bigN_smallNchunk_bypass)
 
+    if not tmpfiles:
+        for t in tmpfiles:
+            t.close()
+
 
 def dmkeypar(infile, key, rtype='string'):
     """Run dmkeypar and return the value; errors out on failure.
@@ -369,7 +374,7 @@ def dmkeypar(infile, key, rtype='string'):
     try:
         func = funcs[rtype]
     except KeyError:
-        raise ValueError("Invalid rtype argument '{}'".format(rtype))
+        raise ValueError(f"Invalid rtype argument '{rtype}'")
 
     run('dmkeypar', ["infile=" + infile,
                      "keyword=" + key,
@@ -378,8 +383,8 @@ def dmkeypar(infile, key, rtype='string'):
     rval = func('dmkeypar', 'value')
     if rtype == 'bool':
         return (rval == 1)
-    else:
-        return rval
+
+    return rval
 
 
 def dmhedit_key(infile, key, value, comment=None, unit=None, verbose=0):
@@ -399,8 +404,8 @@ def dmhedit_key(infile, key, value, comment=None, unit=None, verbose=0):
         v = str(v)
         if v.find('/') == -1:
             return v
-        else:
-            return "'{}'".format(v)
+
+        return f"'{v}'"
 
     dmh = rt.make_tool("dmhedit")
     if comment is not None:
@@ -571,8 +576,7 @@ def make_fov(evtfile, asolfiles, msk, outfile):
     afiles = stk.build(asolfiles)
     contents = { get_content(f) for f in afiles }
     if len(contents) != 1:
-        emsg = f"Multiple types of aspect solution found: " + \
-            f"{', '.join(contents)}\n  {asolfiles}"
+        emsg = f"Multiple types of aspect solution found: {', '.join(contents)}\n  {asolfiles}"
         raise OSError(emsg)
 
     content = contents.pop()

--- a/share/doc/xml/flux_obs.xml
+++ b/share/doc/xml/flux_obs.xml
@@ -1740,6 +1740,16 @@
 
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.18.2 (June 2026) release">
+      <PARA>
+	Enhanced to better handle stacking a very large number of
+	observations and to also check if there is a possibility that there
+	is insufficient usable memory available to proceed with
+	processing the given data sets and parameter settings to run
+	to completion before running the computationally expensive tasks.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.14.0 (December 2021) release">
       <PARA>
 	When using the maxsize parameter, the calculated pixel size is now
@@ -1875,7 +1885,26 @@
 	typo 'undsubtracted').
       </PARA>
     </ADESC>
-
+    
+    <ADESC title="Changes in the scripts 4.6.1 (December 2013) release">
+      <PARA title="Removal of the pbkfiles parameter">
+	The pbkfiles parameter has been removed as these files are no longer needed
+	to run mkinstmap on ACIS observations.
+	This means that it is no longer possible to turn off the
+	<HREF link="https://cxc.harvard.edu/ciao/why/acisdeadarea.html">ACIS dead-area correction</HREF>
+	for the exposure map; users who need this flexibility
+	will have to generate the exposure maps manually (e.g.
+	the
+	<HREF link="https://cxc.harvard.edu/ciao/threads/expmap_acis_single/">ACIS single-chip thread</HREF>).
+      </PARA>
+      <PARA>
+	For old data sets the removal of the pbkfile parameter can lead to
+	error messages about missing keywords;
+	in this case please download the latest archive version of your
+	observation with download_chandra_obsid and then reprocess with chandra_repro.
+      </PARA>
+    </ADESC>
+    
     <ADESC title="Changes in the scripts 4.5.4 (August 2013) release">
       <PARA>
         The description of the bands parameter has been updated to point out
@@ -1913,25 +1942,6 @@
 	none of a particular type - such as the mask file - can be found then
 	the program runs as if you has set that parameter to 'NONE', otherwise
 	the error message now tells you what observation was missing a file.
-      </PARA>
-    </ADESC>
-
-    <ADESC title="Changes in the scripts 4.6.1 (December 2013) release">
-      <PARA title="Removal of the pbkfiles parameter">
-	The pbkfiles parameter has been removed as these files are no longer needed
-	to run mkinstmap on ACIS observations.
-	This means that it is no longer possible to turn off the
-	<HREF link="https://cxc.harvard.edu/ciao/why/acisdeadarea.html">ACIS dead-area correction</HREF>
-	for the exposure map; users who need this flexibility
-	will have to generate the exposure maps manually (e.g.
-	the
-	<HREF link="https://cxc.harvard.edu/ciao/threads/expmap_acis_single/">ACIS single-chip thread</HREF>).
-      </PARA>
-      <PARA>
-	For old data sets the removal of the pbkfile parameter can lead to
-	error messages about missing keywords;
-	in this case please download the latest archive version of your
-	observation with download_chandra_obsid and then reprocess with chandra_repro.
       </PARA>
     </ADESC>
 


### PR DESCRIPTION
This update to flux_obs is primarily linting of Python 2isms into Python 3 in the lower-level files but is driven by recent helpdesk tickets where users were unable to run `merge_obs` to completion due to running out of usable system memory and swap space, either from really large FOVs or having a large number of observations.  The failure stems from `flux_obs`, and even if this fails via `merge_obs`, the reprojection step performed is still useful and those files are retained, and the user may subsequently run `flux_obs` independently.

This update will attempt to estimate the memory usage for generating the data products and stacking the subsequent images and throw an error, either suggesting a maximum number of cores to use if run in parallel or to run the process serially; furthermore, adjusting the file chunk size passed along to he stacking routines is performed to reduce memory usage if needed.

This branch can be rebased if necessary.