### PR TITLE
chandra_repro: update for OBC mode that omit ASPTYPE keyword in header

### DIFF
--- a/bin/chandra_repro
+++ b/bin/chandra_repro
@@ -34,7 +34,7 @@ Aim:
 """
 
 toolname = "chandra_repro"
-version = "29 June 2026"
+version = "08 July 2026"
 
 # import standard python modules as required
 #
@@ -787,7 +787,7 @@ def event1_inputs(params):
             # only have the *_osol1.fits files.  We can't handle that
             # right now.
 
-            if 'KALMAN' != keys["ASPTYPE"].value:
+            if "ASPTYPE" not in keys or 'KALMAN' != keys["ASPTYPE"].value:
                 #msg = "ASPTYPE='{}' mode data is not currently supported."
                 #raise NotImplementedError(msg.format(keys["ASPTYPE"].value))
                 params["__obc_mode__"] = True


### PR DESCRIPTION
OBS_ID 1304 does not even have `ASPTYPE` keyword so add defensive check to force down the OBC path.
