### PR TITLE
`convert_xspec_script` failing on ciao-install distribution looking for $HEADAS

### DIFF
--- a/Changes.CIAO_scripts
+++ b/Changes.CIAO_scripts
@@ -28,6 +28,11 @@ Updated Scripts
     Improve the behaviour when CIAO is installed into multiple conda
     environments.
 
+  convert_xspec_script
+
+    Improve behaviour when run using ciao-install rather than a conda
+    installation.
+
   dax
 
     The standard deviation, as reported by dmstat, is now included in

--- a/bin/convert_xspec_script
+++ b/bin/convert_xspec_script
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright (C) 2020, 2021, 2023
+# Copyright (C) 2020, 2021, 2023, 2026
 # Smithsonian Astrophysical Observatory
 #
 #
@@ -48,12 +48,15 @@ import argparse
 import os
 import sys
 
+if os.getenv("HEADAS") is None and (_headas := os.getenv("CIAO_HEADAS")) is not None:
+    os.environ["HEADAS"] = _headas
+
 import ciao_contrib.logger_wrapper as lw
 from sherpa_contrib.xspec import xcm
 
 
 TOOLNAME = "convert_xspec_script"
-TOOLVER = "11 October 2023"
+TOOLVER = "29 June 2026"
 
 lw.initialize_logger(TOOLNAME, verbose=1)
 V1 = lw.make_verbose_level(TOOLNAME, 1)
@@ -68,7 +71,7 @@ The conversion is not guaranteed to match XSPEC perfectly.
 """
 
 COPYRIGHT_STR = """
-Copyright (C) 2020, 2021, 2023
+Copyright (C) 2020, 2021, 2023, 2026
 Smithsonian Astrophysical Observatory
 
 This program is free software; you can redistribute it and/or modify

--- a/share/doc/xml/convert_xspec_script.xml
+++ b/share/doc/xml/convert_xspec_script.xml
@@ -499,6 +499,12 @@ set_source(1, m1)
       </PARA>
     </ADESC>
 
+    <ADESC title="Changes in the scripts 4.18.2 (July 2026) release">
+      <PARA>
+        Improve behaviour when run from a ciao-install installation.
+      </PARA>
+    </ADESC>
+
     <ADESC title="Changes in the scripts 4.16.0 (December 2023) release">
       <PARA title="Initial support of the ENERGIES command">
 	The <HREF
@@ -613,6 +619,6 @@ WARNING: Spectrum 1: the grouping scheme does not match OGIP standards. The filt
     </BUGS>
 -->
 
-    <LASTMODIFIED>December 2023</LASTMODIFIED>
+    <LASTMODIFIED>June 2026</LASTMODIFIED>
   </ENTRY>
 </cxchelptopics>


### PR DESCRIPTION
`convert_xspec_script` is looking for the `$HEADAS` variable with the `binexe/python` being used in the `ciao-install` distributed CIAO environment when trying to import `sherpa.astro.xspec`.  This isn't a problem for the Conda distribution since the variable is set.  

In this modification of the script, if the `$HEADAS` variable is not present, the script sets it for the Python instance to match the `$CIAO_HEADAS` variable which is set for all CIAO distributions, presently.