### PR TITLE
build script modifications for 4.18.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ packages =
     ciao_contrib/_tools
     ciao_contrib/cda
     ciao_contrib/criss_cross
+    ciao_contrib/criss_cross/tests
     coords
     crates_contrib
     dax

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def list_files(pattern):
     return sorted(files)
 
 
-VERSION = "4.17.2"
+VERSION = "4.18.2"
 for val in sys.argv:
     if val.startswith("--version="):
         VERSION = val.split("=")[1]
@@ -51,7 +51,8 @@ data_files = [
     ("share/sherpa/notebooks", list_files("share/sherpa/notebooks/*ipynb")),
     ("config", list_files("config/*")),
     ("data", list_files("data/*")),
-    ("data", list_files("ciao_contrib/criss_cross/input_files/*fits")),
+    ("data", list_files("ciao_contrib/criss_cross/input_files/*")),
+    ("criss_cross", list_files("ciao_contrib/criss_cross/*tutorial*")),
     ("data/ebounds-lut", list_files("data/ebounds-lut/*")),
     (".", ["Changes.CIAO_scripts"]),
 ]


### PR DESCRIPTION
updated `setup.cfg` and `setup.py` to include `crisscross` `pytests` and tutorial files if packaging up distribution with `python build --sdist` of if installing the package with `pip` locally or through the Git repository.